### PR TITLE
[DPE-9376] Add MySQL 8.0.44 release details

### DIFF
--- a/kubernetes/docs/reference/releases.md
+++ b/kubernetes/docs/reference/releases.md
@@ -31,14 +31,22 @@ Several [revisions](https://documentation.ubuntu.com/juju/3.6/reference/charm/#c
 > 
 > See: [`juju set-constraints`](https://juju.is/docs/juju/juju-set-constraints), [`juju info`](https://juju.is/docs/juju/juju-info) 
 
+### Release 342-344
+
+| Revision | amd64 | arm64 | s390x | Ubuntu 22.04 LTS
+|:--------:|:-----:|:-----:|:-----:|:-----:|
+|[343] | ![check] | | | ![check] |
+|[344] | | ![check] | | ![check] |
+|[342] | | | ![check] | ![check] |
+
+[details=Older releases]
+
 ### Release 254-255
 
 | Revision | amd64 | arm64 | Ubuntu 22.04 LTS
 |:--------:|:-----:|:-----:|:-----:|
 |[254]  || ![check]  | ![check]  |
 |[255] |   ![check]| |  ![check] |
-
-[details=Older releases]
 
 ### Release 240-241
 

--- a/kubernetes/docs/reference/releases.md
+++ b/kubernetes/docs/reference/releases.md
@@ -8,6 +8,7 @@ To see all releases and commits, check the [Charmed MySQL K8s Releases page on G
 
 | Release | MySQL version | Juju version | [TLS encryption](/how-to/enable-tls)* | [COS monitoring](/how-to/monitoring-cos/enable-monitoring) | [Minor version upgrades](/how-to/refresh/single-cluster/refresh-single-cluster) | [Cluster-cluster replication](/how-to/cluster-cluster-replication/deploy) | [Point-in-time recovery](point-in-time-recovery)
 |:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| [342], [343], [344] | 8.0.44 | `3.5.4+` | ![check] | ![check] | ![check] | ![check] | ![check] |
 | [254], [255] | 8.0.41 | `3.5.4+` | ![check] | ![check] | ![check] | ![check] | ![check] |
 | [240], [241] | 8.0.41 | `3.5.4+` | ![check] | ![check] | ![check] | ![check] | |
 | [210], [211] | 8.0.39 | `3.5.4+` | ![check] | ![check] | ![check] | ![check] | |
@@ -92,6 +93,9 @@ Several [revisions](https://documentation.ubuntu.com/juju/3.6/reference/charm/#c
 [/details]
 
 <!-- LINKS -->
+[344]: https://github.com/canonical/mysql-k8s-operator/releases/tag/rev342
+[343]: https://github.com/canonical/mysql-k8s-operator/releases/tag/rev342
+[342]: https://github.com/canonical/mysql-k8s-operator/releases/tag/rev342
 [255]: https://github.com/canonical/mysql-k8s-operator/releases/tag/rev255
 [254]: https://github.com/canonical/mysql-k8s-operator/releases/tag/rev255
 [240]: https://github.com/canonical/mysql-k8s-operator/releases/tag/rev240

--- a/machines/docs/reference/releases.md
+++ b/machines/docs/reference/releases.md
@@ -16,6 +16,7 @@ For a given release, this table shows:
 
 | Release | MySQL version | Juju version | [TLS encryption](/how-to/enable-tls)* | [COS monitoring](/how-to/monitoring-cos/enable-monitoring) | [In-place upgrades](/how-to/refresh/single-cluster/refresh-single-cluster) | [Cluster-cluster replication](/how-to/cluster-cluster-replication/deploy) |
 |:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| [442], [443], [444] | 8.0.44 | `3.4.3+` | ![check] | ![check] | ![check] | ![check] |
 | [366], [367] | 8.0.41 | `3.4.3+` | ![check] | ![check] | ![check] | ![check] |
 | [312], [313] | 8.0.39 | `3.4.3+` | ![check] | ![check] | ![check] | ![check] |
 | [240] | 8.0.36 | `3.4.3+` | ![check] | ![check] | ![check] | ![check] |
@@ -35,6 +36,16 @@ Several [revisions](https://documentation.ubuntu.com/juju/3.6/reference/charm/#c
 > If you deploy a specific revision, **you must make sure it matches your base and architecture** via the tables below or with [`juju info`](https://juju.is/docs/juju/juju-info)
 
 
+### Release 442-444
+
+| Revision | amd64 | arm64 | s390x | Ubuntu 22.04 LTS
+|:--------:|:-----:|:-----:|:-----:|:-----:|
+|[444] | ![check] | | | ![check] |
+|[442] | | ![check] | | ![check] |
+|[443] | | | ![check] | ![check] |
+
+[details=Older releases]
+
 ### Release 366-367
 
 | Revision | amd64 | arm64 | Ubuntu 22.04 LTS
@@ -42,15 +53,12 @@ Several [revisions](https://documentation.ubuntu.com/juju/3.6/reference/charm/#c
 |[366]  |![check] | | ![check]  |
 |[367] |  | ![check]| ![check] |
 
-[details=Older releases]
-
 ### Release 312-313
 
 | Revision | amd64 | arm64 | Ubuntu 22.04 LTS
 |:--------:|:-----:|:-----:|:-----:|
 |[313]  |![check] | | ![check]  |
 |[312] |  | ![check]| ![check] |
-
 
 ### Release 240
 
@@ -78,6 +86,9 @@ Several [revisions](https://documentation.ubuntu.com/juju/3.6/reference/charm/#c
 
 <!-- LINKS -->
 
+[444]: https://github.com/canonical/mysql-operator/releases/tag/rev442
+[443]: https://github.com/canonical/mysql-operator/releases/tag/rev442
+[442]: https://github.com/canonical/mysql-operator/releases/tag/rev442
 [367]: https://github.com/canonical/mysql-operator/releases/tag/rev366
 [366]: https://github.com/canonical/mysql-operator/releases/tag/rev366
 [313]: https://github.com/canonical/mysql-operator/releases/tag/rev312


### PR DESCRIPTION
Added release information for MySQL version 8.0.44 and updated links.

Fix gh-63

## Issue

## Solution

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
