### PR TITLE
[MISC] 8.0 - Remove pytest-operator plugin

### DIFF
--- a/kubernetes/poetry.lock
+++ b/kubernetes/poetry.lock
@@ -72,25 +72,6 @@ test = ["anyio[trio]", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypo
 trio = ["trio (>=0.23)"]
 
 [[package]]
-name = "asttokens"
-version = "2.4.1"
-description = "Annotate AST trees with source code positions"
-optional = false
-python-versions = "*"
-groups = ["integration"]
-files = [
-    {file = "asttokens-2.4.1-py2.py3-none-any.whl", hash = "sha256:051ed49c3dcae8913ea7cd08e46a606dba30b79993209636c4875bc1d637bc24"},
-    {file = "asttokens-2.4.1.tar.gz", hash = "sha256:b03869718ba9a6eb027e134bfdf69f38a236d681c83c160d510768af11254ba0"},
-]
-
-[package.dependencies]
-six = ">=1.12.0"
-
-[package.extras]
-astroid = ["astroid (>=1,<2) ; python_version < \"3\"", "astroid (>=2,<4) ; python_version >= \"3\""]
-test = ["astroid (>=1,<2) ; python_version < \"3\"", "astroid (>=2,<4) ; python_version >= \"3\"", "pytest"]
-
-[[package]]
 name = "attrs"
 version = "23.2.0"
 description = "Classes Without Boilerplate"
@@ -576,18 +557,6 @@ test = ["certifi", "cryptography-vectors (==43.0.1)", "pretend", "pytest (>=6.2.
 test-randomorder = ["pytest-randomly"]
 
 [[package]]
-name = "decorator"
-version = "5.1.1"
-description = "Decorators for Humans"
-optional = false
-python-versions = ">=3.5"
-groups = ["integration"]
-files = [
-    {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
-    {file = "decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
-]
-
-[[package]]
 name = "deprecated"
 version = "1.2.14"
 description = "Python @deprecated decorator to deprecate old python classes, functions or methods."
@@ -620,21 +589,6 @@ files = [
 
 [package.extras]
 test = ["pytest (>=6)"]
-
-[[package]]
-name = "executing"
-version = "2.0.1"
-description = "Get the currently executing AST node of a frame, and other information"
-optional = false
-python-versions = ">=3.5"
-groups = ["integration"]
-files = [
-    {file = "executing-2.0.1-py2.py3-none-any.whl", hash = "sha256:eac49ca94516ccc753f9fb5ce82603156e590b27525a8bc32cce8ae302eb61bc"},
-    {file = "executing-2.0.1.tar.gz", hash = "sha256:35afe2ce3affba8ee97f2d69927fa823b08b472b7b994e36a52a964b93d16147"},
-]
-
-[package.extras]
-tests = ["asttokens (>=2.1.0)", "coverage", "coverage-enable-subprocess", "ipython", "littleutils", "pytest", "rich ; python_version >= \"3.11\""]
 
 [[package]]
 name = "google-auth"
@@ -798,82 +752,6 @@ files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
 ]
-
-[[package]]
-name = "ipdb"
-version = "0.13.13"
-description = "IPython-enabled pdb"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-groups = ["integration"]
-files = [
-    {file = "ipdb-0.13.13-py3-none-any.whl", hash = "sha256:45529994741c4ab6d2388bfa5d7b725c2cf7fe9deffabdb8a6113aa5ed449ed4"},
-    {file = "ipdb-0.13.13.tar.gz", hash = "sha256:e3ac6018ef05126d442af680aad863006ec19d02290561ac88b8b1c0b0cfc726"},
-]
-
-[package.dependencies]
-decorator = {version = "*", markers = "python_version > \"3.6\""}
-ipython = {version = ">=7.31.1", markers = "python_version > \"3.6\""}
-tomli = {version = "*", markers = "python_version > \"3.6\" and python_version < \"3.11\""}
-
-[[package]]
-name = "ipython"
-version = "8.25.0"
-description = "IPython: Productive Interactive Computing"
-optional = false
-python-versions = ">=3.10"
-groups = ["integration"]
-files = [
-    {file = "ipython-8.25.0-py3-none-any.whl", hash = "sha256:53eee7ad44df903a06655871cbab66d156a051fd86f3ec6750470ac9604ac1ab"},
-    {file = "ipython-8.25.0.tar.gz", hash = "sha256:c6ed726a140b6e725b911528f80439c534fac915246af3efc39440a6b0f9d716"},
-]
-
-[package.dependencies]
-colorama = {version = "*", markers = "sys_platform == \"win32\""}
-decorator = "*"
-exceptiongroup = {version = "*", markers = "python_version < \"3.11\""}
-jedi = ">=0.16"
-matplotlib-inline = "*"
-pexpect = {version = ">4.3", markers = "sys_platform != \"win32\" and sys_platform != \"emscripten\""}
-prompt-toolkit = ">=3.0.41,<3.1.0"
-pygments = ">=2.4.0"
-stack-data = "*"
-traitlets = ">=5.13.0"
-typing-extensions = {version = ">=4.6", markers = "python_version < \"3.12\""}
-
-[package.extras]
-all = ["ipython[black,doc,kernel,matplotlib,nbconvert,nbformat,notebook,parallel,qtconsole]", "ipython[test,test-extra]"]
-black = ["black"]
-doc = ["docrepr", "exceptiongroup", "intersphinx-registry", "ipykernel", "ipython[test]", "matplotlib", "setuptools (>=18.5)", "sphinx (>=1.3)", "sphinx-rtd-theme", "sphinxcontrib-jquery", "tomli ; python_version < \"3.11\"", "typing-extensions"]
-kernel = ["ipykernel"]
-matplotlib = ["matplotlib"]
-nbconvert = ["nbconvert"]
-nbformat = ["nbformat"]
-notebook = ["ipywidgets", "notebook"]
-parallel = ["ipyparallel"]
-qtconsole = ["qtconsole"]
-test = ["pickleshare", "pytest", "pytest-asyncio (<0.22)", "testpath"]
-test-extra = ["curio", "ipython[test]", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.23)", "pandas", "trio"]
-
-[[package]]
-name = "jedi"
-version = "0.19.1"
-description = "An autocompletion tool for Python that can be used for text editors."
-optional = false
-python-versions = ">=3.6"
-groups = ["integration"]
-files = [
-    {file = "jedi-0.19.1-py2.py3-none-any.whl", hash = "sha256:e983c654fe5c02867aef4cdfce5a2fbb4a50adc0af145f70504238f18ef5e7e0"},
-    {file = "jedi-0.19.1.tar.gz", hash = "sha256:cf0496f3651bc65d7174ac1b7d043eff454892c708a87d1b683e57b569927ffd"},
-]
-
-[package.dependencies]
-parso = ">=0.8.3,<0.9.0"
-
-[package.extras]
-docs = ["Jinja2 (==2.11.3)", "MarkupSafe (==1.1.1)", "Pygments (==2.8.1)", "alabaster (==0.7.12)", "babel (==2.9.1)", "chardet (==4.0.0)", "commonmark (==0.8.1)", "docutils (==0.17.1)", "future (==0.18.2)", "idna (==2.10)", "imagesize (==1.2.0)", "mock (==1.0.1)", "packaging (==20.9)", "pyparsing (==2.4.7)", "pytz (==2021.1)", "readthedocs-sphinx-ext (==2.1.4)", "recommonmark (==0.5.0)", "requests (==2.25.1)", "six (==1.15.0)", "snowballstemmer (==2.1.0)", "sphinx (==1.8.5)", "sphinx-rtd-theme (==0.4.3)", "sphinxcontrib-serializinghtml (==1.1.4)", "sphinxcontrib-websupport (==1.2.4)", "urllib3 (==1.26.4)"]
-qa = ["flake8 (==5.0.4)", "mypy (==0.971)", "types-setuptools (==67.2.0.1)"]
-testing = ["Django", "attrs", "colorama", "docopt", "pytest (<7.0.0)"]
 
 [[package]]
 name = "jinja2"
@@ -1138,21 +1016,6 @@ files = [
 ]
 
 [[package]]
-name = "matplotlib-inline"
-version = "0.1.7"
-description = "Inline Matplotlib backend for Jupyter"
-optional = false
-python-versions = ">=3.8"
-groups = ["integration"]
-files = [
-    {file = "matplotlib_inline-0.1.7-py3-none-any.whl", hash = "sha256:df192d39a4ff8f21b1895d72e6a13f5fcc5099f00fa84384e0ea28c2cc0653ca"},
-    {file = "matplotlib_inline-0.1.7.tar.gz", hash = "sha256:8423b23ec666be3d16e16b60bdd8ac4e86e840ebd1dd11a30b9f117f2fa0ab90"},
-]
-
-[package.dependencies]
-traitlets = "*"
-
-[[package]]
 name = "mypy-extensions"
 version = "1.0.0"
 description = "Type system extensions for programs checked with the mypy type checker."
@@ -1411,38 +1274,6 @@ gssapi = ["gssapi (>=1.4.1) ; platform_system != \"Windows\"", "pyasn1 (>=0.1.7)
 invoke = ["invoke (>=2.0)"]
 
 [[package]]
-name = "parso"
-version = "0.8.4"
-description = "A Python Parser"
-optional = false
-python-versions = ">=3.6"
-groups = ["integration"]
-files = [
-    {file = "parso-0.8.4-py2.py3-none-any.whl", hash = "sha256:a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18"},
-    {file = "parso-0.8.4.tar.gz", hash = "sha256:eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d"},
-]
-
-[package.extras]
-qa = ["flake8 (==5.0.4)", "mypy (==0.971)", "types-setuptools (==67.2.0.1)"]
-testing = ["docopt", "pytest"]
-
-[[package]]
-name = "pexpect"
-version = "4.9.0"
-description = "Pexpect allows easy control of interactive console applications."
-optional = false
-python-versions = "*"
-groups = ["integration"]
-markers = "sys_platform != \"win32\" and sys_platform != \"emscripten\""
-files = [
-    {file = "pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523"},
-    {file = "pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f"},
-]
-
-[package.dependencies]
-ptyprocess = ">=0.5"
-
-[[package]]
 name = "pluggy"
 version = "1.5.0"
 description = "plugin and hook calling mechanisms for python"
@@ -1469,21 +1300,6 @@ files = [
     {file = "poetry_core-1.9.0-py3-none-any.whl", hash = "sha256:4e0c9c6ad8cf89956f03b308736d84ea6ddb44089d16f2adc94050108ec1f5a1"},
     {file = "poetry_core-1.9.0.tar.gz", hash = "sha256:fa7a4001eae8aa572ee84f35feb510b321bd652e5cf9293249d62853e1f935a2"},
 ]
-
-[[package]]
-name = "prompt-toolkit"
-version = "3.0.46"
-description = "Library for building powerful interactive command lines in Python"
-optional = false
-python-versions = ">=3.7.0"
-groups = ["integration"]
-files = [
-    {file = "prompt_toolkit-3.0.46-py3-none-any.whl", hash = "sha256:45abe60a8300f3c618b23c16c4bb98c6fc80af8ce8b17c7ae92db48db3ee63c1"},
-    {file = "prompt_toolkit-3.0.46.tar.gz", hash = "sha256:869c50d682152336e23c4db7f74667639b5047494202ffe7670817053fd57795"},
-]
-
-[package.dependencies]
-wcwidth = "*"
 
 [[package]]
 name = "protobuf"
@@ -1516,34 +1332,6 @@ files = [
     {file = "protobuf-3.20.3-py2.py3-none-any.whl", hash = "sha256:a7ca6d488aa8ff7f329d4c545b2dbad8ac31464f1d8b1c87ad1346717731e4db"},
     {file = "protobuf-3.20.3.tar.gz", hash = "sha256:2e3427429c9cffebf259491be0af70189607f365c2f41c7c3764af6f337105f2"},
 ]
-
-[[package]]
-name = "ptyprocess"
-version = "0.7.0"
-description = "Run a subprocess in a pseudo terminal"
-optional = false
-python-versions = "*"
-groups = ["integration"]
-markers = "sys_platform != \"win32\" and sys_platform != \"emscripten\""
-files = [
-    {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
-    {file = "ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},
-]
-
-[[package]]
-name = "pure-eval"
-version = "0.2.2"
-description = "Safely evaluate AST nodes without side effects"
-optional = false
-python-versions = "*"
-groups = ["integration"]
-files = [
-    {file = "pure_eval-0.2.2-py3-none-any.whl", hash = "sha256:01eaab343580944bc56080ebe0a674b39ec44a945e6d09ba7db3cb8cec289350"},
-    {file = "pure_eval-0.2.2.tar.gz", hash = "sha256:2b45320af6dfaa1750f543d714b6d1c520a1688dec6fd24d339063ce0aaa9ac3"},
-]
-
-[package.extras]
-tests = ["pytest"]
 
 [[package]]
 name = "pyasn1"
@@ -1639,21 +1427,6 @@ dotenv = ["python-dotenv (>=0.10.4)"]
 email = ["email-validator (>=1.0.3)"]
 
 [[package]]
-name = "pygments"
-version = "2.18.0"
-description = "Pygments is a syntax highlighting package written in Python."
-optional = false
-python-versions = ">=3.8"
-groups = ["integration"]
-files = [
-    {file = "pygments-2.18.0-py3-none-any.whl", hash = "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a"},
-    {file = "pygments-2.18.0.tar.gz", hash = "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199"},
-]
-
-[package.extras]
-windows-terminal = ["colorama (>=0.4.6)"]
-
-[[package]]
 name = "pymacaroons"
 version = "0.13.0"
 description = "Macaroon library for Python"
@@ -1735,25 +1508,6 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
-name = "pytest-asyncio"
-version = "0.21.2"
-description = "Pytest support for asyncio"
-optional = false
-python-versions = ">=3.7"
-groups = ["integration"]
-files = [
-    {file = "pytest_asyncio-0.21.2-py3-none-any.whl", hash = "sha256:ab664c88bb7998f711d8039cacd4884da6430886ae8bbd4eded552ed2004f16b"},
-    {file = "pytest_asyncio-0.21.2.tar.gz", hash = "sha256:d67738fc232b94b326b9d060750beb16e0074210b98dd8b58a5239fa2a154f45"},
-]
-
-[package.dependencies]
-pytest = ">=7.0.0"
-
-[package.extras]
-docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
-testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
-
-[[package]]
 name = "pytest-mock"
 version = "3.14.0"
 description = "Thin-wrapper around the mock package for easier use with pytest"
@@ -1770,26 +1524,6 @@ pytest = ">=6.2.5"
 
 [package.extras]
 dev = ["pre-commit", "pytest-asyncio", "tox"]
-
-[[package]]
-name = "pytest-operator"
-version = "0.28.0"
-description = "Fixtures for Operators"
-optional = false
-python-versions = "*"
-groups = ["integration"]
-files = [
-    {file = "pytest-operator-0.28.0.tar.gz", hash = "sha256:efac98697da71558790eb5d4c9d42f11f3d5fb43dff22a802aee69e1801edce8"},
-    {file = "pytest_operator-0.28.0-py3-none-any.whl", hash = "sha256:b3cb5a8ebf838f890133a25ee520c25c8be259b54341e42e39f64a6d97735d9f"},
-]
-
-[package.dependencies]
-ipdb = "*"
-jinja2 = "*"
-juju = "*"
-pytest = "*"
-pytest-asyncio = "*"
-pyyaml = "*"
 
 [[package]]
 name = "python-dateutil"
@@ -2152,26 +1886,6 @@ files = [
 ]
 
 [[package]]
-name = "stack-data"
-version = "0.6.3"
-description = "Extract data from python stack frames and tracebacks for informative displays"
-optional = false
-python-versions = "*"
-groups = ["integration"]
-files = [
-    {file = "stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695"},
-    {file = "stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9"},
-]
-
-[package.dependencies]
-asttokens = ">=2.1.0"
-executing = ">=1.2.0"
-pure-eval = "*"
-
-[package.extras]
-tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
-
-[[package]]
 name = "tenacity"
 version = "8.3.0"
 description = "Retry code until it succeeds"
@@ -2211,22 +1925,6 @@ files = [
     {file = "toposort-1.10-py3-none-any.whl", hash = "sha256:cbdbc0d0bee4d2695ab2ceec97fe0679e9c10eab4b2a87a9372b929e70563a87"},
     {file = "toposort-1.10.tar.gz", hash = "sha256:bfbb479c53d0a696ea7402601f4e693c97b0367837c8898bc6471adfca37a6bd"},
 ]
-
-[[package]]
-name = "traitlets"
-version = "5.14.3"
-description = "Traitlets Python configuration system"
-optional = false
-python-versions = ">=3.8"
-groups = ["integration"]
-files = [
-    {file = "traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f"},
-    {file = "traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7"},
-]
-
-[package.extras]
-docs = ["myst-parser", "pydata-sphinx-theme", "sphinx"]
-test = ["argcomplete (>=3.0.3)", "mypy (>=1.7.0)", "pre-commit", "pytest (>=7.0,<8.2)", "pytest-mock", "pytest-mypy-testing"]
 
 [[package]]
 name = "typing-extensions"
@@ -2274,18 +1972,6 @@ brotli = ["brotli (>=1.0.9) ; platform_python_implementation == \"CPython\"", "b
 h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
-
-[[package]]
-name = "wcwidth"
-version = "0.2.13"
-description = "Measures the displayed width of unicode strings in a terminal"
-optional = false
-python-versions = "*"
-groups = ["integration"]
-files = [
-    {file = "wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859"},
-    {file = "wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5"},
-]
 
 [[package]]
 name = "websocket-client"

--- a/kubernetes/pyproject.toml
+++ b/kubernetes/pyproject.toml
@@ -50,7 +50,7 @@ unit = [
 ]
 integration = [
     "pytest~=7.4",
-    "pytest-operator~=0.28.0",
+    "jinja2~=3.1",
     "juju~=3.6",
     "ops~=2.15",
     "mysql-connector-python~=9.1.0",
@@ -62,7 +62,6 @@ integration = [
     "kubernetes~=27.2.0",
     "allure-pytest~=2.13",
     "allure-pytest-default-results~=0.1.2",
-    "pytest-asyncio~=0.21.1",
     "jubilant-backports~=1.4",
 ]
 

--- a/kubernetes/tests/integration/conftest.py
+++ b/kubernetes/tests/integration/conftest.py
@@ -52,22 +52,5 @@ def cloud_configs_gcp() -> tuple[dict[str, str], dict[str, str]]:
 
 
 @pytest.fixture(scope="module")
-def juju(request: pytest.FixtureRequest):
-    """Pytest fixture that wraps :meth:`jubilant.with_model`.
-
-    This adds command line parameter ``--keep-models`` (see help for details).
-    """
-    model = request.config.getoption("--model")
-    keep_models = bool(request.config.getoption("--keep-models"))
-
-    if model:
-        juju = jubilant_backports.Juju(model=model)  # type: ignore
-        yield juju
-        log = juju.debug_log(limit=1000)
-    else:
-        with jubilant_backports.temp_model(keep=keep_models) as juju:
-            yield juju
-            log = juju.debug_log(limit=1000)
-
-    if request.session.testsfailed:
-        print(log, end="")
+def juju() -> jubilant_backports.Juju:
+    return jubilant_backports.Juju(model="testing")

--- a/kubernetes/tests/integration/integration/high_availability/test_async_replication.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_async_replication.py
@@ -33,13 +33,13 @@ MINUTE_SECS = 60
 
 
 @pytest.fixture(scope="module")
-def first_model(juju: Juju, request: pytest.FixtureRequest) -> Generator:
+def first_model(juju: Juju) -> Generator:
     """Creates and return the first model."""
     yield juju.model
 
 
 @pytest.fixture(scope="module")
-def second_model(juju: Juju, request: pytest.FixtureRequest) -> Generator:
+def second_model(juju: Juju) -> Generator:
     """Creates and returns the second model."""
     model_name = f"{juju.model}-other"
 
@@ -47,8 +47,6 @@ def second_model(juju: Juju, request: pytest.FixtureRequest) -> Generator:
     juju.add_model(model_name)
 
     yield model_name
-    if request.config.getoption("--keep-models"):
-        return
 
     logging.info(f"Destroying model: {model_name}")
     juju.destroy_model(model_name, destroy_storage=True, force=True)
@@ -72,7 +70,6 @@ def continuous_writes(first_model: str) -> Generator:
 
 
 @juju3
-@pytest.mark.abort_on_fail
 def test_build_and_deploy(first_model: str, second_model: str, charm: str) -> None:
     """Simple test to ensure that the MySQL application charms get deployed."""
     configuration = {"profile": "testing"}
@@ -113,7 +110,6 @@ def test_build_and_deploy(first_model: str, second_model: str, charm: str) -> No
 
 
 @juju3
-@pytest.mark.abort_on_fail
 def test_async_relate(first_model: str, second_model: str) -> None:
     """Relate the two MySQL clusters."""
     logging.info("Creating offers in first model")
@@ -142,7 +138,6 @@ def test_async_relate(first_model: str, second_model: str) -> None:
 
 
 @juju3
-@pytest.mark.abort_on_fail
 def test_deploy_router_and_app(first_model: str) -> None:
     """Deploy the router and the test application."""
     logging.info("Deploying the router and test application")
@@ -181,7 +176,6 @@ def test_deploy_router_and_app(first_model: str) -> None:
 
 
 @juju3
-@pytest.mark.abort_on_fail
 def test_create_replication(first_model: str, second_model: str) -> None:
     """Run the create-replication action and wait for the applications to settle."""
     model_1 = Juju(model=first_model)
@@ -206,7 +200,6 @@ def test_create_replication(first_model: str, second_model: str) -> None:
 
 
 @juju3
-@pytest.mark.abort_on_fail
 def test_data_replication(first_model: str, second_model: str, continuous_writes) -> None:
     """Test to write to primary, and read the same data back from replicas."""
     logging.info("Testing data replication")
@@ -218,7 +211,6 @@ def test_data_replication(first_model: str, second_model: str, continuous_writes
 
 
 @juju3
-@pytest.mark.abort_on_fail
 def test_standby_promotion(first_model: str, second_model: str, continuous_writes) -> None:
     """Test graceful promotion of a standby cluster to primary."""
     model_2 = Juju(model=second_model)
@@ -248,7 +240,6 @@ def test_standby_promotion(first_model: str, second_model: str, continuous_write
 
 
 @juju3
-@pytest.mark.abort_on_fail
 def test_failover(first_model: str, second_model: str) -> None:
     """Test switchover on primary cluster fail."""
     logging.info("Freezing mysqld on primary cluster units")
@@ -301,7 +292,6 @@ def test_failover(first_model: str, second_model: str) -> None:
 
 
 @juju3
-@pytest.mark.abort_on_fail
 def test_rejoin_invalidated_cluster(
     first_model: str, second_model: str, continuous_writes
 ) -> None:
@@ -321,7 +311,6 @@ def test_rejoin_invalidated_cluster(
 
 
 @juju3
-@pytest.mark.abort_on_fail
 def test_unrelate_and_relate(first_model: str, second_model: str, continuous_writes) -> None:
     """Test removing and re-relating the two mysql clusters."""
     model_1 = Juju(model=first_model)

--- a/kubernetes/tests/integration/integration/high_availability/test_async_replication_upgrade.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_async_replication_upgrade.py
@@ -35,13 +35,13 @@ MINUTE_SECS = 60
 
 
 @pytest.fixture(scope="module")
-def first_model(juju: Juju, request: pytest.FixtureRequest) -> Generator:
+def first_model(juju: Juju) -> Generator:
     """Creates and return the first model."""
     yield juju.model
 
 
 @pytest.fixture(scope="module")
-def second_model(juju: Juju, request: pytest.FixtureRequest) -> Generator:
+def second_model(juju: Juju) -> Generator:
     """Creates and returns the second model."""
     model_name = f"{juju.model}-other"
 
@@ -49,8 +49,6 @@ def second_model(juju: Juju, request: pytest.FixtureRequest) -> Generator:
     juju.add_model(model_name)
 
     yield model_name
-    if request.config.getoption("--keep-models"):
-        return
 
     logging.info(f"Destroying model: {model_name}")
     juju.destroy_model(model_name, destroy_storage=True, force=True)
@@ -74,7 +72,6 @@ def continuous_writes(first_model: str) -> Generator:
 
 
 @juju3
-@pytest.mark.abort_on_fail
 def test_build_and_deploy(first_model: str, second_model: str, charm: str) -> None:
     """Simple test to ensure that the MySQL application charms get deployed."""
     configuration = {"profile": "testing"}
@@ -115,7 +112,6 @@ def test_build_and_deploy(first_model: str, second_model: str, charm: str) -> No
 
 
 @juju3
-@pytest.mark.abort_on_fail
 def test_async_relate(first_model: str, second_model: str) -> None:
     """Relate the two MySQL clusters."""
     logging.info("Creating offers in first model")
@@ -144,7 +140,6 @@ def test_async_relate(first_model: str, second_model: str) -> None:
 
 
 @juju3
-@pytest.mark.abort_on_fail
 def test_deploy_test_app(first_model: str) -> None:
     """Deploy the test application."""
     logging.info("Deploying the test application")
@@ -170,7 +165,6 @@ def test_deploy_test_app(first_model: str) -> None:
 
 
 @juju3
-@pytest.mark.abort_on_fail
 def test_create_replication(first_model: str, second_model: str) -> None:
     """Run the create-replication action and wait for the applications to settle."""
     model_1 = Juju(model=first_model)
@@ -195,7 +189,6 @@ def test_create_replication(first_model: str, second_model: str) -> None:
 
 
 @juju3
-@pytest.mark.abort_on_fail
 def test_upgrade_from_edge(
     first_model: str, second_model: str, charm: str, continuous_writes
 ) -> None:
@@ -211,7 +204,6 @@ def test_upgrade_from_edge(
 
 
 @juju3
-@pytest.mark.abort_on_fail
 def test_data_replication(first_model: str, second_model: str, continuous_writes) -> None:
     """Test to write to primary, and read the same data back from replicas."""
     logging.info("Testing data replication")

--- a/kubernetes/tests/integration/integration/high_availability/test_primary_switchover.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_primary_switchover.py
@@ -5,7 +5,6 @@ import logging
 import subprocess
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from ...helpers_ha import (
@@ -26,7 +25,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -62,7 +60,6 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_cluster_switchover(juju: Juju) -> None:
     """Test that the primary node can be switched over."""
     logging.info("Testing cluster switchover...")
@@ -90,7 +87,6 @@ def test_cluster_switchover(juju: Juju) -> None:
     assert get_mysql_primary_unit(juju, app_name) == new_primary_unit, "Switchover failed"
 
 
-@pytest.mark.abort_on_fail
 def test_cluster_failover_after_majority_loss(juju: Juju) -> None:
     """Test the promote-to-primary command after losing the majority of nodes, with force flag."""
     app_name = get_app_name(juju, MYSQL_APP_NAME)

--- a/kubernetes/tests/integration/integration/high_availability/test_replication_data_consistency.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_replication_data_consistency.py
@@ -4,7 +4,6 @@
 import logging
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from ...helpers import generate_random_string
@@ -23,7 +22,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -59,7 +57,6 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_consistent_data_replication_across_cluster(juju: Juju) -> None:
     """Confirm that data is replicated from the primary node to all the replicas."""
     table_name = "data"

--- a/kubernetes/tests/integration/integration/high_availability/test_replication_data_isolation.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_replication_data_isolation.py
@@ -4,7 +4,6 @@
 import logging
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from ...helpers_ha import (
@@ -21,7 +20,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")

--- a/kubernetes/tests/integration/integration/high_availability/test_replication_logs_rotation.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_replication_logs_rotation.py
@@ -8,7 +8,6 @@ from contextlib import suppress
 from pathlib import Path
 
 import jubilant_backports
-import pytest
 from jubilant_backports import CLIError, Juju
 from tenacity import (
     Retrying,
@@ -32,7 +31,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -68,7 +66,6 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_log_rotation(juju: Juju) -> None:
     """Test the log rotation of text files."""
     log_types = ["error", "audit"]

--- a/kubernetes/tests/integration/integration/high_availability/test_replication_reelection.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_replication_reelection.py
@@ -4,7 +4,6 @@
 import logging
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from ...helpers import generate_random_string
@@ -25,7 +24,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -61,7 +59,6 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_kill_primary_check_reelection(juju: Juju) -> None:
     """Confirm that a new primary is elected when the current primary is tear down."""
     check_mysql_units_writes_increment(juju, MYSQL_APP_NAME)

--- a/kubernetes/tests/integration/integration/high_availability/test_replication_scaling.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_replication_scaling.py
@@ -4,7 +4,6 @@
 import logging
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from ...helpers import generate_random_string
@@ -23,7 +22,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -59,7 +57,6 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_scaling_without_data_loss(juju: Juju) -> None:
     """Test that data is preserved during scale up and scale down."""
     table_name = "instance_state_replication"

--- a/kubernetes/tests/integration/integration/high_availability/test_replication_unit_endpoints.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_replication_unit_endpoints.py
@@ -4,7 +4,6 @@
 import logging
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from ...helpers_ha import (
@@ -26,7 +25,6 @@ MYSQL_TEST_APP_NAME_2 = "mysql-test-app2"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster_1(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -66,7 +64,6 @@ def test_deploy_highly_available_cluster_1(juju: Juju, charm: str) -> None:
         )
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster_2(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -106,7 +103,6 @@ def test_deploy_highly_available_cluster_2(juju: Juju, charm: str) -> None:
         )
 
 
-@pytest.mark.abort_on_fail
 def test_labeling_of_k8s_endpoints(juju: Juju) -> None:
     """Test the labeling of k8s endpoints when apps with same cluster-name deployed."""
     logging.info("Ensuring that the created k8s endpoints have correct addresses")

--- a/kubernetes/tests/integration/integration/high_availability/test_replication_variables.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_replication_variables.py
@@ -5,7 +5,6 @@
 import logging
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from ...helpers_ha import (
@@ -23,8 +22,6 @@ CLUSTER_NAME = "test_cluster"
 TIMEOUT = 15 * MINUTE_SECS
 
 
-@pytest.mark.skip_if_deployed
-@pytest.mark.abort_on_fail
 def test_build_and_deploy(juju: Juju, charm) -> None:
     """Build the mysql charm and deploy it."""
     logger.info(f"Deploying {APP_NAME}")
@@ -44,7 +41,6 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_custom_variables(juju: Juju) -> None:
     """Query database for custom variables."""
     app_units = get_app_units(juju, APP_NAME)

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_network_cut.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_network_cut.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from string import Template
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from ...helpers_ha import (
@@ -30,7 +29,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -66,7 +64,6 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_network_cut_affecting_an_instance(juju: Juju, continuous_writes, chaos_mesh) -> None:
     """Test for a network cut affecting an instance."""
     logging.info("Ensuring that all instances have incrementing continuous writes")

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_node_drain.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_node_drain.py
@@ -4,7 +4,6 @@
 import logging
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 from lightkube.core.client import Client
 from lightkube.models.meta_v1 import ObjectMeta
@@ -27,7 +26,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -63,7 +61,6 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_pod_eviction_and_pvc_deletion(juju: Juju, continuous_writes) -> None:
     """Test behavior when node drains - pod is evicted and pvs are rotated."""
     logging.info("Ensuring that all instances have incrementing continuous writes")

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_pod.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_pod.py
@@ -4,7 +4,6 @@
 import logging
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from ...helpers import generate_random_string
@@ -25,7 +24,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -61,7 +59,6 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_single_unit_pod_delete(juju: Juju) -> None:
     """Delete the pod in a single unit deployment and write data to new pod."""
     logging.info("Scale mysql application to 1 unit that is active")

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_process_frozen.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_process_frozen.py
@@ -5,7 +5,6 @@ import logging
 import random
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 from tenacity import (
     Retrying,
@@ -32,7 +31,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -68,7 +66,6 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_freeze_db_process(juju: Juju, continuous_writes) -> None:
     """Test to send a SIGSTOP to the primary db process and ensure that the cluster self heals."""
     logging.info("Ensuring that all instances have incrementing continuous writes")

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_process_killed.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_process_killed.py
@@ -5,7 +5,6 @@ import logging
 import time
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from constants import CONTAINER_NAME
@@ -31,7 +30,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -67,7 +65,6 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_kill_db_process(juju: Juju, continuous_writes) -> None:
     """Test to send a SIGKILL to the primary db process and ensure that the cluster self heals."""
     logging.info("Ensuring all units have continuous writes incrementing")

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_restart_graceful.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_restart_graceful.py
@@ -4,7 +4,6 @@
 import logging
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from ...helpers import execute_queries_on_unit
@@ -27,7 +26,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -63,7 +61,6 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_cluster_manual_rejoin(juju: Juju, continuous_writes) -> None:
     """The cluster manual re-join test.
 

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_setup_crash.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_setup_crash.py
@@ -4,7 +4,6 @@
 import logging
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from ...helpers_ha import (
@@ -19,7 +18,6 @@ MYSQL_APP_NAME = "mysql-k8s"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_single_unit_cluster(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -40,7 +38,6 @@ def test_deploy_single_unit_cluster(juju: Juju, charm: str) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_crash_during_cluster_setup(juju: Juju, charm: str) -> None:
     """Test primary crash during startup.
 

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_stop_all.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_stop_all.py
@@ -4,7 +4,6 @@
 import logging
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from ...helpers_ha import (
@@ -25,7 +24,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -61,7 +59,6 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 async def test_graceful_full_cluster_crash(juju: Juju, continuous_writes) -> None:
     """Pause test.
 

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_stop_primary.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_stop_primary.py
@@ -4,7 +4,6 @@
 import logging
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from constants import CONTAINER_NAME
@@ -25,7 +24,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -61,7 +59,6 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 async def test_graceful_crash_of_primary(juju: Juju, continuous_writes) -> None:
     """Test to send SIGTERM to primary instance and then verify recovery."""
     # Ensure continuous writes still incrementing for all units

--- a/kubernetes/tests/integration/integration/high_availability/test_upgrade.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_upgrade.py
@@ -9,7 +9,6 @@ from contextlib import suppress
 from pathlib import Path
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju, TaskError
 
 from ...helpers_ha import (
@@ -33,7 +32,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_latest(juju: Juju) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -70,7 +68,6 @@ def test_deploy_latest(juju: Juju) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_pre_upgrade_check(juju: Juju) -> None:
     """Test that the pre-upgrade-check action runs successfully."""
     mysql_leader = get_app_leader(juju, MYSQL_APP_NAME)
@@ -92,7 +89,6 @@ def test_pre_upgrade_check(juju: Juju) -> None:
     assert get_k8s_stateful_set_partitions(juju, MYSQL_APP_NAME) == 2, "Partition not set to 2"
 
 
-@pytest.mark.abort_on_fail
 def test_upgrade_from_edge(juju: Juju, charm: str, continuous_writes) -> None:
     """Update the second cluster."""
     logging.info("Ensure continuous writes are incrementing")
@@ -133,7 +129,6 @@ def test_upgrade_from_edge(juju: Juju, charm: str, continuous_writes) -> None:
     check_mysql_units_writes_increment(juju, MYSQL_APP_NAME)
 
 
-@pytest.mark.abort_on_fail
 def test_fail_and_rollback(juju: Juju, charm: str, continuous_writes) -> None:
     """Test an upgrade failure and its rollback."""
     mysql_app_leader = get_app_leader(juju, MYSQL_APP_NAME)

--- a/kubernetes/tests/integration/integration/high_availability/test_upgrade_from_stable.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_upgrade_from_stable.py
@@ -5,7 +5,6 @@ import logging
 from contextlib import suppress
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju, TaskError
 
 from ...helpers_ha import (
@@ -27,7 +26,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_stable(juju: Juju) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -64,7 +62,6 @@ def test_deploy_stable(juju: Juju) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_pre_upgrade_check(juju: Juju) -> None:
     """Test that the pre-upgrade-check action runs successfully."""
     mysql_leader = get_app_leader(juju, MYSQL_APP_NAME)
@@ -86,7 +83,6 @@ def test_pre_upgrade_check(juju: Juju) -> None:
     assert get_k8s_stateful_set_partitions(juju, MYSQL_APP_NAME) == 2, "Partition not set to 2"
 
 
-@pytest.mark.abort_on_fail
 def test_upgrade_from_stable(juju: Juju, charm: str, continuous_writes) -> None:
     """Update the second cluster."""
     logging.info("Ensure continuous writes are incrementing")

--- a/kubernetes/tests/integration/integration/high_availability/test_upgrade_rollback_incompat.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_upgrade_rollback_incompat.py
@@ -9,7 +9,6 @@ from contextlib import suppress
 from pathlib import Path
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju, TaskError
 
 from ...helpers_ha import (
@@ -32,7 +31,6 @@ MINUTE_SECS = 60
 # TODO: remove AMD64 marker after next incompatible MySQL server version is released in our snap
 # (details: https://github.com/canonical/mysql-operator/pull/472#discussion_r1659300069)
 @amd64_only
-@pytest.mark.abort_on_fail
 def test_build_and_deploy(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     juju.deploy(
@@ -59,7 +57,6 @@ def test_build_and_deploy(juju: Juju, charm: str) -> None:
 # TODO: remove AMD64 marker after next incompatible MySQL server version is released in our snap
 # (details: https://github.com/canonical/mysql-operator/pull/472#discussion_r1659300069)
 @amd64_only
-@pytest.mark.abort_on_fail
 def test_pre_upgrade_check(juju: Juju) -> None:
     """Test that the pre-upgrade-check action runs successfully."""
     mysql_leader = get_app_leader(juju, MYSQL_APP_NAME)
@@ -71,7 +68,6 @@ def test_pre_upgrade_check(juju: Juju) -> None:
 # TODO: remove AMD64 marker after next incompatible MySQL server version is released in our snap
 # (details: https://github.com/canonical/mysql-operator/pull/472#discussion_r1659300069)
 @amd64_only
-@pytest.mark.abort_on_fail
 def test_upgrade_to_failing(juju: Juju, charm: str) -> None:
     with InjectFailure(
         path="src/upgrade.py",
@@ -110,7 +106,6 @@ def test_upgrade_to_failing(juju: Juju, charm: str) -> None:
 # TODO: remove AMD64 marker after next incompatible MySQL server version is released in our snap
 # (details: https://github.com/canonical/mysql-operator/pull/472#discussion_r1659300069)
 @amd64_only
-@pytest.mark.abort_on_fail
 def test_rollback(juju: Juju, charm: str) -> None:
     """Test upgrade rollback to a healthy revision."""
     mysql_app_leader = get_app_leader(juju, MYSQL_APP_NAME)

--- a/kubernetes/tests/integration/integration/relations/test_database.py
+++ b/kubernetes/tests/integration/integration/relations/test_database.py
@@ -5,7 +5,6 @@
 import logging
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from ... import markers
@@ -24,8 +23,6 @@ APPLICATION_ENDPOINT = "database"
 APPS = [DATABASE_APP_NAME, APPLICATION_APP_NAME]
 
 
-@pytest.mark.abort_on_fail
-@pytest.mark.skip_if_deployed
 def test_build_and_deploy(juju: Juju, charm):
     """Build the charm and deploy 3 units to ensure a cluster is formed."""
     juju.deploy(
@@ -46,7 +43,6 @@ def test_build_and_deploy(juju: Juju, charm):
     )
 
 
-@pytest.mark.abort_on_fail
 def test_relation_creation_eager(juju: Juju):
     """Relate charms before they have time to properly start.
 
@@ -72,7 +68,6 @@ def test_relation_creation_eager(juju: Juju):
     )
 
 
-@pytest.mark.abort_on_fail
 @markers.only_without_juju_secrets
 def test_relation_creation_databag(juju: Juju):
     """Relate charms and wait for the expected changes in status."""
@@ -85,7 +80,6 @@ def test_relation_creation_databag(juju: Juju):
     assert {"password", "username"} <= set(relation_data[0]["application-data"])
 
 
-@pytest.mark.abort_on_fail
 @markers.only_with_juju_secrets
 def test_relation_creation(juju: Juju):
     """Relate charms and wait for the expected changes in status."""
@@ -99,7 +93,6 @@ def test_relation_creation(juju: Juju):
     assert "secret-user" in relation_data[0]["application-data"]
 
 
-@pytest.mark.abort_on_fail
 def test_relation_broken(juju: Juju):
     """Remove relation and wait for the expected changes in status."""
     juju.remove_relation(

--- a/kubernetes/tests/integration/integration/relations/test_mysql_root.py
+++ b/kubernetes/tests/integration/integration/relations/test_mysql_root.py
@@ -5,7 +5,6 @@
 import logging
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from ...helpers_ha import (
@@ -20,8 +19,6 @@ APPLICATION_APP_NAME = "mysql-test-app"
 APPLICATION_ENDPOINT = "mysql"
 
 
-@pytest.mark.abort_on_fail
-@pytest.mark.skip_if_deployed
 def test_build_and_deploy(juju: Juju, charm):
     """Build the charm and deploy 3 units to ensure a cluster is formed."""
     juju.deploy(
@@ -45,7 +42,6 @@ def test_build_and_deploy(juju: Juju, charm):
     )
 
 
-@pytest.mark.abort_on_fail
 def test_relation_creation_eager(juju: Juju):
     """Relate charms before they have time to properly start.
 

--- a/kubernetes/tests/integration/integration/roles/test_database_dba_role.py
+++ b/kubernetes/tests/integration/integration/roles/test_database_dba_role.py
@@ -24,7 +24,6 @@ DATABASE_APP_NAME = CHARM_METADATA["name"]
 INTEGRATOR_APP_NAME = "data-integrator"
 
 
-@pytest.mark.abort_on_fail
 def test_build_and_deploy(juju: Juju, charm) -> None:
     """Simple test to ensure that the mysql and data-integrator charms get deployed."""
     juju.deploy(
@@ -67,7 +66,6 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_charmed_dba_role(juju: Juju):
     """Test the database-level DBA role."""
     juju.config(

--- a/kubernetes/tests/integration/integration/roles/test_instance_dba_role.py
+++ b/kubernetes/tests/integration/integration/roles/test_instance_dba_role.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from ...helpers_ha import (
@@ -22,7 +21,6 @@ DATABASE_APP_NAME = CHARM_METADATA["name"]
 INTEGRATOR_APP_NAME = "data-integrator"
 
 
-@pytest.mark.abort_on_fail
 def test_build_and_deploy(juju: Juju, charm) -> None:
     """Simple test to ensure that the mysql and data-integrator charms get deployed."""
     juju.deploy(
@@ -54,7 +52,6 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_charmed_dba_role(juju: Juju):
     """Test the DBA predefined role."""
     juju.config(

--- a/kubernetes/tests/integration/integration/roles/test_instance_roles.py
+++ b/kubernetes/tests/integration/integration/roles/test_instance_roles.py
@@ -25,7 +25,6 @@ DATABASE_APP_NAME = CHARM_METADATA["name"]
 INTEGRATOR_APP_NAME = "data-integrator"
 
 
-@pytest.mark.abort_on_fail
 def test_build_and_deploy(juju: Juju, charm) -> None:
     """Simple test to ensure that the mysql and data-integrator charms get deployed."""
     juju.deploy(
@@ -68,7 +67,6 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_charmed_read_role(juju: Juju):
     """Test the charmed_read predefined role."""
     juju.config(
@@ -154,7 +152,6 @@ def test_charmed_read_role(juju: Juju):
     )
 
 
-@pytest.mark.abort_on_fail
 def test_charmed_dml_role(juju: Juju):
     """Test the charmed_dml role."""
     juju.config(

--- a/kubernetes/tests/integration/integration/test_backup_aws.py
+++ b/kubernetes/tests/integration/integration/test_backup_aws.py
@@ -76,7 +76,6 @@ def clean_backups_from_buckets(cloud_configs_aws):
         bucket_object.delete()
 
 
-@pytest.mark.abort_on_fail
 def test_build_and_deploy(juju: Juju, charm) -> None:
     """Simple test to ensure that the mysql charm gets deployed."""
     juju.deploy(
@@ -122,7 +121,6 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_backup(juju: Juju, cloud_configs_aws) -> None:
     """Test to create a backup and list backups."""
     global backup_id, value_before_backup, value_after_backup
@@ -207,7 +205,6 @@ def test_backup(juju: Juju, cloud_configs_aws) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_restore_on_same_cluster(juju: Juju, cloud_configs_aws) -> None:
     """Test to restore a backup to the same mysql cluster."""
     cloud_configs, cloud_credentials = cloud_configs_aws
@@ -319,7 +316,6 @@ def test_restore_on_same_cluster(juju: Juju, cloud_configs_aws) -> None:
     ), "cluster should migrate to blocked status after restore"
 
 
-@pytest.mark.abort_on_fail
 def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_aws) -> None:
     """Test to restore a backup on a new mysql cluster."""
     cloud_configs, cloud_credentials = cloud_configs_aws

--- a/kubernetes/tests/integration/integration/test_backup_ceph.py
+++ b/kubernetes/tests/integration/integration/test_backup_ceph.py
@@ -164,7 +164,6 @@ def clean_backups_from_buckets(cloud_credentials, cloud_configs):
         bucket_object.delete()
 
 
-@pytest.mark.abort_on_fail
 def test_build_and_deploy(juju: Juju, charm) -> None:
     """Simple test to ensure that the mysql charm gets deployed."""
     juju.deploy(
@@ -210,7 +209,6 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_backup(juju: Juju, cloud_credentials, cloud_configs) -> None:
     """Test to create a backup and list backups."""
     global backup_id, value_before_backup, value_after_backup
@@ -293,7 +291,6 @@ def test_backup(juju: Juju, cloud_credentials, cloud_configs) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_restore_on_same_cluster(juju: Juju, cloud_credentials, cloud_configs) -> None:
     """Test to restore a backup to the same mysql cluster."""
     logger.info("Scaling mysql application to 1 unit")
@@ -403,7 +400,6 @@ def test_restore_on_same_cluster(juju: Juju, cloud_credentials, cloud_configs) -
     ), "cluster should migrate to blocked status after restore"
 
 
-@pytest.mark.abort_on_fail
 def test_restore_on_new_cluster(juju: Juju, charm, cloud_credentials, cloud_configs) -> None:
     """Test to restore a backup on a new mysql cluster."""
     logger.info("Deploying a new mysql cluster")

--- a/kubernetes/tests/integration/integration/test_backup_gcp.py
+++ b/kubernetes/tests/integration/integration/test_backup_gcp.py
@@ -75,7 +75,6 @@ def clean_backups_from_buckets(cloud_configs_gcp):
         bucket_object.delete()
 
 
-@pytest.mark.abort_on_fail
 def test_build_and_deploy(juju: Juju, charm) -> None:
     """Simple test to ensure that the mysql charm gets deployed."""
     juju.deploy(
@@ -121,7 +120,6 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_backup(juju: Juju, cloud_configs_gcp) -> None:
     """Test to create a backup and list backups."""
     global backup_id, value_before_backup, value_after_backup
@@ -206,7 +204,6 @@ def test_backup(juju: Juju, cloud_configs_gcp) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_restore_on_same_cluster(juju: Juju, cloud_configs_gcp) -> None:
     """Test to restore a backup to the same mysql cluster."""
     cloud_configs, cloud_credentials = cloud_configs_gcp
@@ -318,7 +315,6 @@ def test_restore_on_same_cluster(juju: Juju, cloud_configs_gcp) -> None:
     ), "cluster should migrate to blocked status after restore"
 
 
-@pytest.mark.abort_on_fail
 def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_gcp) -> None:
     """Test to restore a backup on a new mysql cluster."""
     cloud_configs, cloud_credentials = cloud_configs_gcp

--- a/kubernetes/tests/integration/integration/test_backup_pitr_aws.py
+++ b/kubernetes/tests/integration/integration/test_backup_pitr_aws.py
@@ -1,13 +1,11 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import pytest
 from jubilant_backports import Juju
 
 from .helpers_backups import build_and_deploy_operations, pitr_operations
 
 
-@pytest.mark.abort_on_fail
 def test_build_and_deploy_aws(
     juju: Juju, cloud_configs_aws: tuple[dict[str, str], dict[str, str]], charm
 ) -> None:
@@ -15,7 +13,6 @@ def test_build_and_deploy_aws(
     build_and_deploy_operations(juju, charm, cloud_configs_aws[0], cloud_configs_aws[1])
 
 
-@pytest.mark.abort_on_fail
 def test_pitr_aws(juju: Juju, cloud_configs_aws: tuple[dict[str, str], dict[str, str]]) -> None:
     """Pitr tests."""
     pitr_operations(juju, cloud_configs_aws[0], cloud_configs_aws[1])

--- a/kubernetes/tests/integration/integration/test_backup_pitr_gcp.py
+++ b/kubernetes/tests/integration/integration/test_backup_pitr_gcp.py
@@ -1,13 +1,11 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import pytest
 from jubilant_backports import Juju
 
 from .helpers_backups import build_and_deploy_operations, pitr_operations
 
 
-@pytest.mark.abort_on_fail
 def test_build_and_deploy_gcp(
     juju: Juju, cloud_configs_gcp: tuple[dict[str, str], dict[str, str]], charm
 ) -> None:
@@ -15,7 +13,6 @@ def test_build_and_deploy_gcp(
     build_and_deploy_operations(juju, charm, cloud_configs_gcp[0], cloud_configs_gcp[1])
 
 
-@pytest.mark.abort_on_fail
 def test_pitr_gcp(juju: Juju, cloud_configs_gcp: tuple[dict[str, str], dict[str, str]]) -> None:
     """Pitr tests."""
     pitr_operations(juju, cloud_configs_gcp[0], cloud_configs_gcp[1])

--- a/kubernetes/tests/integration/integration/test_charm.py
+++ b/kubernetes/tests/integration/integration/test_charm.py
@@ -5,7 +5,6 @@
 import logging
 
 import jubilant_backports
-import pytest
 import urllib3
 from jubilant_backports import Juju
 
@@ -33,8 +32,6 @@ CLUSTER_NAME = "test_cluster"
 TIMEOUT = 15 * MINUTE_SECS
 
 
-@pytest.mark.skip_if_deployed
-@pytest.mark.abort_on_fail
 def test_build_and_deploy(juju: Juju, charm) -> None:
     """Build the mysql charm and deploy it."""
     logger.info(f"Deploying {APP_NAME}")
@@ -72,7 +69,6 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
         assert output[0] == 3
 
 
-@pytest.mark.abort_on_fail
 def test_scale_up_after_scale_down(juju: Juju) -> None:
     """Confirm storage reuse works."""
     logger.info("Scale down to one unit")
@@ -88,7 +84,6 @@ def test_scale_up_after_scale_down(juju: Juju) -> None:
     assert (num_online, num_not_online) == (3, 0)
 
 
-@pytest.mark.abort_on_fail
 def test_scale_up_from_zero(juju: Juju) -> None:
     """Ensure scaling down to zero and back up works."""
     logger.info("Scaling down to 0 units")
@@ -106,7 +101,6 @@ def test_scale_up_from_zero(juju: Juju) -> None:
     assert (num_online, num_not_online) == (3, 0)
 
 
-@pytest.mark.abort_on_fail
 def test_password_rotation(juju: Juju):
     """Rotate password and confirm changes."""
     app_units = get_app_units(juju, APP_NAME)
@@ -140,7 +134,6 @@ def test_password_rotation(juju: Juju):
     )
 
 
-@pytest.mark.abort_on_fail
 def test_password_rotation_silent(juju: Juju):
     """Rotate password and confirm changes."""
     app_units = get_app_units(juju, APP_NAME)
@@ -171,7 +164,6 @@ def test_password_rotation_silent(juju: Juju):
     )
 
 
-@pytest.mark.abort_on_fail
 def test_password_rotation_root_user_implicit(juju: Juju):
     """Rotate password and confirm changes."""
     app_units = get_app_units(juju, APP_NAME)
@@ -198,7 +190,6 @@ def test_password_rotation_root_user_implicit(juju: Juju):
     assert updated_credentials["password"] == updated_root_credentials["password"]
 
 
-@pytest.mark.abort_on_fail
 def test_exporter_endpoints(juju: Juju) -> None:
     """Test that endpoints are running."""
     app_units = get_app_units(juju, APP_NAME)

--- a/kubernetes/tests/integration/integration/test_cos_integration_bundle.py
+++ b/kubernetes/tests/integration/integration/test_cos_integration_bundle.py
@@ -7,7 +7,6 @@ import tempfile
 
 import jinja2
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from ..helpers_ha import CHARM_METADATA, wait_for_apps_status
@@ -18,7 +17,6 @@ IMAGE_SOURCE = CHARM_METADATA["resources"]["mysql-image"]["upstream-source"]
 TIMEOUT = 10 * 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_bundle_with_cos_integrations(juju: Juju, charm) -> None:
     """Test COS integrations formed before mysql is allocated and deployed."""
     bundle_template = jinja2.Template(

--- a/kubernetes/tests/integration/integration/test_multi_relations.py
+++ b/kubernetes/tests/integration/integration/test_multi_relations.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 import jubilant_backports
-import pytest
 from jubilant_backports import CLIError, Juju
 from tenacity import RetryError, Retrying, retry_if_exception_type, stop_after_attempt, wait_fixed
 
@@ -14,7 +13,6 @@ SCALE_APPS = 7
 SCALE_UNITS = 3
 
 
-@pytest.mark.abort_on_fail
 def test_build_and_deploy(juju: Juju, charm):
     """Build the charm and deploy 1 units to ensure a cluster is formed."""
     config = {"profile": "testing"}
@@ -83,7 +81,6 @@ def test_build_and_deploy(juju: Juju, charm):
     )
 
 
-@pytest.mark.abort_on_fail
 def test_relate_all(juju: Juju):
     """Relate all the applications to the database."""
     for idx in range(SCALE_APPS):
@@ -105,7 +102,6 @@ def test_relate_all(juju: Juju):
     )
 
 
-@pytest.mark.abort_on_fail
 def test_scale_out(juju: Juju):
     """Scale database and routers."""
     retry_if_cli_error(lambda: juju.add_unit(MYSQL_APP_NAME, num_units=SCALE_UNITS - 1))
@@ -123,7 +119,6 @@ def test_scale_out(juju: Juju):
     )
 
 
-@pytest.mark.abort_on_fail
 def test_scale_in(juju: Juju):
     """Scale database and routers."""
     retry_if_cli_error(lambda: juju.remove_unit(MYSQL_APP_NAME, num_units=SCALE_UNITS - 1))

--- a/kubernetes/tests/integration/integration/test_osm_integration_bundle.py
+++ b/kubernetes/tests/integration/integration/test_osm_integration_bundle.py
@@ -4,7 +4,6 @@
 import logging
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 from tenacity import RetryError, Retrying, stop_after_attempt, wait_fixed
 
@@ -141,7 +140,6 @@ def test_deploy_and_relate_osm_bundle(juju: Juju, charm) -> None:
     juju.integrate("osm-pol:mysql", f"{APP_NAME}:mysql-root")
 
 
-@pytest.mark.abort_on_fail
 @markers.juju3
 @markers.amd64_only  # kafka-k8s charm not available for arm64
 def test_osm_pol_operations(juju: Juju) -> None:

--- a/kubernetes/tests/integration/integration/test_saturate_max_connections.py
+++ b/kubernetes/tests/integration/integration/test_saturate_max_connections.py
@@ -18,7 +18,6 @@ TEST_APP_NAME = "app"
 CONNECTIONS = 10
 
 
-@pytest.mark.abort_on_fail
 def test_build_and_deploy(juju: Juju, charm) -> None:
     """Build the charm and deploy 1 units to ensure a cluster is formed."""
     juju.deploy(
@@ -32,7 +31,6 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_and_relate_test_app(juju: Juju) -> None:
     config = {"auto_start_writes": False, "sleep_interval": "500"}
     logger.info("Deploying test app")
@@ -55,7 +53,6 @@ def test_deploy_and_relate_test_app(juju: Juju) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_saturate_max_connections(juju: Juju) -> None:
     app_unit_name = get_app_units(juju, TEST_APP_NAME)[0]
     mysql_unit_name = get_app_units(juju, MYSQL_APP_NAME)[0]

--- a/kubernetes/tests/integration/integration/test_tls.py
+++ b/kubernetes/tests/integration/integration/test_tls.py
@@ -6,7 +6,6 @@ import logging
 from time import sleep
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from constants import CLUSTER_ADMIN_USERNAME, CONTAINER_NAME, TLS_SSL_CERT_FILE
@@ -48,8 +47,6 @@ else:
 config = {}
 
 
-@pytest.mark.skip_if_deployed
-@pytest.mark.abort_on_fail
 def test_build_and_deploy(juju: Juju, charm) -> None:
     """Build the charm and deploy 3 units to ensure a cluster is formed."""
     # Set model configuration
@@ -72,7 +69,6 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_connection_before_tls(juju: Juju) -> None:
     """Ensure connections (with and without ssl) are possible before relating with TLS operator."""
     app_units = get_app_units(juju, APP_NAME)
@@ -100,7 +96,6 @@ def test_connection_before_tls(juju: Juju) -> None:
         )
 
 
-@pytest.mark.abort_on_fail
 def test_enable_tls(juju: Juju) -> None:
     """Test for encryption enablement when relation to TLS charm."""
     app_units = get_app_units(juju, APP_NAME)
@@ -143,7 +138,6 @@ def test_enable_tls(juju: Juju) -> None:
     assert get_tls_ca(juju, app_units[0]), "❌ No CA found after TLS relation"
 
 
-@pytest.mark.abort_on_fail
 def test_rotate_tls_key(juju: Juju) -> None:
     """Verify rotating tls private keys restarts cluster with new certificates.
 
@@ -193,7 +187,6 @@ def test_rotate_tls_key(juju: Juju) -> None:
         )
 
 
-@pytest.mark.abort_on_fail
 def test_disable_tls(juju: Juju) -> None:
     # Remove the relation
     app_units = get_app_units(juju, APP_NAME)

--- a/kubernetes/tests/spread/integration/test_architecture.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_architecture.py/task.yaml
@@ -2,7 +2,7 @@ summary: test_architecture.py
 environment:
   TEST_MODULE: test_architecture.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 backends:

--- a/kubernetes/tests/spread/integration/test_async_replication.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_async_replication.py/task.yaml
@@ -2,7 +2,7 @@ summary: test_async_replication.py
 environment:
   TEST_MODULE: high_availability/test_async_replication.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 variants:

--- a/kubernetes/tests/spread/integration/test_async_replication_upgrade.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_async_replication_upgrade.py/task.yaml
@@ -2,7 +2,7 @@ summary: test_async_replication_upgrade.py
 environment:
   TEST_MODULE: high_availability/test_async_replication_upgrade.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 variants:

--- a/kubernetes/tests/spread/integration/test_backup_aws.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_backup_aws.py/task.yaml
@@ -2,7 +2,7 @@ summary: test_backup_aws.py
 environment:
   TEST_MODULE: test_backup_aws.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 backends:

--- a/kubernetes/tests/spread/integration/test_backup_ceph.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_backup_ceph.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_backup_ceph.py
 environment:
   TEST_MODULE: test_backup_ceph.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_backup_gcp.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_backup_gcp.py/task.yaml
@@ -2,7 +2,7 @@ summary: test_backup_gcp.py
 environment:
   TEST_MODULE: test_backup_gcp.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 backends:

--- a/kubernetes/tests/spread/integration/test_backup_pitr_aws.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_backup_pitr_aws.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_backup_pitr_aws.py
 environment:
   TEST_MODULE: test_backup_pitr_aws.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_backup_pitr_gcp.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_backup_pitr_gcp.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_backup_pitr_gcp.py
 environment:
   TEST_MODULE: test_backup_pitr_gcp.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_charm.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_charm.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_charm.py
 environment:
   TEST_MODULE: test_charm.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_cos_integration_bundle.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_cos_integration_bundle.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_cos_integration_bundle.py
 environment:
   TEST_MODULE: test_cos_integration_bundle.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_database.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_database.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_database.py
 environment:
   TEST_MODULE: relations/test_database.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_database_dba_role.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_database_dba_role.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_database_dba_role.py
 environment:
   TEST_MODULE: roles/test_database_dba_role.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_instance_dba_role.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_instance_dba_role.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_instance_dba_role.py
 environment:
   TEST_MODULE: roles/test_instance_dba_role.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_instance_roles.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_instance_roles.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_instance_roles.py
 environment:
   TEST_MODULE: roles/test_instance_roles.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_multi_relations.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_multi_relations.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_multi_relations.py
 environment:
   TEST_MODULE: test_multi_relations.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_mysql_root.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_mysql_root.py/task.yaml
@@ -2,7 +2,7 @@ summary: test_mysql_root.py
 environment:
   TEST_MODULE: relations/test_mysql_root.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 systems:

--- a/kubernetes/tests/spread/integration/test_osm_integration_bundle.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_osm_integration_bundle.py/task.yaml
@@ -2,7 +2,7 @@ summary: test_osm_integration_bundle.py
 environment:
   TEST_MODULE: test_osm_integration_bundle.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 variants:

--- a/kubernetes/tests/spread/integration/test_primary_switchover.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_primary_switchover.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_primary_switchover
 environment:
   TEST_MODULE: high_availability/test_primary_switchover.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_replication_data_consistency.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_replication_data_consistency.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_replication_data_consistency.py
 environment:
   TEST_MODULE: high_availability/test_replication_data_consistency.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_replication_data_isolation.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_replication_data_isolation.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_replication_data_isolation.py
 environment:
   TEST_MODULE: high_availability/test_replication_data_isolation.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_replication_logs_rotation.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_replication_logs_rotation.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_replication_logs_rotation.py
 environment:
   TEST_MODULE: high_availability/test_replication_logs_rotation.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_replication_reelection.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_replication_reelection.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_replication_reelection.py
 environment:
   TEST_MODULE: high_availability/test_replication_reelection.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_replication_scaling.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_replication_scaling.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_replication_scaling.py
 environment:
   TEST_MODULE: high_availability/test_replication_scaling.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_replication_unit_endpoints.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_replication_unit_endpoints.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_replication_unit_endpoints.py
 environment:
   TEST_MODULE: high_availability/test_replication_unit_endpoints.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_replication_variables.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_replication_variables.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_replication_variables.py
 environment:
   TEST_MODULE: high_availability/test_replication_variables.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_saturate_max_connections.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_saturate_max_connections.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_saturate_max_connections.py
 environment:
   TEST_MODULE: test_saturate_max_connections.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_self_healing_network_cut.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_self_healing_network_cut.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_self_healing_network_cut.py
 environment:
   TEST_MODULE: high_availability/test_self_healing_network_cut.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_self_healing_node_drain.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_self_healing_node_drain.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_self_healing_node_drain.py
 environment:
   TEST_MODULE: high_availability/test_self_healing_node_drain.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_self_healing_pod.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_self_healing_pod.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_self_healing_pod.py
 environment:
   TEST_MODULE: high_availability/test_self_healing_pod.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_self_healing_process_frozen.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_self_healing_process_frozen.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_self_healing_process_frozen.py
 environment:
   TEST_MODULE: high_availability/test_self_healing_process_frozen.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_self_healing_process_killed.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_self_healing_process_killed.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_self_healing_process_killed.py
 environment:
   TEST_MODULE: high_availability/test_self_healing_process_killed.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_self_healing_restart_graceful.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_self_healing_restart_graceful.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_self_healing_restart_graceful.py
 environment:
   TEST_MODULE: high_availability/test_self_healing_restart_graceful.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_self_healing_setup_crash.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_self_healing_setup_crash.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_self_healing_setup_crash.py
 environment:
   TEST_MODULE: high_availability/test_self_healing_setup_crash.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_self_healing_stop_all.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_self_healing_stop_all.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_self_healing_stop_all.py
 environment:
   TEST_MODULE: high_availability/test_self_healing_stop_all.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_self_healing_stop_primary.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_self_healing_stop_primary.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_self_healing_stop_primary.py
 environment:
   TEST_MODULE: high_availability/test_self_healing_stop_primary.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_tls.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_tls.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_tls.py
 environment:
   TEST_MODULE: test_tls.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_upgrade.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_upgrade.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_upgrade.py
 environment:
   TEST_MODULE: high_availability/test_upgrade.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_upgrade_rollback_incompat.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_upgrade_rollback_incompat.py/task.yaml
@@ -2,7 +2,7 @@ summary: test_upgrade_rollback_incompat.py
 environment:
   TEST_MODULE: high_availability/test_upgrade_rollback_incompat.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 systems:

--- a/kubernetes/tests/spread/release/test_upgrade_from_stable_2023_09_12.py/task.yaml
+++ b/kubernetes/tests/spread/release/test_upgrade_from_stable_2023_09_12.py/task.yaml
@@ -5,7 +5,7 @@ environment:
   CHARM_REVISION_AMD64: 99
   CHARM_REVISION_ARM64:
 execute: |
-  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 backends:

--- a/kubernetes/tests/spread/release/test_upgrade_from_stable_2024_01_08.py/task.yaml
+++ b/kubernetes/tests/spread/release/test_upgrade_from_stable_2024_01_08.py/task.yaml
@@ -5,7 +5,7 @@ environment:
   CHARM_REVISION_AMD64: 113
   CHARM_REVISION_ARM64:
 execute: |
-  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 backends:

--- a/kubernetes/tests/spread/release/test_upgrade_from_stable_2024_03_18.py/task.yaml
+++ b/kubernetes/tests/spread/release/test_upgrade_from_stable_2024_03_18.py/task.yaml
@@ -5,7 +5,7 @@ environment:
   CHARM_REVISION_AMD64: 127
   CHARM_REVISION_ARM64:
 execute: |
-  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 backends:

--- a/kubernetes/tests/spread/release/test_upgrade_from_stable_2024_06_26.py/task.yaml
+++ b/kubernetes/tests/spread/release/test_upgrade_from_stable_2024_06_26.py/task.yaml
@@ -5,7 +5,7 @@ environment:
   CHARM_REVISION_AMD64: 153
   CHARM_REVISION_ARM64:
 execute: |
-  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 backends:

--- a/kubernetes/tests/spread/release/test_upgrade_from_stable_2024_09_04.py/task.yaml
+++ b/kubernetes/tests/spread/release/test_upgrade_from_stable_2024_09_04.py/task.yaml
@@ -5,7 +5,7 @@ environment:
   CHARM_REVISION_AMD64: 180
   CHARM_REVISION_ARM64: 181
 execute: |
-  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 backends:

--- a/kubernetes/tests/spread/release/test_upgrade_from_stable_2025_01_17.py/task.yaml
+++ b/kubernetes/tests/spread/release/test_upgrade_from_stable_2025_01_17.py/task.yaml
@@ -5,7 +5,7 @@ environment:
   CHARM_REVISION_AMD64: 210
   CHARM_REVISION_ARM64: 211
 execute: |
-  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 backends:

--- a/kubernetes/tests/spread/release/test_upgrade_from_stable_2025_03_11.py/task.yaml
+++ b/kubernetes/tests/spread/release/test_upgrade_from_stable_2025_03_11.py/task.yaml
@@ -5,7 +5,7 @@ environment:
   CHARM_REVISION_AMD64: 240
   CHARM_REVISION_ARM64: 241
 execute: |
-  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 backends:

--- a/kubernetes/tests/spread/release/test_upgrade_from_stable_2025_06_23.py/task.yaml
+++ b/kubernetes/tests/spread/release/test_upgrade_from_stable_2025_06_23.py/task.yaml
@@ -5,7 +5,7 @@ environment:
   CHARM_REVISION_AMD64: 255
   CHARM_REVISION_ARM64: 254
 execute: |
-  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 backends:

--- a/kubernetes/tests/spread/release/test_upgrade_from_stable_2026_01_21.py/task.yaml
+++ b/kubernetes/tests/spread/release/test_upgrade_from_stable_2026_01_21.py/task.yaml
@@ -5,7 +5,7 @@ environment:
   CHARM_REVISION_AMD64: 343
   CHARM_REVISION_ARM64: 344
 execute: |
-  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 backends:

--- a/kubernetes/tox.ini
+++ b/kubernetes/tox.ini
@@ -80,4 +80,4 @@ pass_env =
 commands_pre =
     poetry install --only integration
 commands =
-    poetry run pytest -v --tb native --log-cli-level=INFO -s --ignore={[vars]tests_path}/unit/ {posargs}
+    poetry run pytest -v -x --tb native --log-cli-level=INFO -s --ignore={[vars]tests_path}/unit/ {posargs}

--- a/machines/poetry.lock
+++ b/machines/poetry.lock
@@ -72,37 +72,6 @@ test = ["anyio[trio]", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypo
 trio = ["trio (>=0.26.1)"]
 
 [[package]]
-name = "appnope"
-version = "0.1.3"
-description = "Disable App Nap on macOS >= 10.9"
-optional = false
-python-versions = "*"
-groups = ["integration"]
-markers = "sys_platform == \"darwin\""
-files = [
-    {file = "appnope-0.1.3-py2.py3-none-any.whl", hash = "sha256:265a455292d0bd8a72453494fa24df5a11eb18373a60c7c0430889f22548605e"},
-    {file = "appnope-0.1.3.tar.gz", hash = "sha256:02bd91c4de869fbb1e1c50aafc4098827a7a54ab2f39d9dcba6c9547ed920e24"},
-]
-
-[[package]]
-name = "asttokens"
-version = "2.2.1"
-description = "Annotate AST trees with source code positions"
-optional = false
-python-versions = "*"
-groups = ["integration"]
-files = [
-    {file = "asttokens-2.2.1-py2.py3-none-any.whl", hash = "sha256:6b0ac9e93fb0335014d382b8fa9b3afa7df546984258005da0b9e7095b3deb1c"},
-    {file = "asttokens-2.2.1.tar.gz", hash = "sha256:4622110b2a6f30b77e1473affaa97e711bc2f07d3f10848420ff1898edbe94f3"},
-]
-
-[package.dependencies]
-six = "*"
-
-[package.extras]
-test = ["astroid", "pytest"]
-
-[[package]]
 name = "attrs"
 version = "23.1.0"
 description = "Classes Without Boilerplate"
@@ -120,18 +89,6 @@ dev = ["attrs[docs,tests]", "pre-commit"]
 docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier", "zope-interface"]
 tests = ["attrs[tests-no-zope]", "zope-interface"]
 tests-no-zope = ["cloudpickle ; platform_python_implementation == \"CPython\"", "hypothesis", "mypy (>=1.1.1) ; platform_python_implementation == \"CPython\"", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version < \"3.11\"", "pytest-xdist[psutil]"]
-
-[[package]]
-name = "backcall"
-version = "0.2.0"
-description = "Specifications for callback functions passed in to an API"
-optional = false
-python-versions = "*"
-groups = ["integration"]
-files = [
-    {file = "backcall-0.2.0-py2.py3-none-any.whl", hash = "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255"},
-    {file = "backcall-0.2.0.tar.gz", hash = "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e"},
-]
 
 [[package]]
 name = "backoff"
@@ -609,18 +566,6 @@ test = ["certifi (>=2024)", "cryptography-vectors (==44.0.2)", "pretend (>=0.7)"
 test-randomorder = ["pytest-randomly"]
 
 [[package]]
-name = "decorator"
-version = "5.1.1"
-description = "Decorators for Humans"
-optional = false
-python-versions = ">=3.5"
-groups = ["integration"]
-files = [
-    {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
-    {file = "decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
-]
-
-[[package]]
 name = "deprecated"
 version = "1.2.14"
 description = "Python @deprecated decorator to deprecate old python classes, functions or methods."
@@ -653,21 +598,6 @@ files = [
 
 [package.extras]
 test = ["pytest (>=6)"]
-
-[[package]]
-name = "executing"
-version = "1.2.0"
-description = "Get the currently executing AST node of a frame, and other information"
-optional = false
-python-versions = "*"
-groups = ["integration"]
-files = [
-    {file = "executing-1.2.0-py2.py3-none-any.whl", hash = "sha256:0314a69e37426e3608aada02473b4161d4caf5a4b244d1d0c48072b8fee7bacc"},
-    {file = "executing-1.2.0.tar.gz", hash = "sha256:19da64c18d2d851112f09c287f8d3dbbdf725ab0e569077efb6cdcbd3497c107"},
-]
-
-[package.extras]
-tests = ["asttokens", "littleutils", "pytest", "rich ; python_version >= \"3.11\""]
 
 [[package]]
 name = "google-auth"
@@ -831,88 +761,12 @@ files = [
 ]
 
 [[package]]
-name = "ipdb"
-version = "0.13.13"
-description = "IPython-enabled pdb"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-groups = ["integration"]
-files = [
-    {file = "ipdb-0.13.13-py3-none-any.whl", hash = "sha256:45529994741c4ab6d2388bfa5d7b725c2cf7fe9deffabdb8a6113aa5ed449ed4"},
-    {file = "ipdb-0.13.13.tar.gz", hash = "sha256:e3ac6018ef05126d442af680aad863006ec19d02290561ac88b8b1c0b0cfc726"},
-]
-
-[package.dependencies]
-decorator = {version = "*", markers = "python_version > \"3.6\""}
-ipython = {version = ">=7.31.1", markers = "python_version > \"3.6\""}
-tomli = {version = "*", markers = "python_version > \"3.6\" and python_version < \"3.11\""}
-
-[[package]]
-name = "ipython"
-version = "8.14.0"
-description = "IPython: Productive Interactive Computing"
-optional = false
-python-versions = ">=3.9"
-groups = ["integration"]
-files = [
-    {file = "ipython-8.14.0-py3-none-any.whl", hash = "sha256:248aca623f5c99a6635bc3857677b7320b9b8039f99f070ee0d20a5ca5a8e6bf"},
-    {file = "ipython-8.14.0.tar.gz", hash = "sha256:1d197b907b6ba441b692c48cf2a3a2de280dc0ac91a3405b39349a50272ca0a1"},
-]
-
-[package.dependencies]
-appnope = {version = "*", markers = "sys_platform == \"darwin\""}
-backcall = "*"
-colorama = {version = "*", markers = "sys_platform == \"win32\""}
-decorator = "*"
-jedi = ">=0.16"
-matplotlib-inline = "*"
-pexpect = {version = ">4.3", markers = "sys_platform != \"win32\""}
-pickleshare = "*"
-prompt-toolkit = ">=3.0.30,<3.0.37 || >3.0.37,<3.1.0"
-pygments = ">=2.4.0"
-stack-data = "*"
-traitlets = ">=5"
-
-[package.extras]
-all = ["black", "curio", "docrepr", "ipykernel", "ipyparallel", "ipywidgets", "matplotlib", "matplotlib (!=3.2.0)", "nbconvert", "nbformat", "notebook", "numpy (>=1.21)", "pandas", "pytest (<7)", "pytest (<7.1)", "pytest-asyncio", "qtconsole", "setuptools (>=18.5)", "sphinx (>=1.3)", "sphinx-rtd-theme", "stack-data", "testpath", "trio", "typing-extensions"]
-black = ["black"]
-doc = ["docrepr", "ipykernel", "matplotlib", "pytest (<7)", "pytest (<7.1)", "pytest-asyncio", "setuptools (>=18.5)", "sphinx (>=1.3)", "sphinx-rtd-theme", "stack-data", "testpath", "typing-extensions"]
-kernel = ["ipykernel"]
-nbconvert = ["nbconvert"]
-nbformat = ["nbformat"]
-notebook = ["ipywidgets", "notebook"]
-parallel = ["ipyparallel"]
-qtconsole = ["qtconsole"]
-test = ["pytest (<7.1)", "pytest-asyncio", "testpath"]
-test-extra = ["curio", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.21)", "pandas", "pytest (<7.1)", "pytest-asyncio", "testpath", "trio"]
-
-[[package]]
-name = "jedi"
-version = "0.19.0"
-description = "An autocompletion tool for Python that can be used for text editors."
-optional = false
-python-versions = ">=3.6"
-groups = ["integration"]
-files = [
-    {file = "jedi-0.19.0-py2.py3-none-any.whl", hash = "sha256:cb8ce23fbccff0025e9386b5cf85e892f94c9b822378f8da49970471335ac64e"},
-    {file = "jedi-0.19.0.tar.gz", hash = "sha256:bcf9894f1753969cbac8022a8c2eaee06bfa3724e4192470aaffe7eb6272b0c4"},
-]
-
-[package.dependencies]
-parso = ">=0.8.3,<0.9.0"
-
-[package.extras]
-docs = ["Jinja2 (==2.11.3)", "MarkupSafe (==1.1.1)", "Pygments (==2.8.1)", "alabaster (==0.7.12)", "babel (==2.9.1)", "chardet (==4.0.0)", "commonmark (==0.8.1)", "docutils (==0.17.1)", "future (==0.18.2)", "idna (==2.10)", "imagesize (==1.2.0)", "mock (==1.0.1)", "packaging (==20.9)", "pyparsing (==2.4.7)", "pytz (==2021.1)", "readthedocs-sphinx-ext (==2.1.4)", "recommonmark (==0.5.0)", "requests (==2.25.1)", "six (==1.15.0)", "snowballstemmer (==2.1.0)", "sphinx (==1.8.5)", "sphinx-rtd-theme (==0.4.3)", "sphinxcontrib-serializinghtml (==1.1.4)", "sphinxcontrib-websupport (==1.2.4)", "urllib3 (==1.26.4)"]
-qa = ["flake8 (==5.0.4)", "mypy (==0.971)", "types-setuptools (==67.2.0.1)"]
-testing = ["Django (<3.1)", "attrs", "colorama", "docopt", "pytest (<7.0.0)"]
-
-[[package]]
 name = "jinja2"
 version = "3.1.6"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "integration"]
+groups = ["main"]
 files = [
     {file = "jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"},
     {file = "jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"},
@@ -1103,7 +957,7 @@ version = "2.1.3"
 description = "Safely add untrusted strings to HTML/XML markup."
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "integration"]
+groups = ["main"]
 files = [
     {file = "MarkupSafe-2.1.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cd0f502fe016460680cd20aaa5a76d241d6f35a1c3350c474bac1273803893fa"},
     {file = "MarkupSafe-2.1.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e09031c87a1e51556fdcb46e5bd4f59dfb743061cf93c4d6831bf894f125eb57"},
@@ -1166,21 +1020,6 @@ files = [
     {file = "MarkupSafe-2.1.3-cp39-cp39-win_amd64.whl", hash = "sha256:3fd4abcb888d15a94f32b75d8fd18ee162ca0c064f35b11134be77050296d6ba"},
     {file = "MarkupSafe-2.1.3.tar.gz", hash = "sha256:af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad"},
 ]
-
-[[package]]
-name = "matplotlib-inline"
-version = "0.1.6"
-description = "Inline Matplotlib backend for Jupyter"
-optional = false
-python-versions = ">=3.5"
-groups = ["integration"]
-files = [
-    {file = "matplotlib-inline-0.1.6.tar.gz", hash = "sha256:f887e5f10ba98e8d2b150ddcf4702c1e5f8b3a20005eb0f74bfdbd360ee6f304"},
-    {file = "matplotlib_inline-0.1.6-py3-none-any.whl", hash = "sha256:f1f41aab5328aa5aaea9b16d083b128102f8712542f819fe7e6a420ff581b311"},
-]
-
-[package.dependencies]
-traitlets = "*"
 
 [[package]]
 name = "mypy-extensions"
@@ -1443,50 +1282,6 @@ gssapi = ["gssapi (>=1.4.1) ; platform_system != \"Windows\"", "pyasn1 (>=0.1.7)
 invoke = ["invoke (>=1.3)"]
 
 [[package]]
-name = "parso"
-version = "0.8.3"
-description = "A Python Parser"
-optional = false
-python-versions = ">=3.6"
-groups = ["integration"]
-files = [
-    {file = "parso-0.8.3-py2.py3-none-any.whl", hash = "sha256:c001d4636cd3aecdaf33cbb40aebb59b094be2a74c556778ef5576c175e19e75"},
-    {file = "parso-0.8.3.tar.gz", hash = "sha256:8c07be290bb59f03588915921e29e8a50002acaf2cdc5fa0e0114f91709fafa0"},
-]
-
-[package.extras]
-qa = ["flake8 (==3.8.3)", "mypy (==0.782)"]
-testing = ["docopt", "pytest (<6.0.0)"]
-
-[[package]]
-name = "pexpect"
-version = "4.9.0"
-description = "Pexpect allows easy control of interactive console applications."
-optional = false
-python-versions = "*"
-groups = ["integration"]
-markers = "sys_platform != \"win32\""
-files = [
-    {file = "pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523"},
-    {file = "pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f"},
-]
-
-[package.dependencies]
-ptyprocess = ">=0.5"
-
-[[package]]
-name = "pickleshare"
-version = "0.7.5"
-description = "Tiny 'shelve'-like database with concurrency support"
-optional = false
-python-versions = "*"
-groups = ["integration"]
-files = [
-    {file = "pickleshare-0.7.5-py2.py3-none-any.whl", hash = "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56"},
-    {file = "pickleshare-0.7.5.tar.gz", hash = "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca"},
-]
-
-[[package]]
 name = "pluggy"
 version = "1.6.0"
 description = "plugin and hook calling mechanisms for python"
@@ -1513,21 +1308,6 @@ files = [
     {file = "poetry_core-1.7.0-py3-none-any.whl", hash = "sha256:38e174cdb00a84ee4a1cab66a378b435747f72414f5573bc18cfc3850a94df38"},
     {file = "poetry_core-1.7.0.tar.gz", hash = "sha256:8f679b83bd9c820082637beca1204124d5d2a786e4818da47ec8acefd0353b74"},
 ]
-
-[[package]]
-name = "prompt-toolkit"
-version = "3.0.39"
-description = "Library for building powerful interactive command lines in Python"
-optional = false
-python-versions = ">=3.7.0"
-groups = ["integration"]
-files = [
-    {file = "prompt_toolkit-3.0.39-py3-none-any.whl", hash = "sha256:9dffbe1d8acf91e3de75f3b544e4842382fc06c6babe903ac9acb74dc6e08d88"},
-    {file = "prompt_toolkit-3.0.39.tar.gz", hash = "sha256:04505ade687dc26dc4284b1ad19a83be2f2afe83e7a828ace0c72f3a1df72aac"},
-]
-
-[package.dependencies]
-wcwidth = "*"
 
 [[package]]
 name = "protobuf"
@@ -1560,34 +1340,6 @@ files = [
     {file = "protobuf-3.20.3-py2.py3-none-any.whl", hash = "sha256:a7ca6d488aa8ff7f329d4c545b2dbad8ac31464f1d8b1c87ad1346717731e4db"},
     {file = "protobuf-3.20.3.tar.gz", hash = "sha256:2e3427429c9cffebf259491be0af70189607f365c2f41c7c3764af6f337105f2"},
 ]
-
-[[package]]
-name = "ptyprocess"
-version = "0.7.0"
-description = "Run a subprocess in a pseudo terminal"
-optional = false
-python-versions = "*"
-groups = ["integration"]
-markers = "sys_platform != \"win32\""
-files = [
-    {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
-    {file = "ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},
-]
-
-[[package]]
-name = "pure-eval"
-version = "0.2.2"
-description = "Safely evaluate AST nodes without side effects"
-optional = false
-python-versions = "*"
-groups = ["integration"]
-files = [
-    {file = "pure_eval-0.2.2-py3-none-any.whl", hash = "sha256:01eaab343580944bc56080ebe0a674b39ec44a945e6d09ba7db3cb8cec289350"},
-    {file = "pure_eval-0.2.2.tar.gz", hash = "sha256:2b45320af6dfaa1750f543d714b6d1c520a1688dec6fd24d339063ce0aaa9ac3"},
-]
-
-[package.extras]
-tests = ["pytest"]
 
 [[package]]
 name = "pyasn1"
@@ -1683,21 +1435,6 @@ dotenv = ["python-dotenv (>=0.10.4)"]
 email = ["email-validator (>=1.0.3)"]
 
 [[package]]
-name = "pygments"
-version = "2.15.1"
-description = "Pygments is a syntax highlighting package written in Python."
-optional = false
-python-versions = ">=3.7"
-groups = ["integration"]
-files = [
-    {file = "Pygments-2.15.1-py3-none-any.whl", hash = "sha256:db2db3deb4b4179f399a09054b023b6a586b76499d36965813c71aa8ed7b5fd1"},
-    {file = "Pygments-2.15.1.tar.gz", hash = "sha256:8ace4d3c1dd481894b2005f560ead0f9f19ee64fe983366be1a21e171d12775c"},
-]
-
-[package.extras]
-plugins = ["importlib-metadata ; python_version < \"3.8\""]
-
-[[package]]
 name = "pyhcl"
 version = "0.4.5"
 description = "HCL configuration parser for python"
@@ -1791,25 +1528,6 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
-name = "pytest-asyncio"
-version = "0.21.2"
-description = "Pytest support for asyncio"
-optional = false
-python-versions = ">=3.7"
-groups = ["integration"]
-files = [
-    {file = "pytest_asyncio-0.21.2-py3-none-any.whl", hash = "sha256:ab664c88bb7998f711d8039cacd4884da6430886ae8bbd4eded552ed2004f16b"},
-    {file = "pytest_asyncio-0.21.2.tar.gz", hash = "sha256:d67738fc232b94b326b9d060750beb16e0074210b98dd8b58a5239fa2a154f45"},
-]
-
-[package.dependencies]
-pytest = ">=7.0.0"
-
-[package.extras]
-docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
-testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
-
-[[package]]
 name = "pytest-mock"
 version = "3.11.1"
 description = "Thin-wrapper around the mock package for easier use with pytest"
@@ -1826,26 +1544,6 @@ pytest = ">=5.0"
 
 [package.extras]
 dev = ["pre-commit", "pytest-asyncio", "tox"]
-
-[[package]]
-name = "pytest-operator"
-version = "0.35.0"
-description = "Fixtures for Operators"
-optional = false
-python-versions = "*"
-groups = ["integration"]
-files = [
-    {file = "pytest-operator-0.35.0.tar.gz", hash = "sha256:ed963dc013fc576e218081e95197926b7c98116c1fb5ab234269cf72e0746d5b"},
-    {file = "pytest_operator-0.35.0-py3-none-any.whl", hash = "sha256:026715faba7a0d725ca386fe05a45cfc73746293d8d755be6d2a67ca252267f5"},
-]
-
-[package.dependencies]
-ipdb = "*"
-jinja2 = "*"
-juju = "*"
-pytest = "*"
-pytest-asyncio = "<0.23"
-pyyaml = "*"
 
 [[package]]
 name = "python-dateutil"
@@ -2213,26 +1911,6 @@ files = [
 ]
 
 [[package]]
-name = "stack-data"
-version = "0.6.2"
-description = "Extract data from python stack frames and tracebacks for informative displays"
-optional = false
-python-versions = "*"
-groups = ["integration"]
-files = [
-    {file = "stack_data-0.6.2-py3-none-any.whl", hash = "sha256:cbb2a53eb64e5785878201a97ed7c7b94883f48b87bfb0bbe8b623c74679e4a8"},
-    {file = "stack_data-0.6.2.tar.gz", hash = "sha256:32d2dd0376772d01b6cb9fc996f3c8b57a357089dec328ed4b6553d037eaf815"},
-]
-
-[package.dependencies]
-asttokens = ">=2.1.0"
-executing = ">=1.2.0"
-pure-eval = "*"
-
-[package.extras]
-tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
-
-[[package]]
 name = "tenacity"
 version = "8.2.2"
 description = "Retry code until it succeeds"
@@ -2271,22 +1949,6 @@ files = [
     {file = "toposort-1.10-py3-none-any.whl", hash = "sha256:cbdbc0d0bee4d2695ab2ceec97fe0679e9c10eab4b2a87a9372b929e70563a87"},
     {file = "toposort-1.10.tar.gz", hash = "sha256:bfbb479c53d0a696ea7402601f4e693c97b0367837c8898bc6471adfca37a6bd"},
 ]
-
-[[package]]
-name = "traitlets"
-version = "5.9.0"
-description = "Traitlets Python configuration system"
-optional = false
-python-versions = ">=3.7"
-groups = ["integration"]
-files = [
-    {file = "traitlets-5.9.0-py3-none-any.whl", hash = "sha256:9e6ec080259b9a5940c797d58b613b5e31441c2257b87c2e795c5228ae80d2d8"},
-    {file = "traitlets-5.9.0.tar.gz", hash = "sha256:f6cde21a9c68cf756af02035f72d5a723bf607e862e7be33ece505abf4a3bad9"},
-]
-
-[package.extras]
-docs = ["myst-parser", "pydata-sphinx-theme", "sphinx"]
-test = ["argcomplete (>=2.0)", "pre-commit", "pytest", "pytest-mock"]
 
 [[package]]
 name = "typing-extensions"
@@ -2333,18 +1995,6 @@ brotli = ["brotli (>=1.0.9) ; platform_python_implementation == \"CPython\"", "b
 h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
-
-[[package]]
-name = "wcwidth"
-version = "0.2.6"
-description = "Measures the displayed width of unicode strings in a terminal"
-optional = false
-python-versions = "*"
-groups = ["integration"]
-files = [
-    {file = "wcwidth-0.2.6-py2.py3-none-any.whl", hash = "sha256:795b138f6875577cd91bba52baf9e445cd5118fd32723b460e30a0af30ea230e"},
-    {file = "wcwidth-0.2.6.tar.gz", hash = "sha256:a5220780a404dbe3353789870978e472cfe477761f06ee55077256e509b156d0"},
-]
 
 [[package]]
 name = "websocket-client"

--- a/machines/pyproject.toml
+++ b/machines/pyproject.toml
@@ -50,7 +50,6 @@ unit = [
 ]
 integration = [
     "pytest~=7.4",
-    "pytest-operator~=0.35.0",
     "juju~=3.6",
     "mysql-connector-python~=9.1",
     "tenacity~=8.2",

--- a/machines/tests/integration/conftest.py
+++ b/machines/tests/integration/conftest.py
@@ -52,22 +52,5 @@ def cloud_configs_gcp() -> tuple[dict[str, str], dict[str, str]]:
 
 
 @pytest.fixture(scope="module")
-def juju(request: pytest.FixtureRequest):
-    """Pytest fixture that wraps :meth:`jubilant.with_model`.
-
-    This adds command line parameter ``--keep-models`` (see help for details).
-    """
-    model = request.config.getoption("--model")
-    keep_models = bool(request.config.getoption("--keep-models"))
-
-    if model:
-        juju = jubilant_backports.Juju(model=model)  # type: ignore
-        yield juju
-        log = juju.debug_log(limit=1000)
-    else:
-        with jubilant_backports.temp_model(keep=keep_models) as juju:
-            yield juju
-            log = juju.debug_log(limit=1000)
-
-    if request.session.testsfailed:
-        print(log, end="")
+def juju() -> jubilant_backports.Juju:
+    return jubilant_backports.Juju(model="testing")

--- a/machines/tests/integration/integration/high_availability/test_async_replication.py
+++ b/machines/tests/integration/integration/high_availability/test_async_replication.py
@@ -29,13 +29,13 @@ MINUTE_SECS = 60
 
 
 @pytest.fixture(scope="module")
-def first_model(juju: Juju, request: pytest.FixtureRequest) -> Generator:
+def first_model(juju: Juju) -> Generator:
     """Creates and return the first model."""
     yield juju.model
 
 
 @pytest.fixture(scope="module")
-def second_model(juju: Juju, request: pytest.FixtureRequest) -> Generator:
+def second_model(juju: Juju) -> Generator:
     """Creates and returns the second model."""
     model_name = f"{juju.model}-other"
 
@@ -43,8 +43,6 @@ def second_model(juju: Juju, request: pytest.FixtureRequest) -> Generator:
     juju.add_model(model_name)
 
     yield model_name
-    if request.config.getoption("--keep-models"):
-        return
 
     logging.info(f"Destroying model: {model_name}")
     juju.destroy_model(model_name, destroy_storage=True, force=True)
@@ -68,7 +66,6 @@ def continuous_writes(first_model: str) -> Generator:
 
 
 @juju3
-@pytest.mark.abort_on_fail
 def test_build_and_deploy(first_model: str, second_model: str, charm: str) -> None:
     """Simple test to ensure that the MySQL application charms get deployed."""
     configuration = {"profile": "testing"}
@@ -106,7 +103,6 @@ def test_build_and_deploy(first_model: str, second_model: str, charm: str) -> No
 
 
 @juju3
-@pytest.mark.abort_on_fail
 def test_async_relate(first_model: str, second_model: str) -> None:
     """Relate the two MySQL clusters."""
     logging.info("Creating offers in first model")
@@ -135,7 +131,6 @@ def test_async_relate(first_model: str, second_model: str) -> None:
 
 
 @juju3
-@pytest.mark.abort_on_fail
 def test_deploy_router_and_app(first_model: str) -> None:
     """Deploy the router and the test application."""
     logging.info("Deploying the router and test application")
@@ -174,7 +169,6 @@ def test_deploy_router_and_app(first_model: str) -> None:
 
 
 @juju3
-@pytest.mark.abort_on_fail
 def test_create_replication(first_model: str, second_model: str) -> None:
     """Run the create-replication action and wait for the applications to settle."""
     model_1 = Juju(model=first_model)
@@ -199,7 +193,6 @@ def test_create_replication(first_model: str, second_model: str) -> None:
 
 
 @juju3
-@pytest.mark.abort_on_fail
 def test_data_replication(first_model: str, second_model: str, continuous_writes) -> None:
     """Test to write to primary, and read the same data back from replicas."""
     logging.info("Testing data replication")
@@ -211,7 +204,6 @@ def test_data_replication(first_model: str, second_model: str, continuous_writes
 
 
 @juju3
-@pytest.mark.abort_on_fail
 def test_standby_promotion(first_model: str, second_model: str, continuous_writes) -> None:
     """Test graceful promotion of a standby cluster to primary."""
     model_2 = Juju(model=second_model)
@@ -241,7 +233,6 @@ def test_standby_promotion(first_model: str, second_model: str, continuous_write
 
 
 @juju3
-@pytest.mark.abort_on_fail
 def test_failover(first_model: str, second_model: str) -> None:
     """Test switchover on primary cluster fail."""
     logging.info("Freezing mysqld on primary cluster units")
@@ -284,7 +275,6 @@ def test_failover(first_model: str, second_model: str) -> None:
 
 
 @juju3
-@pytest.mark.abort_on_fail
 def test_rejoin_invalidated_cluster(
     first_model: str, second_model: str, continuous_writes
 ) -> None:
@@ -304,7 +294,6 @@ def test_rejoin_invalidated_cluster(
 
 
 @juju3
-@pytest.mark.abort_on_fail
 def test_unrelate_and_relate(first_model: str, second_model: str, continuous_writes) -> None:
     """Test removing and re-relating the two mysql clusters."""
     model_1 = Juju(model=first_model)

--- a/machines/tests/integration/integration/high_availability/test_async_replication_upgrade.py
+++ b/machines/tests/integration/integration/high_availability/test_async_replication_upgrade.py
@@ -30,13 +30,13 @@ MINUTE_SECS = 60
 
 
 @pytest.fixture(scope="module")
-def first_model(juju: Juju, request: pytest.FixtureRequest) -> Generator:
+def first_model(juju: Juju) -> Generator:
     """Creates and return the first model."""
     yield juju.model
 
 
 @pytest.fixture(scope="module")
-def second_model(juju: Juju, request: pytest.FixtureRequest) -> Generator:
+def second_model(juju: Juju) -> Generator:
     """Creates and returns the second model."""
     model_name = f"{juju.model}-other"
 
@@ -44,8 +44,6 @@ def second_model(juju: Juju, request: pytest.FixtureRequest) -> Generator:
     juju.add_model(model_name)
 
     yield model_name
-    if request.config.getoption("--keep-models"):
-        return
 
     logging.info(f"Destroying model: {model_name}")
     juju.destroy_model(model_name, destroy_storage=True, force=True)
@@ -69,7 +67,6 @@ def continuous_writes(first_model: str) -> Generator:
 
 
 @juju3
-@pytest.mark.abort_on_fail
 def test_build_and_deploy(first_model: str, second_model: str, charm: str) -> None:
     """Simple test to ensure that the MySQL application charms get deployed."""
     configuration = {"profile": "testing"}
@@ -107,7 +104,6 @@ def test_build_and_deploy(first_model: str, second_model: str, charm: str) -> No
 
 
 @juju3
-@pytest.mark.abort_on_fail
 def test_async_relate(first_model: str, second_model: str) -> None:
     """Relate the two MySQL clusters."""
     logging.info("Creating offers in first model")
@@ -136,7 +132,6 @@ def test_async_relate(first_model: str, second_model: str) -> None:
 
 
 @juju3
-@pytest.mark.abort_on_fail
 def test_deploy_test_app(first_model: str) -> None:
     """Deploy the test application."""
     logging.info("Deploying the test application")
@@ -162,7 +157,6 @@ def test_deploy_test_app(first_model: str) -> None:
 
 
 @juju3
-@pytest.mark.abort_on_fail
 def test_create_replication(first_model: str, second_model: str) -> None:
     """Run the create-replication action and wait for the applications to settle."""
     model_1 = Juju(model=first_model)
@@ -187,7 +181,6 @@ def test_create_replication(first_model: str, second_model: str) -> None:
 
 
 @juju3
-@pytest.mark.abort_on_fail
 def test_upgrade_from_edge(
     first_model: str, second_model: str, charm: str, continuous_writes
 ) -> None:
@@ -203,7 +196,6 @@ def test_upgrade_from_edge(
 
 
 @juju3
-@pytest.mark.abort_on_fail
 def test_data_replication(first_model: str, second_model: str, continuous_writes) -> None:
     """Test to write to primary, and read the same data back from replicas."""
     logging.info("Testing data replication")

--- a/machines/tests/integration/integration/high_availability/test_primary_switchover.py
+++ b/machines/tests/integration/integration/high_availability/test_primary_switchover.py
@@ -5,7 +5,6 @@ import logging
 import subprocess
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from ...helpers_ha import (
@@ -25,7 +24,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -60,7 +58,6 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_cluster_switchover(juju: Juju) -> None:
     """Test that the primary node can be switched over."""
     logging.info("Testing cluster switchover...")
@@ -88,7 +85,6 @@ def test_cluster_switchover(juju: Juju) -> None:
     assert get_mysql_primary_unit(juju, app_name) == new_primary_unit, "Switchover failed"
 
 
-@pytest.mark.abort_on_fail
 def test_cluster_failover_after_majority_loss(juju: Juju) -> None:
     """Test the promote-to-primary command after losing the majority of nodes, with force flag."""
     app_name = get_app_name(juju, "mysql")

--- a/machines/tests/integration/integration/high_availability/test_replication_data_consistency.py
+++ b/machines/tests/integration/integration/high_availability/test_replication_data_consistency.py
@@ -4,7 +4,6 @@
 import logging
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from ...helpers import generate_random_string
@@ -22,7 +21,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -57,7 +55,6 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_consistent_data_replication_across_cluster(juju: Juju) -> None:
     """Confirm that data is replicated from the primary node to all the replicas."""
     table_name = "data"

--- a/machines/tests/integration/integration/high_availability/test_replication_data_isolation.py
+++ b/machines/tests/integration/integration/high_availability/test_replication_data_isolation.py
@@ -5,7 +5,6 @@ import logging
 from time import sleep
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from ...helpers_ha import (
@@ -21,7 +20,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")

--- a/machines/tests/integration/integration/high_availability/test_replication_logs_rotation.py
+++ b/machines/tests/integration/integration/high_availability/test_replication_logs_rotation.py
@@ -6,7 +6,6 @@ import tempfile
 from pathlib import Path
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 from tenacity import (
     Retrying,
@@ -28,7 +27,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -63,7 +61,6 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_log_rotation(juju: Juju) -> None:
     """Test the log rotation of text files."""
     log_types = ["error", "audit"]

--- a/machines/tests/integration/integration/high_availability/test_replication_reelection.py
+++ b/machines/tests/integration/integration/high_availability/test_replication_reelection.py
@@ -4,7 +4,6 @@
 import logging
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from ...helpers import generate_random_string
@@ -24,7 +23,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -59,7 +57,6 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_kill_primary_check_reelection(juju: Juju) -> None:
     """Confirm that a new primary is elected when the current primary is tear down."""
     check_mysql_units_writes_increment(juju, MYSQL_APP_NAME)

--- a/machines/tests/integration/integration/high_availability/test_replication_scaling.py
+++ b/machines/tests/integration/integration/high_availability/test_replication_scaling.py
@@ -4,7 +4,6 @@
 import logging
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from ...helpers import generate_random_string
@@ -23,7 +22,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -58,7 +56,6 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_scaling_without_data_loss(juju: Juju) -> None:
     """Test that data is preserved during scale up and scale down."""
     table_name = "instance_state_replication"

--- a/machines/tests/integration/integration/high_availability/test_replication_unit_endpoints.py
+++ b/machines/tests/integration/integration/high_availability/test_replication_unit_endpoints.py
@@ -5,7 +5,6 @@ import logging
 import time
 
 import jubilant_backports
-import pytest
 import urllib3
 from jubilant_backports import Juju
 from tenacity import (
@@ -33,7 +32,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -68,7 +66,6 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_exporter_endpoints(juju: Juju) -> None:
     """Test that endpoints are running."""
     http_client = urllib3.PoolManager()

--- a/machines/tests/integration/integration/high_availability/test_replication_variables.py
+++ b/machines/tests/integration/integration/high_availability/test_replication_variables.py
@@ -4,7 +4,6 @@
 import logging
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from ...helpers_ha import (
@@ -19,7 +18,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -54,7 +52,6 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_custom_variables(juju: Juju) -> None:
     """Query database for custom variables."""
     for unit in get_app_units(juju, MYSQL_APP_NAME):

--- a/machines/tests/integration/integration/high_availability/test_self_healing_network_cut.py
+++ b/machines/tests/integration/integration/high_availability/test_self_healing_network_cut.py
@@ -6,7 +6,6 @@ import logging
 import subprocess
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 from tenacity import (
     Retrying,
@@ -39,7 +38,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -74,7 +72,6 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_network_cut(juju: Juju, continuous_writes) -> None:
     """Completely cut and restore network."""
     mysql_units = get_app_units(juju, MYSQL_APP_NAME)

--- a/machines/tests/integration/integration/high_availability/test_self_healing_process_frozen.py
+++ b/machines/tests/integration/integration/high_availability/test_self_healing_process_frozen.py
@@ -4,7 +4,6 @@
 import logging
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from constants import CLUSTER_ADMIN_USERNAME
@@ -32,7 +31,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -67,7 +65,6 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_freeze_db_process(juju: Juju, continuous_writes) -> None:
     """Freeze and unfreeze process and check for auto cluster recovery."""
     # Ensure continuous writes still incrementing for all units

--- a/machines/tests/integration/integration/high_availability/test_self_healing_process_killed.py
+++ b/machines/tests/integration/integration/high_availability/test_self_healing_process_killed.py
@@ -4,7 +4,6 @@
 import logging
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from ...helpers import generate_random_string
@@ -26,7 +25,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -61,7 +59,6 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_kill_db_process(juju: Juju, continuous_writes) -> None:
     """Kill mysqld process and check for auto cluster recovery."""
     # Ensure continuous writes still incrementing for all units

--- a/machines/tests/integration/integration/high_availability/test_self_healing_restart_forceful.py
+++ b/machines/tests/integration/integration/high_availability/test_self_healing_restart_forceful.py
@@ -4,7 +4,6 @@
 import logging
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from constants import SERVER_CONFIG_USERNAME
@@ -33,7 +32,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -68,7 +66,6 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_sst_test(juju: Juju, continuous_writes):
     """Test a forceful restart with deleted data and without transaction logs (forced clone)."""
     # Ensure continuous writes still incrementing for all units

--- a/machines/tests/integration/integration/high_availability/test_self_healing_restart_graceful.py
+++ b/machines/tests/integration/integration/high_availability/test_self_healing_restart_graceful.py
@@ -4,7 +4,6 @@
 import logging
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from constants import SERVER_CONFIG_USERNAME
@@ -27,7 +26,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -62,7 +60,6 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_cluster_manual_rejoin(juju: Juju, continuous_writes) -> None:
     """The cluster manual re-join test.
 

--- a/machines/tests/integration/integration/high_availability/test_self_healing_stop_all.py
+++ b/machines/tests/integration/integration/high_availability/test_self_healing_stop_all.py
@@ -4,7 +4,6 @@
 import logging
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from constants import CLUSTER_ADMIN_USERNAME
@@ -33,7 +32,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -68,7 +66,6 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_cluster_pause(juju: Juju, continuous_writes) -> None:
     """Pause test.
 

--- a/machines/tests/integration/integration/high_availability/test_self_healing_stop_primary.py
+++ b/machines/tests/integration/integration/high_availability/test_self_healing_stop_primary.py
@@ -5,7 +5,6 @@ import logging
 import random
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from constants import CLUSTER_ADMIN_USERNAME, SERVER_CONFIG_USERNAME
@@ -35,7 +34,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -70,7 +68,6 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_replicate_data_on_restart(juju: Juju, continuous_writes) -> None:
     """Stop server, write data, start and validate replication."""
     # Ensure continuous writes still incrementing for all units

--- a/machines/tests/integration/integration/high_availability/test_upgrade.py
+++ b/machines/tests/integration/integration/high_availability/test_upgrade.py
@@ -8,7 +8,6 @@ import zipfile
 from pathlib import Path
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from ...helpers_ha import (
@@ -27,7 +26,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_latest(juju: Juju) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -62,7 +60,6 @@ def test_deploy_latest(juju: Juju) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_pre_upgrade_check(juju: Juju) -> None:
     """Test that the pre-upgrade-check action runs successfully."""
     mysql_leader = get_app_leader(juju, MYSQL_APP_NAME)
@@ -81,7 +78,6 @@ def test_pre_upgrade_check(juju: Juju) -> None:
     assert mysql_primary == mysql_leader, "Primary unit not set to leader"
 
 
-@pytest.mark.abort_on_fail
 def test_upgrade_from_edge(juju: Juju, charm: str, continuous_writes) -> None:
     """Update the second cluster."""
     logging.info("Ensure continuous writes are incrementing")
@@ -106,7 +102,6 @@ def test_upgrade_from_edge(juju: Juju, charm: str, continuous_writes) -> None:
     check_mysql_units_writes_increment(juju, MYSQL_APP_NAME)
 
 
-@pytest.mark.abort_on_fail
 def test_fail_and_rollback(juju: Juju, charm: str, continuous_writes) -> None:
     """Test an upgrade failure and its rollback."""
     mysql_app_leader = get_app_leader(juju, MYSQL_APP_NAME)

--- a/machines/tests/integration/integration/high_availability/test_upgrade_rollback_incompat.py
+++ b/machines/tests/integration/integration/high_availability/test_upgrade_rollback_incompat.py
@@ -10,7 +10,6 @@ from ast import literal_eval
 from pathlib import Path
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from ...helpers_ha import (
@@ -33,7 +32,6 @@ MINUTE_SECS = 60
 # TODO: remove AMD64 marker after next incompatible MySQL server version is released in our snap
 # (details: https://github.com/canonical/mysql-operator/pull/472#discussion_r1659300069)
 @amd64_only
-@pytest.mark.abort_on_fail
 def test_build_and_deploy(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     snap_revisions = Path("snap_revisions.json")
@@ -86,7 +84,6 @@ def test_build_and_deploy(juju: Juju, charm: str) -> None:
 # TODO: remove AMD64 marker after next incompatible MySQL server version is released in our snap
 # (details: https://github.com/canonical/mysql-operator/pull/472#discussion_r1659300069)
 @amd64_only
-@pytest.mark.abort_on_fail
 def test_pre_upgrade_check(juju: Juju) -> None:
     """Test that the pre-upgrade-check action runs successfully."""
     mysql_leader = get_app_leader(juju, MYSQL_APP_NAME)
@@ -98,7 +95,6 @@ def test_pre_upgrade_check(juju: Juju) -> None:
 # TODO: remove AMD64 marker after next incompatible MySQL server version is released in our snap
 # (details: https://github.com/canonical/mysql-operator/pull/472#discussion_r1659300069)
 @amd64_only
-@pytest.mark.abort_on_fail
 def test_upgrade_to_failing(juju: Juju, charm: str, continuous_writes) -> None:
     logging.info("Ensure continuous_writes")
     check_mysql_units_writes_increment(juju, MYSQL_APP_NAME)
@@ -135,7 +131,6 @@ def test_upgrade_to_failing(juju: Juju, charm: str, continuous_writes) -> None:
 # TODO: remove AMD64 marker after next incompatible MySQL server version is released in our snap
 # (details: https://github.com/canonical/mysql-operator/pull/472#discussion_r1659300069)
 @amd64_only
-@pytest.mark.abort_on_fail
 def test_rollback(juju: Juju, charm: str, continuous_writes) -> None:
     """Test upgrade rollback to a healthy revision."""
     relation_data = get_relation_data(juju, MYSQL_APP_NAME, "upgrade")

--- a/machines/tests/integration/integration/high_availability/test_upgrade_skip_pre_upgrade_check.py
+++ b/machines/tests/integration/integration/high_availability/test_upgrade_skip_pre_upgrade_check.py
@@ -4,7 +4,6 @@
 import logging
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from ...helpers_ha import (
@@ -20,7 +19,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 MINUTE_SECS = 60
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_stable(juju: Juju) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
@@ -56,7 +54,6 @@ def test_deploy_stable(juju: Juju) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_refresh_without_pre_upgrade_check(juju: Juju, charm: str) -> None:
     """Test updating from stable channel."""
     logging.info("Refresh the charm")
@@ -75,7 +72,6 @@ def test_refresh_without_pre_upgrade_check(juju: Juju, charm: str) -> None:
     check_mysql_units_writes_increment(juju, MYSQL_APP_NAME)
 
 
-@pytest.mark.abort_on_fail
 def test_rollback_without_pre_upgrade_check(juju: Juju, charm: str) -> None:
     """Test refresh back to stable channel."""
     # Early Jubilant 1.X.Y versions do not support the `switch` option

--- a/machines/tests/integration/integration/relations/test_database.py
+++ b/machines/tests/integration/integration/relations/test_database.py
@@ -6,7 +6,6 @@ import json
 import logging
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from constants import DB_RELATION_NAME, PASSWORD_LENGTH, ROOT_USERNAME, SERVER_CONFIG_USERNAME
@@ -39,8 +38,6 @@ ENDPOINT = "database"
 TIMEOUT = 15 * MINUTE_SECS
 
 
-@pytest.mark.abort_on_fail
-@pytest.mark.skip_if_deployed
 def test_build_and_deploy(juju: Juju, charm):
     """Build the charm and deploy 3 units to ensure a cluster is formed."""
     juju.deploy(
@@ -69,7 +66,6 @@ def test_build_and_deploy(juju: Juju, charm):
     )
 
 
-@pytest.mark.abort_on_fail
 def test_password_rotation(juju: Juju):
     """Rotate password and confirm changes."""
     # get primary unit first, need that to invoke set-password action
@@ -97,7 +93,6 @@ def test_password_rotation(juju: Juju):
     assert len(output) > 0, "query with new password failed, no databases found"
 
 
-@pytest.mark.abort_on_fail
 def test_password_rotation_silent(juju: Juju):
     """Rotate password and confirm changes."""
     # get primary unit first, need that to invoke set-password action
@@ -122,7 +117,6 @@ def test_password_rotation_silent(juju: Juju):
     assert len(output) > 0, "query with new password failed, no databases found"
 
 
-@pytest.mark.abort_on_fail
 def test_password_rotation_root_user(juju: Juju):
     """Rotate password for root user and confirm changes."""
     # get primary unit first, need that to invoke set-password action
@@ -137,7 +131,6 @@ def test_password_rotation_root_user(juju: Juju):
     assert updated_credentials["password"] != old_credentials["password"]
 
 
-@pytest.mark.abort_on_fail
 @markers.only_without_juju_secrets
 def test_relation_creation_databag(juju: Juju):
     """Relate charms and wait for the expected changes in status."""
@@ -158,7 +151,6 @@ def test_relation_creation_databag(juju: Juju):
     assert {"password", "username"} <= set(relation_data[0]["application-data"])
 
 
-@pytest.mark.abort_on_fail
 @markers.only_with_juju_secrets
 def test_relation_creation(juju: Juju):
     """Relate charms and wait for the expected changes in status (using juju secrets)."""
@@ -175,7 +167,6 @@ def test_relation_creation(juju: Juju):
     assert "secret-user" in relation_data[0]["application-data"]
 
 
-@pytest.mark.abort_on_fail
 def test_read_only_endpoints(juju: Juju):
     """Check read-only-endpoints are correctly updated."""
     relation_data = get_relation_data(juju, DATABASE_APP_NAME, DB_RELATION_NAME)
@@ -213,7 +204,6 @@ def test_read_only_endpoints(juju: Juju):
     )
 
 
-@pytest.mark.abort_on_fail
 def test_relation_broken(juju: Juju):
     """Remove relation and wait for the expected changes in status."""
     juju.remove_relation(f"{APPLICATION_APP_NAME}:{ENDPOINT}", f"{DATABASE_APP_NAME}:{ENDPOINT}")

--- a/machines/tests/integration/integration/relations/test_db_router.py
+++ b/machines/tests/integration/integration/relations/test_db_router.py
@@ -6,7 +6,6 @@ import logging
 import random
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from ...helpers_ha import (
@@ -32,7 +31,6 @@ SLOW_WAIT_TIMEOUT = 45 * 60
 FAST_WAIT_TIMEOUT = 30 * 60
 
 
-@pytest.mark.abort_on_fail
 def test_keystone_bundle_db_router(juju: Juju, charm) -> None:
     """Deploy the keystone bundle to test the 'db-router' relation."""
     juju.deploy(

--- a/machines/tests/integration/integration/relations/test_relation_mysql_legacy.py
+++ b/machines/tests/integration/integration/relations/test_relation_mysql_legacy.py
@@ -5,7 +5,6 @@
 import logging
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from ...helpers import (
@@ -31,8 +30,6 @@ TEST_DATABASE = "continuous_writes"
 TIMEOUT = 15 * 60
 
 
-@pytest.mark.abort_on_fail
-@pytest.mark.skip_if_deployed
 def test_build_and_deploy(juju: Juju, charm) -> None:
     """Build the charm and deploy 3 units to ensure a cluster is formed."""
     logger.info(
@@ -67,7 +64,6 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_relation_creation(juju: Juju):
     """Relate charms and wait for the expected changes in status."""
     # Configure a user and database to be used for the relation
@@ -92,7 +88,6 @@ def test_relation_creation(juju: Juju):
     )
 
 
-@pytest.mark.abort_on_fail
 def test_relation_broken(juju: Juju):
     """Remove relation and wait for the expected changes in status."""
     # store database credentials for test access later

--- a/machines/tests/integration/integration/relations/test_shared_db.py
+++ b/machines/tests/integration/integration/relations/test_shared_db.py
@@ -7,7 +7,6 @@ import random
 from time import sleep
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from ...helpers_ha import (
@@ -32,7 +31,6 @@ SLOW_WAIT_TIMEOUT = 25 * 60
 FAST_WAIT_TIMEOUT = 15 * 60
 
 
-@pytest.mark.abort_on_fail
 def test_keystone_bundle_shared_db(juju: Juju, charm) -> None:
     """Deploy the keystone bundle to test the 'shared-db' relation.
 

--- a/machines/tests/integration/integration/roles/test_database_dba_role.py
+++ b/machines/tests/integration/integration/roles/test_database_dba_role.py
@@ -26,8 +26,6 @@ INTEGRATOR_APP_NAME = "data-integrator"
 TIMEOUT = 15 * MINUTE_SECS
 
 
-@pytest.mark.abort_on_fail
-@pytest.mark.skip_if_deployed
 def test_build_and_deploy(juju: Juju, charm) -> None:
     """Simple test to ensure that the mysql and data-integrator charms get deployed."""
     juju.deploy(
@@ -62,7 +60,6 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_charmed_dba_role(juju: Juju):
     """Test the database-level DBA role."""
     juju.config(f"{INTEGRATOR_APP_NAME}1", {"database-name": "preserved", "extra-user-roles": ""})

--- a/machines/tests/integration/integration/roles/test_instance_dba_role.py
+++ b/machines/tests/integration/integration/roles/test_instance_dba_role.py
@@ -5,7 +5,6 @@
 import logging
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from ...helpers import execute_queries_on_unit
@@ -25,8 +24,6 @@ INTEGRATOR_APP_NAME = "data-integrator"
 TIMEOUT = 15 * MINUTE_SECS
 
 
-@pytest.mark.abort_on_fail
-@pytest.mark.skip_if_deployed
 def test_build_and_deploy(juju: Juju, charm) -> None:
     """Simple test to ensure that the mysql and data-integrator charms get deployed."""
     juju.deploy(
@@ -52,7 +49,6 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_charmed_dba_role(juju: Juju):
     """Test the instance-level DBA role."""
     # configure integrator and relate

--- a/machines/tests/integration/integration/roles/test_instance_roles.py
+++ b/machines/tests/integration/integration/roles/test_instance_roles.py
@@ -27,8 +27,6 @@ INTEGRATOR_APP_NAME = "data-integrator"
 TIMEOUT = 15 * MINUTE_SECS
 
 
-@pytest.mark.abort_on_fail
-@pytest.mark.skip_if_deployed
 def test_build_and_deploy(juju: Juju, charm) -> None:
     """Simple test to ensure that the mysql and data-integrator charms get deployed."""
     juju.deploy(
@@ -63,7 +61,6 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_charmed_read_role(juju: Juju):
     """Test the instance-level charmed_read role."""
     juju.config(
@@ -143,7 +140,6 @@ def test_charmed_read_role(juju: Juju):
     )
 
 
-@pytest.mark.abort_on_fail
 def test_charmed_dml_role(juju: Juju):
     """Test the instance-level charmed_dml role."""
     juju.config(

--- a/machines/tests/integration/integration/spaces/test_spaced_db.py
+++ b/machines/tests/integration/integration/spaces/test_spaced_db.py
@@ -22,7 +22,6 @@ TIMEOUT = 15 * MINUTE_SECS
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.abort_on_fail
 def test_build_and_deploy(juju: Juju, lxd_spaces, charm) -> None:
     """Build the charm and deploy 3 units to ensure a cluster is formed."""
     juju.deploy(

--- a/machines/tests/integration/integration/test_backup_aws.py
+++ b/machines/tests/integration/integration/test_backup_aws.py
@@ -72,7 +72,6 @@ def clean_backups_from_buckets(cloud_configs_aws):
         bucket_object.delete()
 
 
-@pytest.mark.abort_on_fail
 def test_build_and_deploy(juju: Juju, charm) -> None:
     """Simple test to ensure that the mysql charm gets deployed."""
     logger.info("Deploying mysql")
@@ -117,7 +116,6 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_backup(juju: Juju, cloud_configs_aws) -> None:
     """Test to create a backup and list backups."""
     global backup_id, value_before_backup, value_after_backup
@@ -202,7 +200,6 @@ def test_backup(juju: Juju, cloud_configs_aws) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_restore_on_same_cluster(juju: Juju, cloud_configs_aws) -> None:
     """Test to restore a backup to the same mysql cluster."""
     cloud_configs, cloud_credentials = cloud_configs_aws
@@ -317,7 +314,6 @@ def test_restore_on_same_cluster(juju: Juju, cloud_configs_aws) -> None:
     scale_app_units(juju, DATABASE_APP_NAME, 0)
 
 
-@pytest.mark.abort_on_fail
 def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_aws) -> None:
     """Test to restore a backup on a new mysql cluster."""
     cloud_configs, cloud_credentials = cloud_configs_aws

--- a/machines/tests/integration/integration/test_backup_ceph.py
+++ b/machines/tests/integration/integration/test_backup_ceph.py
@@ -162,7 +162,6 @@ def clean_backups_from_buckets(cloud_configs_ceph):
         bucket_object.delete()
 
 
-@pytest.mark.abort_on_fail
 def test_build_and_deploy(juju: Juju, charm) -> None:
     """Simple test to ensure that the mysql charm gets deployed."""
     logger.info("Deploying mysql")
@@ -207,7 +206,6 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_backup(juju: Juju, cloud_configs_ceph) -> None:
     """Test to create a backup and list backups."""
     global backup_id, value_before_backup, value_after_backup
@@ -292,7 +290,6 @@ def test_backup(juju: Juju, cloud_configs_ceph) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_restore_on_same_cluster(juju: Juju, cloud_configs_ceph) -> None:
     """Test to restore a backup to the same mysql cluster."""
     cloud_configs, cloud_credentials = cloud_configs_ceph
@@ -407,7 +404,6 @@ def test_restore_on_same_cluster(juju: Juju, cloud_configs_ceph) -> None:
     scale_app_units(juju, DATABASE_APP_NAME, 0)  # TODO: is this needed?
 
 
-@pytest.mark.abort_on_fail
 def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_ceph) -> None:
     """Test to restore a backup on a new mysql cluster."""
     cloud_configs, cloud_credentials = cloud_configs_ceph

--- a/machines/tests/integration/integration/test_backup_gcp.py
+++ b/machines/tests/integration/integration/test_backup_gcp.py
@@ -72,7 +72,6 @@ def clean_backups_from_buckets(cloud_configs_gcp):
         bucket_object.delete()
 
 
-@pytest.mark.abort_on_fail
 def test_build_and_deploy(juju: Juju, charm) -> None:
     """Simple test to ensure that the mysql charm gets deployed."""
     logger.info("Deploying mysql")
@@ -117,7 +116,6 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_backup(juju: Juju, cloud_configs_gcp) -> None:
     """Test to create a backup and list backups."""
     global backup_id, value_before_backup, value_after_backup
@@ -202,7 +200,6 @@ def test_backup(juju: Juju, cloud_configs_gcp) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_restore_on_same_cluster(juju: Juju, cloud_configs_gcp) -> None:
     """Test to restore a backup to the same mysql cluster."""
     cloud_configs, cloud_credentials = cloud_configs_gcp
@@ -317,7 +314,6 @@ def test_restore_on_same_cluster(juju: Juju, cloud_configs_gcp) -> None:
     scale_app_units(juju, DATABASE_APP_NAME, 0)
 
 
-@pytest.mark.abort_on_fail
 def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_gcp) -> None:
     """Test to restore a backup on a new mysql cluster."""
     cloud_configs, cloud_credentials = cloud_configs_gcp

--- a/machines/tests/integration/integration/test_backup_pitr_aws.py
+++ b/machines/tests/integration/integration/test_backup_pitr_aws.py
@@ -1,13 +1,11 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import pytest
 from jubilant_backports import Juju
 
 from .helpers_backups import build_and_deploy_operations, pitr_operations
 
 
-@pytest.mark.abort_on_fail
 def test_build_and_deploy_aws(
     juju: Juju, cloud_configs_aws: tuple[dict[str, str], dict[str, str]], charm
 ) -> None:

--- a/machines/tests/integration/integration/test_backup_pitr_gcp.py
+++ b/machines/tests/integration/integration/test_backup_pitr_gcp.py
@@ -1,13 +1,11 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import pytest
 from jubilant_backports import Juju
 
 from .helpers_backups import build_and_deploy_operations, pitr_operations
 
 
-@pytest.mark.abort_on_fail
 def test_build_and_deploy_gcp(
     juju: Juju, cloud_configs_gcp: tuple[dict[str, str], dict[str, str]], charm
 ) -> None:

--- a/machines/tests/integration/integration/test_saturate_max_connections.py
+++ b/machines/tests/integration/integration/test_saturate_max_connections.py
@@ -18,7 +18,6 @@ TEST_APP_NAME = "app"
 CONNECTIONS = 10
 
 
-@pytest.mark.abort_on_fail
 def test_build_and_deploy(juju: Juju, charm) -> None:
     """Build the charm and deploy 1 units to ensure a cluster is formed."""
     juju.deploy(
@@ -31,7 +30,6 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_deploy_and_relate_test_app(juju: Juju) -> None:
     config = {"auto_start_writes": False, "sleep_interval": "500"}
     logger.info("Deploying test app")
@@ -54,7 +52,6 @@ def test_deploy_and_relate_test_app(juju: Juju) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_saturate_max_connections(juju: Juju) -> None:
     app_unit_name = get_app_units(juju, TEST_APP_NAME)[0]
     mysql_unit_name = get_app_units(juju, MYSQL_APP_NAME)[0]

--- a/machines/tests/integration/integration/test_tls.py
+++ b/machines/tests/integration/integration/test_tls.py
@@ -6,7 +6,6 @@ import logging
 from time import sleep
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from constants import CLUSTER_ADMIN_USERNAME, TLS_SSL_CERT_FILE
@@ -46,8 +45,6 @@ else:
 config = {}
 
 
-@pytest.mark.skip_if_deployed
-@pytest.mark.abort_on_fail
 def test_build_and_deploy(juju: Juju, charm) -> None:
     """Build the charm and deploy 3 units to ensure a cluster is formed."""
     logger.info(f"Deploying {APP_NAME}")
@@ -69,7 +66,6 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_connection_before_tls(juju: Juju) -> None:
     """Ensure connections (with and without ssl) are possible before relating with TLS operator."""
     app_units = get_app_units(juju, APP_NAME)
@@ -97,7 +93,6 @@ def test_connection_before_tls(juju: Juju) -> None:
         )
 
 
-@pytest.mark.abort_on_fail
 def test_enable_tls(juju: Juju) -> None:
     """Test for encryption enablement when relation to TLS charm."""
     app_units = get_app_units(juju, APP_NAME)
@@ -147,7 +142,6 @@ def test_enable_tls(juju: Juju) -> None:
     assert get_tls_ca(juju, app_units[0]), "❌ No CA found after TLS relation"
 
 
-@pytest.mark.abort_on_fail
 def test_rotate_tls_key(juju: Juju) -> None:
     """Verify rotating tls private keys restarts cluster with new certificates.
 
@@ -202,7 +196,6 @@ def test_rotate_tls_key(juju: Juju) -> None:
         )
 
 
-@pytest.mark.abort_on_fail
 def test_disable_tls(juju: Juju) -> None:
     # Remove the relation
     app_units = get_app_units(juju, APP_NAME)

--- a/machines/tests/integration/integration/test_vm_reboot.py
+++ b/machines/tests/integration/integration/test_vm_reboot.py
@@ -6,7 +6,6 @@ from subprocess import run
 from time import sleep
 
 import jubilant_backports
-import pytest
 from jubilant_backports import Juju
 
 from ..helpers_ha import MINUTE_SECS, get_app_units, get_unit_machine
@@ -19,8 +18,6 @@ SLEEP_WAIT = 5
 TIMEOUT = 15 * MINUTE_SECS
 
 
-@pytest.mark.skip_if_deployed
-@pytest.mark.abort_on_fail
 def test_build_and_deploy(juju: Juju, charm) -> None:
     """Build the charm and deploy 3 units to ensure a cluster is formed."""
     logger.info(f"Deploying {APP_NAME}")
@@ -42,7 +39,6 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_reboot_1_of_3_units(juju: Juju) -> None:
     """Reboot a single unit and ensure it comes back online."""
     app_units = get_app_units(juju, APP_NAME)
@@ -61,7 +57,6 @@ def test_reboot_1_of_3_units(juju: Juju) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_reboot_2_of_3_units(juju: Juju) -> None:
     """Reboot 2 units and ensure they come back online."""
     app_units = get_app_units(juju, APP_NAME)
@@ -80,7 +75,6 @@ def test_reboot_2_of_3_units(juju: Juju) -> None:
     )
 
 
-@pytest.mark.abort_on_fail
 def test_reboot_3_of_3_units(juju: Juju) -> None:
     """Reboot all 3 units and ensure they come back online."""
     app_units = get_app_units(juju, APP_NAME)

--- a/machines/tests/spread/integration/test_architecture.py/task.yaml
+++ b/machines/tests/spread/integration/test_architecture.py/task.yaml
@@ -2,7 +2,7 @@ summary: test_architecture.py
 environment:
   TEST_MODULE: test_architecture.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 backends:

--- a/machines/tests/spread/integration/test_async_replication.py/task.yaml
+++ b/machines/tests/spread/integration/test_async_replication.py/task.yaml
@@ -2,7 +2,7 @@ summary: test_async_replication.py
 environment:
   TEST_MODULE: high_availability/test_async_replication.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 variants:

--- a/machines/tests/spread/integration/test_async_replication_upgrade.py/task.yaml
+++ b/machines/tests/spread/integration/test_async_replication_upgrade.py/task.yaml
@@ -2,7 +2,7 @@ summary: test_async_replication_upgrade.py
 environment:
   TEST_MODULE: high_availability/test_async_replication_upgrade.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 variants:

--- a/machines/tests/spread/integration/test_backup_aws.py/task.yaml
+++ b/machines/tests/spread/integration/test_backup_aws.py/task.yaml
@@ -2,7 +2,7 @@ summary: test_backup_aws.py
 environment:
   TEST_MODULE: test_backup_aws.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 backends:

--- a/machines/tests/spread/integration/test_backup_ceph.py/task.yaml
+++ b/machines/tests/spread/integration/test_backup_ceph.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_backup_ceph.py
 environment:
   TEST_MODULE: test_backup_ceph.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_backup_gcp.py/task.yaml
+++ b/machines/tests/spread/integration/test_backup_gcp.py/task.yaml
@@ -2,7 +2,7 @@ summary: test_backup_gcp.py
 environment:
   TEST_MODULE: test_backup_gcp.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 backends:

--- a/machines/tests/spread/integration/test_backup_pitr_aws.py/task.yaml
+++ b/machines/tests/spread/integration/test_backup_pitr_aws.py/task.yaml
@@ -2,7 +2,7 @@ summary: test_backup_pitr_aws.py
 environment:
   TEST_MODULE: test_backup_pitr_aws.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 backends:

--- a/machines/tests/spread/integration/test_backup_pitr_gcp.py/task.yaml
+++ b/machines/tests/spread/integration/test_backup_pitr_gcp.py/task.yaml
@@ -2,7 +2,7 @@ summary: test_backup_pitr_gcp.py
 environment:
   TEST_MODULE: test_backup_pitr_gcp.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 backends:

--- a/machines/tests/spread/integration/test_database.py/task.yaml
+++ b/machines/tests/spread/integration/test_database.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_database.py
 environment:
   TEST_MODULE: relations/test_database.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_database_dba_role.py/task.yaml
+++ b/machines/tests/spread/integration/test_database_dba_role.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_database_dba_role.py
 environment:
   TEST_MODULE: roles/test_database_dba_role.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_db_router.py/task.yaml
+++ b/machines/tests/spread/integration/test_db_router.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_db_router.py
 environment:
   TEST_MODULE: relations/test_db_router.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_instance_dba_role.py/task.yaml
+++ b/machines/tests/spread/integration/test_instance_dba_role.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_instance_dba_role.py
 environment:
   TEST_MODULE: roles/test_instance_dba_role.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_instance_roles.py/task.yaml
+++ b/machines/tests/spread/integration/test_instance_roles.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_instance_roles.py
 environment:
   TEST_MODULE: roles/test_instance_roles.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_primary_switchover.py/task.yaml
+++ b/machines/tests/spread/integration/test_primary_switchover.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_primary_switchover
 environment:
   TEST_MODULE: high_availability/test_primary_switchover.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_relation_mysql_legacy.py/task.yaml
+++ b/machines/tests/spread/integration/test_relation_mysql_legacy.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_relation_mysql_legacy.py
 environment:
   TEST_MODULE: relations/test_relation_mysql_legacy.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_replication_data_consistency.py/task.yaml
+++ b/machines/tests/spread/integration/test_replication_data_consistency.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_replication_data_consistency.py
 environment:
   TEST_MODULE: high_availability/test_replication_data_consistency.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_replication_data_isolation.py/task.yaml
+++ b/machines/tests/spread/integration/test_replication_data_isolation.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_replication_data_isolation.py
 environment:
   TEST_MODULE: high_availability/test_replication_data_isolation.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_replication_logs_rotation.py/task.yaml
+++ b/machines/tests/spread/integration/test_replication_logs_rotation.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_replication_logs_rotation.py
 environment:
   TEST_MODULE: high_availability/test_replication_logs_rotation.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_replication_reelection.py/task.yaml
+++ b/machines/tests/spread/integration/test_replication_reelection.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_replication_reelection.py
 environment:
   TEST_MODULE: high_availability/test_replication_reelection.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_replication_scaling.py/task.yaml
+++ b/machines/tests/spread/integration/test_replication_scaling.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_replication_scaling.py
 environment:
   TEST_MODULE: high_availability/test_replication_scaling.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_replication_unit_endpoints.py/task.yaml
+++ b/machines/tests/spread/integration/test_replication_unit_endpoints.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_replication_unit_endpoints.py
 environment:
   TEST_MODULE: high_availability/test_replication_unit_endpoints.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_replication_variables.py/task.yaml
+++ b/machines/tests/spread/integration/test_replication_variables.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_replication_variables.py
 environment:
   TEST_MODULE: high_availability/test_replication_variables.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_saturate_max_connections.py/task.yaml
+++ b/machines/tests/spread/integration/test_saturate_max_connections.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_saturate_max_connections.py
 environment:
   TEST_MODULE: test_saturate_max_connections.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_self_healing_network_cut.py/task.yaml
+++ b/machines/tests/spread/integration/test_self_healing_network_cut.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_self_healing_network_cut.py
 environment:
   TEST_MODULE: high_availability/test_self_healing_network_cut.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_self_healing_process_frozen.py/task.yaml
+++ b/machines/tests/spread/integration/test_self_healing_process_frozen.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_self_healing_process_frozen.py
 environment:
   TEST_MODULE: high_availability/test_self_healing_process_frozen.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_self_healing_process_killed.py/task.yaml
+++ b/machines/tests/spread/integration/test_self_healing_process_killed.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_self_healing_process_killed.py
 environment:
   TEST_MODULE: high_availability/test_self_healing_process_killed.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_self_healing_restart_forceful.py/task.yaml
+++ b/machines/tests/spread/integration/test_self_healing_restart_forceful.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_self_healing_restart_forceful.py
 environment:
   TEST_MODULE: high_availability/test_self_healing_restart_forceful.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_self_healing_restart_graceful.py/task.yaml
+++ b/machines/tests/spread/integration/test_self_healing_restart_graceful.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_self_healing_restart_graceful.py
 environment:
   TEST_MODULE: high_availability/test_self_healing_restart_graceful.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_self_healing_stop_all.py/task.yaml
+++ b/machines/tests/spread/integration/test_self_healing_stop_all.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_self_healing_stop_all.py
 environment:
   TEST_MODULE: high_availability/test_self_healing_stop_all.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_self_healing_stop_primary.py/task.yaml
+++ b/machines/tests/spread/integration/test_self_healing_stop_primary.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_self_healing_stop_primary.py
 environment:
   TEST_MODULE: high_availability/test_self_healing_stop_primary.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_shared_db.py/task.yaml
+++ b/machines/tests/spread/integration/test_shared_db.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_shared_db.py
 environment:
   TEST_MODULE: relations/test_shared_db.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_spaced_db.py/task.yaml
+++ b/machines/tests/spread/integration/test_spaced_db.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_spaced_db.py
 environment:
   TEST_MODULE: spaces/test_spaced_db.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_subordinate_charms.py/task.yaml
+++ b/machines/tests/spread/integration/test_subordinate_charms.py/task.yaml
@@ -2,7 +2,7 @@ summary: test_subordinate_charms.py
 environment:
   TEST_MODULE: test_subordinate_charms.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 backends:

--- a/machines/tests/spread/integration/test_tls.py/task.yaml
+++ b/machines/tests/spread/integration/test_tls.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_tls.py
 environment:
   TEST_MODULE: test_tls.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_upgrade.py/task.yaml
+++ b/machines/tests/spread/integration/test_upgrade.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_upgrade.py
 environment:
   TEST_MODULE: high_availability/test_upgrade.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_upgrade_rollback_incompat.py/task.yaml
+++ b/machines/tests/spread/integration/test_upgrade_rollback_incompat.py/task.yaml
@@ -2,7 +2,7 @@ summary: test_upgrade_rollback_incompat.py
 environment:
   TEST_MODULE: high_availability/test_upgrade_rollback_incompat.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 systems:

--- a/machines/tests/spread/integration/test_upgrade_skip_pre_upgrade_check.py/task.yaml
+++ b/machines/tests/spread/integration/test_upgrade_skip_pre_upgrade_check.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_upgrade_skip_pre_upgrade_check.py
 environment:
   TEST_MODULE: high_availability/test_upgrade_skip_pre_upgrade_check.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_vm_reboot.py/task.yaml
+++ b/machines/tests/spread/integration/test_vm_reboot.py/task.yaml
@@ -2,6 +2,6 @@ summary: test_vm_reboot.py
 environment:
   TEST_MODULE: test_vm_reboot.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/release/test_upgrade_from_stable_2023_04_20.py/task.yaml
+++ b/machines/tests/spread/release/test_upgrade_from_stable_2023_04_20.py/task.yaml
@@ -4,7 +4,7 @@ environment:
   CHARM_REVISION_AMD64: 151
   CHARM_REVISION_ARM64:
 execute: |
-  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 backends:

--- a/machines/tests/spread/release/test_upgrade_from_stable_2023_10_06.py/task.yaml
+++ b/machines/tests/spread/release/test_upgrade_from_stable_2023_10_06.py/task.yaml
@@ -4,7 +4,7 @@ environment:
   CHARM_REVISION_AMD64: 196
   CHARM_REVISION_ARM64:
 execute: |
-  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 backends:

--- a/machines/tests/spread/release/test_upgrade_from_stable_2024_06_26.py/task.yaml
+++ b/machines/tests/spread/release/test_upgrade_from_stable_2024_06_26.py/task.yaml
@@ -4,7 +4,7 @@ environment:
   CHARM_REVISION_AMD64: 240
   CHARM_REVISION_ARM64:
 execute: |
-  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 backends:

--- a/machines/tests/spread/release/test_upgrade_from_stable_2024_12_02.py/task.yaml
+++ b/machines/tests/spread/release/test_upgrade_from_stable_2024_12_02.py/task.yaml
@@ -4,7 +4,7 @@ environment:
   CHARM_REVISION_AMD64: 313
   CHARM_REVISION_ARM64: 312
 execute: |
-  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 backends:

--- a/machines/tests/spread/release/test_upgrade_from_stable_2025_03_31.py/task.yaml
+++ b/machines/tests/spread/release/test_upgrade_from_stable_2025_03_31.py/task.yaml
@@ -4,7 +4,7 @@ environment:
   CHARM_REVISION_AMD64: 366
   CHARM_REVISION_ARM64: 367
 execute: |
-  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 backends:

--- a/machines/tests/spread/release/test_upgrade_from_stable_2026_01_22.py/task.yaml
+++ b/machines/tests/spread/release/test_upgrade_from_stable_2026_01_22.py/task.yaml
@@ -4,7 +4,7 @@ environment:
   CHARM_REVISION_AMD64: 444
   CHARM_REVISION_ARM64: 442
 execute: |
-  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration -- "tests/integration/release/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 backends:

--- a/machines/tox.ini
+++ b/machines/tox.ini
@@ -86,4 +86,4 @@ pass_env =
 commands_pre =
     poetry install --only integration
 commands =
-    poetry run pytest -v --tb native --log-cli-level=INFO -s --ignore={[vars]tests_path}/unit/ {posargs}
+    poetry run pytest -v -x --tb native --log-cli-level=INFO -s --ignore={[vars]tests_path}/unit/ {posargs}


### PR DESCRIPTION
This PR removes the installation of `pytest-operator` (and `pytest-asyncio` when present) from the operators.

This was a leftover from the migration to Jubilant, where such plugin is not valid anymore (see [migration steps](https://github.com/canonical/charmIng-recipes/blob/main/integration-testing/commands/migrate-jubilant.md)). Every instance of the _abort-on-fail_ plugin strategy has been replaced by the pytest `-x / --exitfirst` flag.
