### PR TITLE
Improve instructions around integration tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ but you will need a full local setup depending on the substrate.
 Alternatively, you can use [spread], which will take care of that for you.
 For example, to run a single test with spread, do
 
-```
+```shell
 ~/go/bin/spread lxd-vm:ubuntu-24.04:tests/spread/integration/test_database.py:juju36
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,13 +40,24 @@ You can create an environment for development:
 (cd kubernetes && tox run -e format)
 (cd kubernetes && tox run -e lint)
 (cd kubernetes && tox run -e unit)
-(cd kubernetes && charmcraft test lxd-vm)
 
 (cd machines && tox run -e format)
 (cd machines && tox run -e lint)
 (cd machines && tox run -e unit)
-(cd machines && charmcraft test lxd-vm)
 ```
+
+To run integration tests, you can run `tox run -e integration`,
+but you will need a full local setup depending on the substrate.
+Alternatively, you can use [spread], which will take care of that for you.
+For example, to run a single test with spread, do
+
+```
+~/go/bin/spread lxd-vm:ubuntu-24.04:tests/spread/integration/test_database.py:juju36
+```
+
+See the [spread] repository for more information.
+
+[spread]: https://github.com/canonical/spread/
 
 ## Build charm
 


### PR DESCRIPTION
## Issue

After running our integration tests dozens of times, I think I'm ready to backport https://github.com/canonical/mysql-k8s-operator/pull/679

I submitted this against 8.4/edge, in the understanding that this will soon become the default branch, so the most visible in the repo. Trying to minimize changes in 8.0/edge from this point.

## Solution

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
