### PR TITLE
[MISC] 8.0 - Bump mysql-shell-client to >=0.7.1

### DIFF
--- a/kubernetes/lib/charms/mysql/v0/async_replication.py
+++ b/kubernetes/lib/charms/mysql/v0/async_replication.py
@@ -59,7 +59,7 @@ LIBID = "4de21f1a022c4e2c87ac8e672ec16f6a"
 LIBAPI = 0
 LIBPATCH = 12
 
-PYDEPS = ["mysql_shell_client ~= 0.6"]
+PYDEPS = ["mysql_shell_client ~= 0.7"]
 
 RELATION_OFFER = "replication-offer"
 RELATION_CONSUMER = "replication"

--- a/kubernetes/lib/charms/mysql/v0/backups.py
+++ b/kubernetes/lib/charms/mysql/v0/backups.py
@@ -107,9 +107,9 @@ S3_INTEGRATOR_RELATION_NAME = "s3-parameters"
 # The unique Charmhub library identifier, never change it
 LIBID = "183844304be247129572309a5fb1e47c"
 LIBAPI = 0
-LIBPATCH = 19
+LIBPATCH = 20
 
-PYDEPS = ["mysql_shell_client ~= 0.6"]
+PYDEPS = ["mysql_shell_client ~= 0.7"]
 
 ANOTHER_S3_CLUSTER_REPOSITORY_ERROR_MESSAGE = "S3 repository claimed by another cluster"
 MOVE_RESTORED_CLUSTER_TO_ANOTHER_S3_REPOSITORY_ERROR = (

--- a/kubernetes/lib/charms/mysql/v0/mysql.py
+++ b/kubernetes/lib/charms/mysql/v0/mysql.py
@@ -136,9 +136,9 @@ LIBID = "8c1428f06b1b4ec8bf98b7d980a38a8c"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
-LIBPATCH = 101
+LIBPATCH = 102
 
-PYDEPS = ["mysql_shell_client ~= 0.6"]
+PYDEPS = ["mysql_shell_client ~= 0.7"]
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"
@@ -1426,23 +1426,28 @@ class MySQLBase(ABC):
 
         primary_address = self.get_cluster_primary_address()
         primary_executor = self._build_instance_tcp_executor(primary_address)
-
-        role_name = self._build_mysql_database_dba_role(database)
-        role_query = self._auth_query_builder.build_database_admin_role_query(role_name, database)
-
-        queries = ";".join([
-            f"CREATE DATABASE `{database}`",
-            f"GRANT SELECT ON `{database}`.* TO '{ROLE_READ}'",
-            f"GRANT SELECT, INSERT, DELETE, UPDATE ON `{database}`.* TO '{ROLE_DML}'",
-            role_query,
-        ])
+        primary_client = MySQLInstanceClient(primary_executor, self._quoter)
 
         try:
-            logger.info(f"Creating application {database=} and DBA {role_name=}")
-            primary_executor.execute_sql(queries)
+            logger.info(f"Creating application {database=}")
+            primary_client.create_instance_database(database)
         except ExecutionError as e:
             logger.error(f"Failed to create application database {database}")
             raise MySQLCreateApplicationDatabaseError() from e
+
+        role_name = self._build_mysql_database_dba_role(database)
+
+        queries = ";".join([
+            self._auth_query_builder.build_instance_reader_role_update_query(database),
+            self._auth_query_builder.build_instance_writer_role_update_query(database),
+            self._auth_query_builder.build_database_admin_role_query(role_name, database),
+        ])
+
+        try:
+            logger.info(f"Creating application DBA {role_name=}")
+            primary_executor.execute_sql(queries)
+        except ExecutionError:
+            logger.warning(f"Failed to create application DBA {role_name}")
 
     def create_scoped_user(
         self,

--- a/kubernetes/lib/charms/mysql/v0/tls.py
+++ b/kubernetes/lib/charms/mysql/v0/tls.py
@@ -50,9 +50,9 @@ logger = logging.getLogger(__name__)
 
 LIBID = "eb73947deedd4380a3a90d527e0878eb"
 LIBAPI = 0
-LIBPATCH = 11
+LIBPATCH = 12
 
-PYDEPS = ["mysql_shell_client ~= 0.6"]
+PYDEPS = ["mysql_shell_client ~= 0.7"]
 
 SCOPE = "unit"
 

--- a/kubernetes/poetry.lock
+++ b/kubernetes/poetry.lock
@@ -1024,14 +1024,14 @@ telemetry = ["opentelemetry-api (==1.18.0)", "opentelemetry-exporter-otlp-proto-
 
 [[package]]
 name = "mysql-shell-client"
-version = "0.6.1"
+version = "0.7.1"
 description = "Python client for MySQL Shell"
 optional = false
 python-versions = ">=3.10"
 groups = ["charm-libs"]
 files = [
-    {file = "mysql_shell_client-0.6.1-py3-none-any.whl", hash = "sha256:364bfddb6003aeaf4599057f29d0e2d76f4463e998adf397c7ca1918f97485b2"},
-    {file = "mysql_shell_client-0.6.1.tar.gz", hash = "sha256:4d67003aaf049c3003b931b95bd1f6ceb3fa129f252d4f7c6c41646869404dff"},
+    {file = "mysql_shell_client-0.7.1-py3-none-any.whl", hash = "sha256:0223fde0ad97a132d1ad0c4ba91cb15c1ef1041272c2b74d764a5441f3092562"},
+    {file = "mysql_shell_client-0.7.1.tar.gz", hash = "sha256:e5595cd6ec76b2c0d887dccc32c4feb18031afd7f22b5b7222596308052efa44"},
 ]
 
 [package.extras]

--- a/kubernetes/pyproject.toml
+++ b/kubernetes/pyproject.toml
@@ -20,7 +20,7 @@ charm-libs = [
     # tempo_coordinator_k8s/v0/charm_tracing.py requires pydantic
     "pydantic~=1.10",
     # mysql/v0/*.py"
-    "mysql_shell_client~=0.6",
+    "mysql_shell_client~=0.7",
     # tls_certificates_interface/v1/tls_certificates.py
     # tls_certificates lib uses a feature only available in cryptography >=42.0.5
     "cryptography>=42.0.5",

--- a/machines/lib/charms/mysql/v0/async_replication.py
+++ b/machines/lib/charms/mysql/v0/async_replication.py
@@ -57,9 +57,9 @@ logger = logging.getLogger(__name__)
 # The unique Charmhub library identifier, never change it
 LIBID = "4de21f1a022c4e2c87ac8e672ec16f6a"
 LIBAPI = 0
-LIBPATCH = 12
+LIBPATCH = 13
 
-PYDEPS = ["mysql_shell_client ~= 0.6"]
+PYDEPS = ["mysql_shell_client ~= 0.7"]
 
 RELATION_OFFER = "replication-offer"
 RELATION_CONSUMER = "replication"

--- a/machines/lib/charms/mysql/v0/backups.py
+++ b/machines/lib/charms/mysql/v0/backups.py
@@ -107,9 +107,9 @@ S3_INTEGRATOR_RELATION_NAME = "s3-parameters"
 # The unique Charmhub library identifier, never change it
 LIBID = "183844304be247129572309a5fb1e47c"
 LIBAPI = 0
-LIBPATCH = 19
+LIBPATCH = 20
 
-PYDEPS = ["mysql_shell_client ~= 0.6"]
+PYDEPS = ["mysql_shell_client ~= 0.7"]
 
 ANOTHER_S3_CLUSTER_REPOSITORY_ERROR_MESSAGE = "S3 repository claimed by another cluster"
 MOVE_RESTORED_CLUSTER_TO_ANOTHER_S3_REPOSITORY_ERROR = (

--- a/machines/lib/charms/mysql/v0/mysql.py
+++ b/machines/lib/charms/mysql/v0/mysql.py
@@ -136,9 +136,9 @@ LIBID = "8c1428f06b1b4ec8bf98b7d980a38a8c"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
-LIBPATCH = 101
+LIBPATCH = 102
 
-PYDEPS = ["mysql_shell_client ~= 0.6"]
+PYDEPS = ["mysql_shell_client ~= 0.7"]
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"
@@ -1426,23 +1426,28 @@ class MySQLBase(ABC):
 
         primary_address = self.get_cluster_primary_address()
         primary_executor = self._build_instance_tcp_executor(primary_address)
-
-        role_name = self._build_mysql_database_dba_role(database)
-        role_query = self._auth_query_builder.build_database_admin_role_query(role_name, database)
-
-        queries = ";".join([
-            f"CREATE DATABASE `{database}`",
-            f"GRANT SELECT ON `{database}`.* TO '{ROLE_READ}'",
-            f"GRANT SELECT, INSERT, DELETE, UPDATE ON `{database}`.* TO '{ROLE_DML}'",
-            role_query,
-        ])
+        primary_client = MySQLInstanceClient(primary_executor, self._quoter)
 
         try:
-            logger.info(f"Creating application {database=} and DBA {role_name=}")
-            primary_executor.execute_sql(queries)
+            logger.info(f"Creating application {database=}")
+            primary_client.create_instance_database(database)
         except ExecutionError as e:
             logger.error(f"Failed to create application database {database}")
             raise MySQLCreateApplicationDatabaseError() from e
+
+        role_name = self._build_mysql_database_dba_role(database)
+
+        queries = ";".join([
+            self._auth_query_builder.build_instance_reader_role_update_query(database),
+            self._auth_query_builder.build_instance_writer_role_update_query(database),
+            self._auth_query_builder.build_database_admin_role_query(role_name, database),
+        ])
+
+        try:
+            logger.info(f"Creating application DBA {role_name=}")
+            primary_executor.execute_sql(queries)
+        except ExecutionError:
+            logger.warning(f"Failed to create application DBA {role_name}")
 
     def create_scoped_user(
         self,

--- a/machines/lib/charms/mysql/v0/tls.py
+++ b/machines/lib/charms/mysql/v0/tls.py
@@ -50,9 +50,9 @@ logger = logging.getLogger(__name__)
 
 LIBID = "eb73947deedd4380a3a90d527e0878eb"
 LIBAPI = 0
-LIBPATCH = 11
+LIBPATCH = 12
 
-PYDEPS = ["mysql_shell_client ~= 0.6"]
+PYDEPS = ["mysql_shell_client ~= 0.7"]
 
 SCOPE = "unit"
 

--- a/machines/poetry.lock
+++ b/machines/poetry.lock
@@ -1030,14 +1030,14 @@ telemetry = ["opentelemetry-api (==1.18.0)", "opentelemetry-exporter-otlp-proto-
 
 [[package]]
 name = "mysql-shell-client"
-version = "0.6.1"
+version = "0.7.1"
 description = "Python client for MySQL Shell"
 optional = false
 python-versions = ">=3.10"
 groups = ["charm-libs"]
 files = [
-    {file = "mysql_shell_client-0.6.1-py3-none-any.whl", hash = "sha256:364bfddb6003aeaf4599057f29d0e2d76f4463e998adf397c7ca1918f97485b2"},
-    {file = "mysql_shell_client-0.6.1.tar.gz", hash = "sha256:4d67003aaf049c3003b931b95bd1f6ceb3fa129f252d4f7c6c41646869404dff"},
+    {file = "mysql_shell_client-0.7.1-py3-none-any.whl", hash = "sha256:0223fde0ad97a132d1ad0c4ba91cb15c1ef1041272c2b74d764a5441f3092562"},
+    {file = "mysql_shell_client-0.7.1.tar.gz", hash = "sha256:e5595cd6ec76b2c0d887dccc32c4feb18031afd7f22b5b7222596308052efa44"},
 ]
 
 [package.extras]

--- a/machines/pyproject.toml
+++ b/machines/pyproject.toml
@@ -23,7 +23,7 @@ charm-libs = [
     # grafana_agent/v0/cos_agent.py
     "cosl>=0.0.50",
     # mysql/v0/*.py"
-    "mysql_shell_client~=0.6",
+    "mysql_shell_client~=0.7",
     # tls_certificates_interface/v2/tls_certificates.py
     "cryptography>=42.0.5",
     "jsonschema",

--- a/machines/tests/unit/test_mysql.py
+++ b/machines/tests/unit/test_mysql.py
@@ -303,16 +303,19 @@ class TestMySQLBase(unittest.TestCase):
         self.mock_executor.execute_sql.assert_not_called()
 
         _get_non_system_databases.return_value = set()
-        query = ";".join([
-            "CREATE DATABASE `test_database`",
-            "GRANT SELECT ON `test_database`.* TO 'charmed_read'",
-            "GRANT SELECT, INSERT, DELETE, UPDATE ON `test_database`.* TO 'charmed_dml'",
-            "CREATE ROLE 'test_database_00'",
-            "GRANT SELECT, INSERT, DELETE, UPDATE, EXECUTE, ALTER, ALTER ROUTINE, CREATE, CREATE ROUTINE, CREATE VIEW, DROP, INDEX, LOCK TABLES, REFERENCES, TRIGGER ON `test_database`.* TO 'test_database_00'",
+        creation_query = "CREATE DATABASE `test_database`"
+        granting_query = ";".join([
+            "GRANT SELECT ON `test_database`.* TO `charmed_read`",
+            "GRANT SELECT, INSERT, DELETE, UPDATE ON `test_database`.* TO `charmed_dml`",
+            "CREATE ROLE `test_database_00`",
+            "GRANT SELECT, INSERT, DELETE, UPDATE, EXECUTE, ALTER, ALTER ROUTINE, CREATE, CREATE ROUTINE, CREATE VIEW, DROP, INDEX, LOCK TABLES, REFERENCES, TRIGGER ON `test_database`.* TO `test_database_00`",
         ])
 
         self.mysql.create_database("test_database")
-        self.mock_executor.execute_sql.assert_called_once_with(query)
+        self.mock_executor.execute_sql.assert_has_calls([
+            call(creation_query),
+            call(granting_query),
+        ])
 
     @patch("charms.mysql.v0.mysql.MySQLBase.get_cluster_primary_address")
     @patch("charms.mysql.v0.mysql.MySQLBase.get_non_system_databases")
@@ -335,7 +338,7 @@ class TestMySQLBase(unittest.TestCase):
     def test_create_application_scoped_user(self, _get_cluster_primary_address):
         """Test the successful execution of create_application_scoped_user."""
         create_commands = ";".join((
-            "CREATE USER 'test_username'@'1.1.1.1' IDENTIFIED BY 'test_password' ATTRIBUTE '{\\\"unit_name\\\": \\\"app/0\\\"}'",
+            "CREATE USER `test_username`@`1.1.1.1` IDENTIFIED BY 'test_password' ATTRIBUTE '{\\\"unit_name\\\": \\\"app/0\\\"}'",
             "",
         ))
         grant_commands = ";".join((
@@ -857,7 +860,7 @@ class TestMySQLBase(unittest.TestCase):
     @patch("charms.mysql.v0.mysql.MySQLBase.get_cluster_primary_address")
     def test_delete_user(self, _get_cluster_primary_address):
         """Test delete_user() method."""
-        query = "DROP USER IF EXISTS 'testuser'@'%'"
+        query = "DROP USER IF EXISTS `testuser`@`%`"
 
         self.mysql.delete_user("testuser")
         self.mock_executor.execute_sql.assert_called_once_with(query)
@@ -904,7 +907,7 @@ class TestMySQLBase(unittest.TestCase):
         """Test the successful execution of update_user_password."""
         _get_cluster_global_primary_address.return_value = "1.1.1.1"
 
-        query = "ALTER USER 'test_user'@'%' IDENTIFIED BY 'test_password'"
+        query = "ALTER USER `test_user`@`%` IDENTIFIED BY 'test_password'"
 
         self.mysql.update_user_password("test_user", "test_password")
         self.mock_executor.execute_sql.assert_called_once_with(query)


### PR DESCRIPTION
This PR bumps the version of the `mysql-shell-client` to be >= 0.7, but specifies version 0.7.1 in the poetry lock file. This specific patch version introduces a fix on how the instance replication-members are searched.

---

Depends on PR https://github.com/canonical/mysql-shell-client/pull/34.
