### PR TITLE
[MISC] 8.4 - Bump mysql-shell-client to >=0.7.1

### DIFF
--- a/kubernetes/lib/charms/mysql/v0/async_replication.py
+++ b/kubernetes/lib/charms/mysql/v0/async_replication.py
@@ -59,7 +59,7 @@ LIBID = "4de21f1a022c4e2c87ac8e672ec16f6a"
 LIBAPI = 0
 LIBPATCH = 12
 
-PYDEPS = ["mysql_shell_client ~= 0.6"]
+PYDEPS = ["mysql_shell_client ~= 0.7"]
 
 RELATION_OFFER = "replication-offer"
 RELATION_CONSUMER = "replication"

--- a/kubernetes/lib/charms/mysql/v0/backups.py
+++ b/kubernetes/lib/charms/mysql/v0/backups.py
@@ -109,7 +109,7 @@ LIBID = "183844304be247129572309a5fb1e47c"
 LIBAPI = 0
 LIBPATCH = 19
 
-PYDEPS = ["mysql_shell_client ~= 0.6"]
+PYDEPS = ["mysql_shell_client ~= 0.7"]
 
 ANOTHER_S3_CLUSTER_REPOSITORY_ERROR_MESSAGE = "S3 repository claimed by another cluster"
 MOVE_RESTORED_CLUSTER_TO_ANOTHER_S3_REPOSITORY_ERROR = (

--- a/kubernetes/lib/charms/mysql/v0/mysql.py
+++ b/kubernetes/lib/charms/mysql/v0/mysql.py
@@ -138,7 +138,7 @@ LIBID = "8c1428f06b1b4ec8bf98b7d980a38a8c"
 LIBAPI = 0
 LIBPATCH = 102
 
-PYDEPS = ["mysql_shell_client ~= 0.6"]
+PYDEPS = ["mysql_shell_client ~= 0.7"]
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"
@@ -1445,23 +1445,28 @@ class MySQLBase(ABC):
 
         primary_address = self.get_cluster_primary_address()
         primary_executor = self._build_instance_tcp_executor(primary_address)
-
-        role_name = self._build_mysql_database_dba_role(database)
-        role_query = self._auth_query_builder.build_database_admin_role_query(role_name, database)
-
-        queries = ";".join([
-            f"CREATE DATABASE `{database}`",
-            f"GRANT SELECT ON `{database}`.* TO '{ROLE_READ}'",
-            f"GRANT SELECT, INSERT, DELETE, UPDATE ON `{database}`.* TO '{ROLE_DML}'",
-            role_query,
-        ])
+        primary_client = MySQLInstanceClient(primary_executor, self._quoter)
 
         try:
-            logger.info(f"Creating application {database=} and DBA {role_name=}")
-            primary_executor.execute_sql(queries)
+            logger.info(f"Creating application {database=}")
+            primary_client.create_instance_database(database)
         except ExecutionError as e:
             logger.error(f"Failed to create application database {database}")
             raise MySQLCreateApplicationDatabaseError() from e
+
+        role_name = self._build_mysql_database_dba_role(database)
+
+        queries = ";".join([
+            self._auth_query_builder.build_instance_reader_role_update_query(database),
+            self._auth_query_builder.build_instance_writer_role_update_query(database),
+            self._auth_query_builder.build_database_admin_role_query(role_name, database),
+        ])
+
+        try:
+            logger.info(f"Creating application DBA {role_name=}")
+            primary_executor.execute_sql(queries)
+        except ExecutionError:
+            logger.warning(f"Failed to create application DBA {role_name}")
 
     def create_scoped_user(
         self,

--- a/kubernetes/lib/charms/mysql/v0/tls.py
+++ b/kubernetes/lib/charms/mysql/v0/tls.py
@@ -52,7 +52,7 @@ LIBID = "eb73947deedd4380a3a90d527e0878eb"
 LIBAPI = 0
 LIBPATCH = 12
 
-PYDEPS = ["mysql_shell_client ~= 0.6"]
+PYDEPS = ["mysql_shell_client ~= 0.7"]
 
 SCOPE = "unit"
 

--- a/kubernetes/poetry.lock
+++ b/kubernetes/poetry.lock
@@ -1024,14 +1024,14 @@ telemetry = ["opentelemetry-api (==1.18.0)", "opentelemetry-exporter-otlp-proto-
 
 [[package]]
 name = "mysql-shell-client"
-version = "0.7.0"
+version = "0.7.1"
 description = "Python client for MySQL Shell"
 optional = false
 python-versions = ">=3.10"
 groups = ["charm-libs"]
 files = [
-    {file = "mysql_shell_client-0.7.0-py3-none-any.whl", hash = "sha256:6f11ce5ab275262baf2d37f93e40f153fd25e1bd7874a2b0569bcfe60474480d"},
-    {file = "mysql_shell_client-0.7.0.tar.gz", hash = "sha256:44fc10503236f93383557ee4eb8c559293a9b4f713a991fa8ecac72b8f17f008"},
+    {file = "mysql_shell_client-0.7.1-py3-none-any.whl", hash = "sha256:0223fde0ad97a132d1ad0c4ba91cb15c1ef1041272c2b74d764a5441f3092562"},
+    {file = "mysql_shell_client-0.7.1.tar.gz", hash = "sha256:e5595cd6ec76b2c0d887dccc32c4feb18031afd7f22b5b7222596308052efa44"},
 ]
 
 [package.extras]

--- a/machines/lib/charms/mysql/v0/async_replication.py
+++ b/machines/lib/charms/mysql/v0/async_replication.py
@@ -59,7 +59,7 @@ LIBID = "4de21f1a022c4e2c87ac8e672ec16f6a"
 LIBAPI = 0
 LIBPATCH = 12
 
-PYDEPS = ["mysql_shell_client ~= 0.6"]
+PYDEPS = ["mysql_shell_client ~= 0.7"]
 
 RELATION_OFFER = "replication-offer"
 RELATION_CONSUMER = "replication"

--- a/machines/lib/charms/mysql/v0/backups.py
+++ b/machines/lib/charms/mysql/v0/backups.py
@@ -109,7 +109,7 @@ LIBID = "183844304be247129572309a5fb1e47c"
 LIBAPI = 0
 LIBPATCH = 19
 
-PYDEPS = ["mysql_shell_client ~= 0.6"]
+PYDEPS = ["mysql_shell_client ~= 0.7"]
 
 ANOTHER_S3_CLUSTER_REPOSITORY_ERROR_MESSAGE = "S3 repository claimed by another cluster"
 MOVE_RESTORED_CLUSTER_TO_ANOTHER_S3_REPOSITORY_ERROR = (

--- a/machines/lib/charms/mysql/v0/mysql.py
+++ b/machines/lib/charms/mysql/v0/mysql.py
@@ -138,7 +138,7 @@ LIBID = "8c1428f06b1b4ec8bf98b7d980a38a8c"
 LIBAPI = 0
 LIBPATCH = 102
 
-PYDEPS = ["mysql_shell_client ~= 0.6"]
+PYDEPS = ["mysql_shell_client ~= 0.7"]
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"
@@ -1445,23 +1445,28 @@ class MySQLBase(ABC):
 
         primary_address = self.get_cluster_primary_address()
         primary_executor = self._build_instance_tcp_executor(primary_address)
-
-        role_name = self._build_mysql_database_dba_role(database)
-        role_query = self._auth_query_builder.build_database_admin_role_query(role_name, database)
-
-        queries = ";".join([
-            f"CREATE DATABASE `{database}`",
-            f"GRANT SELECT ON `{database}`.* TO '{ROLE_READ}'",
-            f"GRANT SELECT, INSERT, DELETE, UPDATE ON `{database}`.* TO '{ROLE_DML}'",
-            role_query,
-        ])
+        primary_client = MySQLInstanceClient(primary_executor, self._quoter)
 
         try:
-            logger.info(f"Creating application {database=} and DBA {role_name=}")
-            primary_executor.execute_sql(queries)
+            logger.info(f"Creating application {database=}")
+            primary_client.create_instance_database(database)
         except ExecutionError as e:
             logger.error(f"Failed to create application database {database}")
             raise MySQLCreateApplicationDatabaseError() from e
+
+        role_name = self._build_mysql_database_dba_role(database)
+
+        queries = ";".join([
+            self._auth_query_builder.build_instance_reader_role_update_query(database),
+            self._auth_query_builder.build_instance_writer_role_update_query(database),
+            self._auth_query_builder.build_database_admin_role_query(role_name, database),
+        ])
+
+        try:
+            logger.info(f"Creating application DBA {role_name=}")
+            primary_executor.execute_sql(queries)
+        except ExecutionError:
+            logger.warning(f"Failed to create application DBA {role_name}")
 
     def create_scoped_user(
         self,

--- a/machines/lib/charms/mysql/v0/tls.py
+++ b/machines/lib/charms/mysql/v0/tls.py
@@ -51,7 +51,7 @@ LIBID = "eb73947deedd4380a3a90d527e0878eb"
 LIBAPI = 0
 LIBPATCH = 12
 
-PYDEPS = ["mysql_shell_client ~= 0.6"]
+PYDEPS = ["mysql_shell_client ~= 0.7"]
 
 SCOPE = "unit"
 

--- a/machines/poetry.lock
+++ b/machines/poetry.lock
@@ -1034,14 +1034,14 @@ telemetry = ["opentelemetry-api (==1.18.0)", "opentelemetry-exporter-otlp-proto-
 
 [[package]]
 name = "mysql-shell-client"
-version = "0.7.0"
+version = "0.7.1"
 description = "Python client for MySQL Shell"
 optional = false
 python-versions = ">=3.10"
 groups = ["charm-libs"]
 files = [
-    {file = "mysql_shell_client-0.7.0-py3-none-any.whl", hash = "sha256:6f11ce5ab275262baf2d37f93e40f153fd25e1bd7874a2b0569bcfe60474480d"},
-    {file = "mysql_shell_client-0.7.0.tar.gz", hash = "sha256:44fc10503236f93383557ee4eb8c559293a9b4f713a991fa8ecac72b8f17f008"},
+    {file = "mysql_shell_client-0.7.1-py3-none-any.whl", hash = "sha256:0223fde0ad97a132d1ad0c4ba91cb15c1ef1041272c2b74d764a5441f3092562"},
+    {file = "mysql_shell_client-0.7.1.tar.gz", hash = "sha256:e5595cd6ec76b2c0d887dccc32c4feb18031afd7f22b5b7222596308052efa44"},
 ]
 
 [package.extras]

--- a/machines/tests/unit/test_mysql.py
+++ b/machines/tests/unit/test_mysql.py
@@ -271,16 +271,19 @@ class TestMySQLBase(unittest.TestCase):
         self.mock_executor.execute_sql.assert_not_called()
 
         _get_non_system_databases.return_value = set()
-        query = ";".join([
-            "CREATE DATABASE `test_database`",
-            "GRANT SELECT ON `test_database`.* TO 'charmed_read'",
-            "GRANT SELECT, INSERT, DELETE, UPDATE ON `test_database`.* TO 'charmed_dml'",
+        creation_query = "CREATE DATABASE `test_database`"
+        granting_query = ";".join([
+            "GRANT SELECT ON `test_database`.* TO `charmed_read`",
+            "GRANT SELECT, INSERT, DELETE, UPDATE ON `test_database`.* TO `charmed_dml`",
             "CREATE ROLE `test_database_00`",
             "GRANT SELECT, INSERT, DELETE, UPDATE, EXECUTE, ALTER, ALTER ROUTINE, CREATE, CREATE ROUTINE, CREATE VIEW, DROP, INDEX, LOCK TABLES, REFERENCES, TRIGGER ON `test_database`.* TO `test_database_00`",
         ])
 
         self.mysql.create_database("test_database")
-        self.mock_executor.execute_sql.assert_called_once_with(query)
+        self.mock_executor.execute_sql.assert_has_calls([
+            call(creation_query),
+            call(granting_query),
+        ])
 
     @patch("charms.mysql.v0.mysql.MySQLBase.get_cluster_primary_address")
     @patch("charms.mysql.v0.mysql.MySQLBase.get_non_system_databases")


### PR DESCRIPTION
This PR bumps the version of the `mysql-shell-client` to be >= 0.7, but specifies version 0.7.1 in the poetry lock file. This specific patch version introduces a fix on how the instance replication-members are searched.

---

Depends on PR https://github.com/canonical/mysql-shell-client/pull/34.
