### PR TITLE
[MISC] Fix saturate-max-connections tests

### DIFF
--- a/kubernetes/lib/charms/mysql/v0/mysql.py
+++ b/kubernetes/lib/charms/mysql/v0/mysql.py
@@ -1965,7 +1965,7 @@ class MySQLBase(ABC):
             from_instance = self.instance_address
 
         client = MySQLClusterClient(
-            executor=self._build_cluster_tcp_executor(from_instance),
+            executor=self._build_instance_tcp_executor(from_instance),
         )
 
         try:
@@ -1983,7 +1983,7 @@ class MySQLBase(ABC):
             from_instance = self.instance_address
 
         client = MySQLClusterClient(
-            executor=self._build_cluster_tcp_executor(from_instance),
+            executor=self._build_instance_tcp_executor(from_instance),
         )
 
         try:

--- a/machines/lib/charms/mysql/v0/mysql.py
+++ b/machines/lib/charms/mysql/v0/mysql.py
@@ -1965,7 +1965,7 @@ class MySQLBase(ABC):
             from_instance = self.instance_address
 
         client = MySQLClusterClient(
-            executor=self._build_cluster_tcp_executor(from_instance),
+            executor=self._build_instance_tcp_executor(from_instance),
         )
 
         try:
@@ -1983,7 +1983,7 @@ class MySQLBase(ABC):
             from_instance = self.instance_address
 
         client = MySQLClusterClient(
-            executor=self._build_cluster_tcp_executor(from_instance),
+            executor=self._build_instance_tcp_executor(from_instance),
         )
 
         try:


### PR DESCRIPTION
This PR updates the charm lib in order to keep using the admin port (`33062`) for all cluster related operations, as the charm lib did before the migration to [mysql-shell-client](https://github.com/canonical/mysql-shell-client).

Integration tests errors did not show up before, as the previously framework used to run the tests, `ops.test` did not validated that Juju actions executed successfully, unlike the current `jubilant` framework. Therefore, only a combination of Juanlu's test migrations to Jubilant + Sinclert's migration to mysql-shell-client, raised the issue.
