### PR TITLE
[MISC] Fix packaging again

### DIFF
--- a/kubernetes/poetry.lock
+++ b/kubernetes/poetry.lock
@@ -679,7 +679,7 @@ version = "6.11.0"
 description = "Read metadata from Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "charm-libs"]
+groups = ["main", "charm-libs", "integration"]
 files = [
     {file = "importlib_metadata-6.11.0-py3-none-any.whl", hash = "sha256:f0afba6205ad8f8947c7d338b5342d5db2afbfd82f9cbef7879a9539cc12eb9b"},
     {file = "importlib_metadata-6.11.0.tar.gz", hash = "sha256:1231cf92d825c9e03cfc4da076a16de6422c863558229ea0b22b675657463443"},
@@ -1062,7 +1062,7 @@ version = "1.39.1"
 description = "OpenTelemetry Python API"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "charm-libs"]
+groups = ["main", "charm-libs", "integration"]
 files = [
     {file = "opentelemetry_api-1.39.1-py3-none-any.whl", hash = "sha256:2edd8463432a7f8443edce90972169b195e7d6a05500cd29e6d13898187c9950"},
     {file = "opentelemetry_api-1.39.1.tar.gz", hash = "sha256:fbde8c80e1b937a2c61f20347e91c0c18a1940cecf012d62e65a7caf08967c9c"},
@@ -1111,7 +1111,7 @@ version = "2.23.1"
 description = "The Python library behind great charms"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "charm-libs"]
+groups = ["main", "charm-libs", "integration"]
 files = [
     {file = "ops-2.23.1-py3-none-any.whl", hash = "sha256:fdf58163beafd25180c12a4c7efaf1e76e5f8710508a97840c07055bb78b0c77"},
     {file = "ops-2.23.1.tar.gz", hash = "sha256:aecacd67ef7ca913f63f397e0330bfa93d70529a3ef71ed2d99e2bc232564ae3"},
@@ -1995,7 +1995,7 @@ version = "3.19.2"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "charm-libs"]
+groups = ["main", "charm-libs", "integration"]
 files = [
     {file = "zipp-3.19.2-py3-none-any.whl", hash = "sha256:f091755f667055f2d02b32c53771a7a6c8b47e1fdbc4b72a8b9072b3eef8015c"},
     {file = "zipp-3.19.2.tar.gz", hash = "sha256:bf1dcf6450f873a13e952a29504887c89e6de7506209e5b1bcc3460135d4de19"},

--- a/kubernetes/pyproject.toml
+++ b/kubernetes/pyproject.toml
@@ -46,6 +46,7 @@ integration = [
     "pytest~=7.4",
     "jinja2~=3.1",
     "juju~=3.6",
+    "ops~=2.15",
     "mysql-connector-python~=9.1.0",
     "tenacity~=8.2",
     "boto3~=1.28",


### PR DESCRIPTION
## Issue

🤦🏼🤦🏼🤦🏼🤦🏼 

https://github.com/canonical/mysql-operators/pull/76 accidentally removed `ops` from the `integration` dependency group on the `8.0/edge` branch, possibly because of a copy paste or cherry-pick error from the `8.4/edge` branch. This wasn't noticed during review. Because the `s390x` build didn't succeed the integration tests didn't run, but I went ahead and merged the PR regardless, oblivious to the problem. @sinclert-canonical uncovered the issue while working on #80.

## Solution

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
