### PR TITLE
[MISC] Add new stable releases spread tasks

### DIFF
--- a/kubernetes/tests/spread/release/test_upgrade_from_stable_2026_01_21.py/task.yaml
+++ b/kubernetes/tests/spread/release/test_upgrade_from_stable_2026_01_21.py/task.yaml
@@ -1,0 +1,12 @@
+summary: test_upgrade_from_stable.py
+environment:
+  TEST_MODULE: high_availability/test_upgrade_from_stable.py
+  MYSQL_IMAGE: ghcr.io/canonical/charmed-mysql@sha256:672f20830d66678a3ece7285048700d6e52a9393202eb51e9749eb35031559c4
+  CHARM_REVISION_AMD64: 343
+  CHARM_REVISION_ARM64: 344
+execute: |
+  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results
+backends:
+  - -lxd-vm  # This task requires charm built on different architecture from host

--- a/machines/tests/spread/release/test_upgrade_from_stable_2026_01_22.py/task.yaml
+++ b/machines/tests/spread/release/test_upgrade_from_stable_2026_01_22.py/task.yaml
@@ -1,0 +1,11 @@
+summary: test_upgrade_from_stable.py
+environment:
+  TEST_MODULE: high_availability/test_upgrade_from_stable.py
+  CHARM_REVISION_AMD64: 444
+  CHARM_REVISION_ARM64: 442
+execute: |
+  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results
+backends:
+  - -lxd-vm  # This task requires charm built on different architecture from host


### PR DESCRIPTION
This PR adds the latest `8.0/stable` releases to the list of charms we must check upgreadability, on _release time_.