### PR TITLE
[MISC] Unify packaging

### DIFF
--- a/kubernetes/poetry.lock
+++ b/kubernetes/poetry.lock
@@ -2007,5 +2007,5 @@ test = ["big-O", "importlib-resources ; python_version < \"3.9\"", "jaraco.funct
 
 [metadata]
 lock-version = "2.1"
-python-versions = "~=3.10"
-content-hash = "e559e07b9ecdd5dd6da59495b16846784c4255e6b25b7ec69af7d2068d3a2fad"
+python-versions = "^3.10"
+content-hash = "fd1d73b9ae588606a3d067549d868fedc4338f301c3ff825ee15a551805f651b"

--- a/kubernetes/pyproject.toml
+++ b/kubernetes/pyproject.toml
@@ -85,7 +85,7 @@ log_cli_level = "INFO"
 [tool.ruff]
 # preview and explicit preview are enabled for CPY001
 preview = true
-target-version = "py38"  # Bump when ready to re-lint
+target-version = "py310"
 src = ["src", "."]
 line-length = 99
 

--- a/kubernetes/pyproject.toml
+++ b/kubernetes/pyproject.toml
@@ -1,9 +1,8 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-[project]
-name = "mysql-k8s-operator"  # Charm is not meant to be packaged
-dependencies = [
+[dependency-groups]
+main = [
     "boto3~=1.28",
     "jinja2~=3.1",
     "lightkube~=0.15.0",
@@ -11,9 +10,6 @@ dependencies = [
     "pyyaml~=6.0",
     "tenacity~=8.2",
 ]
-requires-python = "~=3.10"
-
-[dependency-groups]
 charm-libs = [
     # data_platform_libs/v0/data_interfaces.py
     "ops>=2.0.0",
@@ -65,6 +61,9 @@ integration = [
 [tool.poetry]
 package-mode = false
 requires-poetry = ">=2.2.0"
+
+[tool.poetry.dependencies]
+python = "^3.10"
 
 [tool.poetry.group.format]
 optional = true

--- a/kubernetes/src/charm.py
+++ b/kubernetes/src/charm.py
@@ -17,7 +17,6 @@ import logging
 import random
 from socket import getfqdn
 from time import sleep
-from typing import Optional
 
 import ops
 from charms.data_platform_libs.v0.data_models import TypedCharmBase
@@ -261,7 +260,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         return Layer(layer)  # pyright: ignore [reportArgumentType]
 
     @property
-    def restart_peers(self) -> Optional[ops.model.Relation]:
+    def restart_peers(self) -> ops.model.Relation | None:
         """Retrieve the peer relation."""
         return self.model.get_relation("restart")
 
@@ -310,7 +309,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         else:
             return False
 
-    def get_unit_hostname(self, unit_name: Optional[str] = None) -> str:
+    def get_unit_hostname(self, unit_name: str | None = None) -> str:
         """Get the hostname.localdomain for a unit.
 
         Translate juju unit name to hostname.localdomain, necessary
@@ -369,7 +368,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             logger.exception("Failed to initialize primary")
             raise
 
-    def _get_primary_from_online_peer(self) -> Optional[str]:
+    def _get_primary_from_online_peer(self) -> str | None:
         """Get the primary address from an online peer."""
         for unit in self.peers.units:
             # TODO:
@@ -995,7 +994,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         # avoid changing status while async replication is setting up
         return not (self.replication_consumer.idle and self.replication_offer.idle)
 
-    def _on_update_status(self, _: Optional[UpdateStatusEvent]) -> None:
+    def _on_update_status(self, _: UpdateStatusEvent | None) -> None:
         """Handle the update status event."""
         if not self.upgrade.idle:
             # avoid changing status while upgrade is in progress

--- a/kubernetes/src/config.py
+++ b/kubernetes/src/config.py
@@ -7,7 +7,7 @@
 import configparser
 import logging
 import re
-from typing import ClassVar, Optional
+from typing import ClassVar
 
 from charms.data_platform_libs.v0.data_models import BaseConfigModel
 from charms.mysql.v0.mysql import MAX_CONNECTIONS_FLOOR
@@ -51,10 +51,10 @@ class CharmConfig(BaseConfigModel):
     """Manager for the structured configuration."""
 
     profile: str
-    cluster_name: Optional[str]
-    cluster_set_name: Optional[str]
-    profile_limit_memory: Optional[int]
-    experimental_max_connections: Optional[int]
+    cluster_name: str | None
+    cluster_set_name: str | None
+    profile_limit_memory: int | None
+    experimental_max_connections: int | None
     binlog_retention_days: int
     plugin_audit_enabled: bool
     plugin_audit_strategy: str
@@ -63,7 +63,7 @@ class CharmConfig(BaseConfigModel):
 
     @validator("profile")
     @classmethod
-    def profile_values(cls, value: str) -> Optional[str]:
+    def profile_values(cls, value: str) -> str | None:
         """Check profile config option is one of `testing` or `production`."""
         if value not in ["testing", "production"]:
             raise ValueError("Value not one of 'testing' or 'production'")
@@ -72,7 +72,7 @@ class CharmConfig(BaseConfigModel):
 
     @validator("cluster_name", "cluster_set_name")
     @classmethod
-    def cluster_name_validator(cls, value: str) -> Optional[str]:
+    def cluster_name_validator(cls, value: str) -> str | None:
         """Check for valid cluster, cluster-set name.
 
         Limited to 63 characters, and must start with a letter and
@@ -94,7 +94,7 @@ class CharmConfig(BaseConfigModel):
 
     @validator("profile_limit_memory")
     @classmethod
-    def profile_limit_memory_validator(cls, value: int) -> Optional[int]:
+    def profile_limit_memory_validator(cls, value: int) -> int | None:
         """Check profile limit memory."""
         if value < 600:
             raise ValueError("MySQL Charm requires at least 600MB for bootstrapping")
@@ -105,7 +105,7 @@ class CharmConfig(BaseConfigModel):
 
     @validator("experimental_max_connections")
     @classmethod
-    def experimental_max_connections_validator(cls, value: int) -> Optional[int]:
+    def experimental_max_connections_validator(cls, value: int) -> int | None:
         """Check experimental max connections."""
         if value < MAX_CONNECTIONS_FLOOR:
             raise ValueError(
@@ -126,7 +126,7 @@ class CharmConfig(BaseConfigModel):
 
     @validator("plugin_audit_strategy")
     @classmethod
-    def plugin_audit_strategy_validator(cls, value: str) -> Optional[str]:
+    def plugin_audit_strategy_validator(cls, value: str) -> str | None:
         """Check profile config option is one of `testing` or `production`."""
         if value not in ["async", "semi-async"]:
             raise ValueError("plugin_audit_strategy not one of 'async' or 'semi-async'")
@@ -135,7 +135,7 @@ class CharmConfig(BaseConfigModel):
 
     @validator("logs_audit_policy")
     @classmethod
-    def logs_audit_policy_validator(cls, value: str) -> Optional[str]:
+    def logs_audit_policy_validator(cls, value: str) -> str | None:
         """Check values for audit log policy."""
         valid_values = ["all", "logins", "queries"]
         if value not in valid_values:

--- a/kubernetes/src/k8s_helpers.py
+++ b/kubernetes/src/k8s_helpers.py
@@ -6,7 +6,6 @@
 import logging
 import socket
 import typing
-from typing import Dict, List, Optional, Tuple
 
 from lightkube.core.client import Client
 from lightkube.core.exceptions import ApiError
@@ -47,7 +46,7 @@ class KubernetesHelpers:
         self.cluster_name = charm.app_peer_data.get("cluster-name")
         self.client = Client()  # type: ignore
 
-    def create_endpoint_services(self, roles: List[str]) -> None:
+    def create_endpoint_services(self, roles: list[str]) -> None:
         """Create kubernetes service for endpoints.
 
         Args:
@@ -94,7 +93,7 @@ class KubernetesHelpers:
                     logger.exception("Kubernetes service creation failed: %s", e)
                 raise KubernetesClientError from e
 
-    def delete_endpoint_services(self, roles: List[str]) -> None:
+    def delete_endpoint_services(self, roles: list[str]) -> None:
         """Delete kubernetes service for endpoints.
 
         Args:
@@ -112,7 +111,7 @@ class KubernetesHelpers:
                 else:
                     logger.warning("Kubernetes service deletion failed: %s", e)
 
-    def label_pod(self, role: str, pod_name: Optional[str] = None) -> None:
+    def label_pod(self, role: str, pod_name: str | None = None) -> None:
         """Create or update pod labels.
 
         Args:
@@ -148,7 +147,7 @@ class KubernetesHelpers:
                 logger.exception("Kubernetes pod label creation failed: %s", e)
             raise KubernetesClientError from e
 
-    def get_resources_limits(self, container_name: str) -> Dict:
+    def get_resources_limits(self, container_name: str) -> dict:
         """Return resources limits for a given container.
 
         Args:
@@ -187,7 +186,7 @@ class KubernetesHelpers:
             raise KubernetesClientError from e
 
     @retry(stop=stop_after_attempt(60), wait=wait_fixed(1), reraise=True)
-    def wait_service_ready(self, service_endpoint: Tuple[str, int]) -> None:
+    def wait_service_ready(self, service_endpoint: tuple[str, int]) -> None:
         """Wait for a service to be listening on a given endpoint.
 
         Args:

--- a/kubernetes/src/mysql_k8s_executor.py
+++ b/kubernetes/src/mysql_k8s_executor.py
@@ -5,7 +5,7 @@
 
 import json
 import re
-from typing import Generator
+from collections.abc import Generator
 
 import ops
 from mysql_shell.executors import BaseExecutor

--- a/kubernetes/src/mysql_k8s_helpers.py
+++ b/kubernetes/src/mysql_k8s_helpers.py
@@ -5,7 +5,8 @@
 """Helper class to manage the MySQL InnoDB cluster lifecycle with MySQL Shell."""
 
 import logging
-from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Tuple
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 import jinja2
 from charms.mysql.v0.mysql import (
@@ -326,16 +327,16 @@ class MySQL(MySQLBase):
     def execute_backup_commands(
         self,
         s3_path: str,
-        s3_parameters: Dict[str, str],
+        s3_parameters: dict[str, str],
         xtrabackup_location: str = CHARMED_MYSQL_XTRABACKUP_LOCATION,
         xbcloud_location: str = CHARMED_MYSQL_XBCLOUD_LOCATION,
         xtrabackup_plugin_dir: str = XTRABACKUP_PLUGIN_DIR,
         mysqld_socket_file: str = MYSQLD_SOCK_FILE,
         tmp_base_directory: str = MYSQL_DATA_DIR,
         defaults_config_file: str = MYSQLD_DEFAULTS_CONFIG_FILE,
-        user: Optional[str] = MYSQL_SYSTEM_USER,
-        group: Optional[str] = MYSQL_SYSTEM_GROUP,
-    ) -> Tuple[str, str]:
+        user: str | None = MYSQL_SYSTEM_USER,
+        group: str | None = MYSQL_SYSTEM_GROUP,
+    ) -> tuple[str, str]:
         """Executes commands to create a backup."""
         return super().execute_backup_commands(
             s3_path,
@@ -361,13 +362,13 @@ class MySQL(MySQLBase):
     def retrieve_backup_with_xbcloud(
         self,
         backup_id: str,
-        s3_parameters: Dict[str, str],
+        s3_parameters: dict[str, str],
         temp_restore_directory: str = MYSQL_DATA_DIR,
         xbcloud_location: str = CHARMED_MYSQL_XBCLOUD_LOCATION,
         xbstream_location: str = CHARMED_MYSQL_XBSTREAM_LOCATION,
         user: str = MYSQL_SYSTEM_USER,
         group: str = MYSQL_SYSTEM_GROUP,
-    ) -> Tuple[str, str, str]:
+    ) -> tuple[str, str, str]:
         """Retrieve the specified backup from S3.
 
         The backup is retrieved using xbcloud and stored in a temp dir in the
@@ -383,7 +384,7 @@ class MySQL(MySQLBase):
             group,
         )
 
-    def prepare_backup_for_restore(self, backup_location: str) -> Tuple[str, str]:
+    def prepare_backup_for_restore(self, backup_location: str) -> tuple[str, str]:
         """Prepare the backup in the provided dir for restore."""
         return super().prepare_backup_for_restore(
             backup_location,
@@ -401,7 +402,7 @@ class MySQL(MySQLBase):
             group=MYSQL_SYSTEM_GROUP,
         )
 
-    def restore_backup(self, backup_location: str) -> Tuple[str, str]:
+    def restore_backup(self, backup_location: str) -> tuple[str, str]:
         """Restore the provided prepared backup."""
         return super().restore_backup(
             backup_location,
@@ -494,14 +495,14 @@ class MySQL(MySQLBase):
 
     def _execute_commands(
         self,
-        commands: List[str],
+        commands: list[str],
         bash: bool = False,
-        user: Optional[str] = None,
-        group: Optional[str] = None,
-        env_extra: Optional[Dict] = None,
-        timeout: Optional[float] = None,
-        stream_output: Optional[str] = None,
-    ) -> Tuple[str, str]:
+        user: str | None = None,
+        group: str | None = None,
+        env_extra: dict | None = None,
+        timeout: float | None = None,
+        stream_output: str | None = None,
+    ) -> tuple[str, str]:
         """Execute commands on the server where MySQL is running."""
         try:
             if bash:
@@ -554,7 +555,7 @@ class MySQL(MySQLBase):
         """
         self.container.push(path, content, permissions=permission, user=owner, group=group)
 
-    def read_file_content(self, path: str) -> Optional[str]:
+    def read_file_content(self, path: str) -> str | None:
         """Read file content.
 
         Args:
@@ -660,7 +661,7 @@ class MySQL(MySQLBase):
         super().set_cluster_primary(new_primary_address)
         self.update_endpoints(PEER)
 
-    def fetch_error_log(self) -> Optional[str]:
+    def fetch_error_log(self) -> str | None:
         """Fetch the MySQL error log."""
         return self.read_file_content(MYSQL_LOG_ERROR)
 

--- a/kubernetes/tests/integration/helpers.py
+++ b/kubernetes/tests/integration/helpers.py
@@ -4,7 +4,6 @@
 import itertools
 import secrets
 import string
-from typing import Dict, List
 
 from mysql.connector.errors import (
     DatabaseError,
@@ -34,10 +33,10 @@ def execute_queries_on_unit(
     unit_address: str,
     username: str,
     password: str,
-    queries: List[str],
+    queries: list[str],
     commit: bool = False,
     raw: bool = False,
-) -> List:
+) -> list:
     """Execute given MySQL queries on a unit.
 
     Args:
@@ -68,7 +67,7 @@ def execute_queries_on_unit(
 
 
 @retry(stop=stop_after_attempt(8), wait=wait_fixed(15), reraise=True)
-def is_connection_possible(credentials: Dict, **extra_opts) -> bool:
+def is_connection_possible(credentials: dict, **extra_opts) -> bool:
     """Test a connection to a MySQL server.
 
     Args:

--- a/kubernetes/tests/unit/test_upgrade.py
+++ b/kubernetes/tests/unit/test_upgrade.py
@@ -179,13 +179,16 @@ class TestUpgrade(unittest.TestCase):
         self.harness.update_relation_data(
             self.upgrade_relation_id, "mysql-k8s/0", {"state": "upgrading"}
         )
-        with patch(
-            "charm.MySQLOperatorCharm.unit_initialized",
-            return_value=True,
-        ), patch(
-            "charm.MySQLOperatorCharm.cluster_initialized",
-            new_callable=PropertyMock,
-            return_value=True,
+        with (
+            patch(
+                "charm.MySQLOperatorCharm.unit_initialized",
+                return_value=True,
+            ),
+            patch(
+                "charm.MySQLOperatorCharm.cluster_initialized",
+                new_callable=PropertyMock,
+                return_value=True,
+            ),
         ):
             self.harness.container_pebble_ready("mysql")
         self.assertEqual(
@@ -199,13 +202,16 @@ class TestUpgrade(unittest.TestCase):
         # setup for exception
         mock_recover_unit_after_restart.side_effect = RetryError("dummy")
 
-        with patch(
-            "charm.MySQLOperatorCharm.unit_initialized",
-            return_value=True,
-        ), patch(
-            "charm.MySQLOperatorCharm.cluster_initialized",
-            new_callable=PropertyMock,
-            return_value=True,
+        with (
+            patch(
+                "charm.MySQLOperatorCharm.unit_initialized",
+                return_value=True,
+            ),
+            patch(
+                "charm.MySQLOperatorCharm.cluster_initialized",
+                new_callable=PropertyMock,
+                return_value=True,
+            ),
         ):
             self.harness.container_pebble_ready("mysql")
         self.assertTrue(isinstance(self.charm.unit.status, BlockedStatus))

--- a/machines/poetry.lock
+++ b/machines/poetry.lock
@@ -2039,5 +2039,5 @@ type = ["pytest-mypy"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = "~=3.10"
-content-hash = "a4b785c176248ea7e5771171cf8842c3e4a88a00710aa32255c0c06d10e67b44"
+python-versions = "^3.10"
+content-hash = "fd1d73b9ae588606a3d067549d868fedc4338f301c3ff825ee15a551805f651b"

--- a/machines/pyproject.toml
+++ b/machines/pyproject.toml
@@ -1,9 +1,8 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-[project]
-name = "mysql-operator"  # Charm is not meant to be packaged
-dependencies = [
+[dependency-groups]
+main = [
     "boto3~=1.28",
     "jinja2~=3.1",
     "ops[tracing]~=2.21",
@@ -12,9 +11,6 @@ dependencies = [
     "tenacity~=8.2",
     "typing_extensions~=4.7",
 ]
-requires-python = "~=3.10"
-
-[dependency-groups]
 charm-libs = [
     # data_platform_libs/v0/data_interfaces.py
     "ops>=2.0.0",
@@ -62,6 +58,9 @@ integration = [
 [tool.poetry]
 package-mode = false
 requires-poetry = ">=2.2.0"
+
+[tool.poetry.dependencies]
+python = "^3.10"
 
 [tool.poetry.group.format]
 optional = true

--- a/machines/pyproject.toml
+++ b/machines/pyproject.toml
@@ -78,7 +78,7 @@ show_missing = true
 minversion = "6.0"
 log_cli_level = "INFO"
 
-# Formatting tools configuration
+# Linting tools configuration
 [tool.ruff]
 # preview and explicit preview are enabled for CPY001
 preview = true
@@ -88,7 +88,23 @@ line-length = 99
 
 [tool.ruff.lint]
 explicit-preview-rules = true
-select = ["A", "E", "W", "F", "C", "N", "D", "I", "B", "CPY001", "RUF", "S", "SIM", "UP", "TC"]
+select = [
+  "A",
+  "E",
+  "W",
+  "F",
+  "C",
+  "N",
+  "D",
+  "I",
+  "B",
+  "CPY001",
+  "RUF",
+  "S",
+  "SIM",
+  "UP",
+  "TC",
+]
 ignore = [
   "D107", # Ignore D107 Missing docstring in __init__
   "E501", # Ignore E501 Line too long
@@ -96,11 +112,12 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = [
-    "D1", "D417",
-    # Asserts
-    "B011",
-    # Disable security checks for tests
-    "S",
+  "D1",
+  "D417",
+  # Asserts
+  "B011",
+  # Disable security checks for tests
+  "S",
 ]
 
 [tool.ruff.lint.flake8-copyright]


### PR DESCRIPTION
## Issue

1. https://github.com/canonical/mysql-k8s-operator/pull/680 and https://github.com/canonical/mysql-operator/pull/717 introduced packaging standards (good) but turns out PEP 621 `[project]` table was a mistake, since we don't intend to package the project as a library and we had to introduce a fake name. Other tools were requesting a mandatory version too, so I moved those dependencies to a dependency group and everything continues to work.
2. The `kubernetes/` substrate was being linted with Python 3.8, so I unified the linting configuration of both substrates, which resulted in some modernization of typing specs.

## Solution

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
