### PR TITLE
[MISC] Remove legacy pytest-asyncio config

### DIFF
--- a/kubernetes/pyproject.toml
+++ b/kubernetes/pyproject.toml
@@ -85,7 +85,6 @@ show_missing = true
 minversion = "6.0"
 log_cli_level = "INFO"
 markers = ["juju3", "only_with_juju_secrets", "only_without_juju_secrets"]
-asyncio_mode = "auto"
 
 # Linting tools configuration
 [tool.ruff]

--- a/machines/pyproject.toml
+++ b/machines/pyproject.toml
@@ -80,7 +80,6 @@ show_missing = true
 [tool.pytest.ini_options]
 minversion = "6.0"
 log_cli_level = "INFO"
-asyncio_mode = "auto"
 
 # Formatting tools configuration
 [tool.ruff]


### PR DESCRIPTION
This PR removes a `pytest-asyncio` plugin configuration option leftover.