### PR TITLE
[DPE-9104] Fix README and metadata.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MySQL operators
-[![Charmhub](https://charmhub.io/mysql-k8s-operator/badge.svg)](https://charmhub.io/mysql-k8s)
-[![Charmhub](https://charmhub.io/mysql-operator/badge.svg)](https://charmhub.io/mysql)
+[![Charmhub](https://charmhub.io/mysql/badge.svg)](https://charmhub.io/mysql)
+[![Charmhub](https://charmhub.io/mysql-k8s/badge.svg)](https://charmhub.io/mysql-k8s)
 [![Release](https://github.com/canonical/mysql-operators/actions/workflows/release.yaml/badge.svg?branch=8.0/edge)](https://github.com/canonical/mysql-operators/actions/workflows/release.yaml)
 [![Tests](https://github.com/canonical/mysql-operators/actions/workflows/ci.yaml/badge.svg?branch=8.0/edge)](https://github.com/canonical/mysql-operators/actions/workflows/ci.yaml)
 

--- a/kubernetes/metadata.yaml
+++ b/kubernetes/metadata.yaml
@@ -10,14 +10,13 @@ description: |
   for MySQL via Group Replication.
 
   This charm supports MySQL 8.0 in Kubernetes environments.
-docs: https://discourse.charmhub.io/t/charmed-mysql-k8s-documentation/9680
-source: https://github.com/canonical/mysql-k8s-operator
-issues: https://github.com/canonical/mysql-k8s-operator/issues
+docs: https://canonical-charmed-mysql-k8s.readthedocs-hosted.com/
+source: https://github.com/canonical/mysql-operators
+issues: https://github.com/canonical/mysql-operators/issues
 website:
   - https://ubuntu.com/data/mysql
   - https://charmhub.io/mysql-k8s
-  - https://github.com/canonical/mysql-k8s-operator
-  - https://chat.charmhub.io/charmhub/channels/data-platform
+  - https://github.com/canonical/mysql-operators
 maintainers:
   - Canonical Data Platform <data-platform@lists.launchpad.net>
 

--- a/machines/metadata.yaml
+++ b/machines/metadata.yaml
@@ -10,14 +10,13 @@ description: |
   for MySQL via Group Replication.
 
   This charm supports MySQL 8.0 in bare-metal/virtual-machines.
-docs: https://discourse.charmhub.io/t/charmed-mysql-documentation/9925
-source: https://github.com/canonical/mysql-operator
-issues: https://github.com/canonical/mysql-operator/issues
+docs: https://canonical-charmed-mysql.readthedocs-hosted.com/
+source: https://github.com/canonical/mysql-operators
+issues: https://github.com/canonical/mysql-operators/issues
 website:
   - https://ubuntu.com/data/mysql
   - https://charmhub.io/mysql
-  - https://github.com/canonical/mysql-operator
-  - https://chat.charmhub.io/charmhub/channels/data-platform
+  - https://github.com/canonical/mysql-operators
 maintainers:
   - Canonical Data Platform <data-platform@lists.launchpad.net>
 


### PR DESCRIPTION
This PR fixes the top-level README and the charms `metadata.yaml` files by updating the links to the current mono-repo.