### PR TITLE
[MISC] Disable fail-fast property from CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
+      fail-fast: false
       matrix:
         path:
           - kubernetes
@@ -45,6 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
+      fail-fast: false
       matrix:
         path:
           - kubernetes
@@ -69,6 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
+      fail-fast: false
       matrix:
         path:
           - kubernetes
@@ -88,6 +91,7 @@ jobs:
   build:
     name: Build charm | ${{ matrix.path }}
     strategy:
+      fail-fast: false
       matrix:
         path:
           - kubernetes
@@ -103,6 +107,7 @@ jobs:
       - unit-test
       - build
     strategy:
+      fail-fast: false
       matrix:
         path:
           - kubernetes

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,7 @@ jobs:
   build:
     name: Build charm | ${{ matrix.path }}
     strategy:
+      fail-fast: false
       matrix:
         path:
           - kubernetes
@@ -29,6 +30,7 @@ jobs:
     needs:
       - build
     strategy:
+      fail-fast: false
       matrix:
         path:
           - kubernetes
@@ -44,6 +46,7 @@ jobs:
     needs:
       - build
     strategy:
+      fail-fast: false
       matrix:
         path:
           - kubernetes
@@ -61,6 +64,7 @@ jobs:
       - integration-test
       - release-test
     strategy:
+      fail-fast: false
       matrix:
         path:
           - kubernetes

--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -14,6 +14,7 @@ jobs:
   build:
     name: Build charm | ${{ matrix.path }}
     strategy:
+      fail-fast: false
       matrix:
         path:
           - kubernetes
@@ -27,6 +28,7 @@ jobs:
     needs:
       - build
     strategy:
+      fail-fast: false
       matrix:
         path:
           - kubernetes
@@ -42,6 +44,7 @@ jobs:
     needs:
       - build
     strategy:
+      fail-fast: false
       matrix:
         path:
           - kubernetes


### PR DESCRIPTION
This PR disables `fail-fast` property on every CI job that follows a matrix strategy. By default, the value is true, and given the flakiness of our tests suite jobs were being cancel at the slightly issue.
