### PR TITLE
[MISC] integration test fixes

### DIFF
--- a/kubernetes/tests/integration/helpers_ha.py
+++ b/kubernetes/tests/integration/helpers_ha.py
@@ -267,11 +267,13 @@ def scale_app_units(juju: Juju, app_name: str, num_units: int) -> None:
     juju.wait(
         ready=lambda status: len(status.apps[app_name].units) == num_units,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, app_name),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 

--- a/kubernetes/tests/integration/integration/helpers_backups.py
+++ b/kubernetes/tests/integration/integration/helpers_backups.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 
 import logging
+from time import sleep
 
 import boto3
 import jubilant_backports
@@ -82,6 +83,10 @@ def build_and_deploy_operations(
         resources={"mysql-image": CHARM_METADATA["resources"]["mysql-image"]["upstream-source"]},
         trust=True,
     )
+
+    # Allow some time between deploy and status call. Avoids:
+    # ERROR getting details for storage database/0: filesystem for storage instance "database/0" not found
+    sleep(30)
 
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, MYSQL_APPLICATION_NAME),

--- a/kubernetes/tests/integration/integration/helpers_backups.py
+++ b/kubernetes/tests/integration/integration/helpers_backups.py
@@ -91,6 +91,7 @@ def build_and_deploy_operations(
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, MYSQL_APPLICATION_NAME),
         timeout=15 * MINUTE_SECS,
+        delay=2,
     )
 
     logger.info("Rotating mysql credentials")
@@ -108,6 +109,7 @@ def build_and_deploy_operations(
             ),
         )),
         timeout=TIMEOUT,
+        delay=2,
     )
     juju.config(S3_INTEGRATOR, cloud_configs)
     s3_unit_name = get_app_units(juju, S3_INTEGRATOR)[0]
@@ -121,6 +123,7 @@ def build_and_deploy_operations(
             jubilant_backports.all_active, MYSQL_APPLICATION_NAME, S3_INTEGRATOR
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
     juju.integrate(MYSQL_APPLICATION_NAME, S3_INTEGRATOR)
     juju.wait(
@@ -128,6 +131,7 @@ def build_and_deploy_operations(
             jubilant_backports.all_active, MYSQL_APPLICATION_NAME, S3_INTEGRATOR
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
 
@@ -223,6 +227,7 @@ def pitr_operations(
             jubilant_backports.all_agents_idle(status, MYSQL_APPLICATION_NAME, S3_INTEGRATOR),
         )),
         timeout=TIMEOUT,
+        delay=2,
     )
     assert check_test_data_existence(first_mysql_ip, should_not_exist=[td1, td2]), (
         "test data should not exist"
@@ -239,6 +244,7 @@ def pitr_operations(
             jubilant_backports.all_agents_idle(status, MYSQL_APPLICATION_NAME, S3_INTEGRATOR),
         )),
         timeout=TIMEOUT,
+        delay=2,
     )
     assert check_test_data_existence(first_mysql_ip, should_exist=[td1, td2]), (
         "both test data should exist"
@@ -255,6 +261,7 @@ def pitr_operations(
             jubilant_backports.all_agents_idle(status, MYSQL_APPLICATION_NAME, S3_INTEGRATOR),
         )),
         timeout=TIMEOUT,
+        delay=2,
     )
     assert check_test_data_existence(first_mysql_ip, should_exist=[td1], should_not_exist=[td2]), (
         "only first test data should exist"
@@ -271,6 +278,7 @@ def pitr_operations(
             jubilant_backports.all_agents_idle(status, MYSQL_APPLICATION_NAME, S3_INTEGRATOR),
         )),
         timeout=TIMEOUT,
+        delay=2,
     )
     assert check_test_data_existence(first_mysql_ip, should_exist=[td1, td2]), (
         "both test data should exist"

--- a/kubernetes/tests/integration/integration/high_availability/test_async_replication.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_async_replication.py
@@ -86,6 +86,7 @@ def test_build_and_deploy(first_model: str, second_model: str, charm: str) -> No
         constraints=constraints,
         resources=resources,
         num_units=3,
+        trust=True,
     )
     model_2 = Juju(model=second_model)
     model_2.deploy(
@@ -96,6 +97,7 @@ def test_build_and_deploy(first_model: str, second_model: str, charm: str) -> No
         constraints=constraints,
         resources=resources,
         num_units=3,
+        trust=True,
     )
 
     logging.info("Waiting for the applications to settle")
@@ -141,6 +143,7 @@ def test_async_relate(first_model: str, second_model: str) -> None:
 def test_deploy_router_and_app(first_model: str) -> None:
     """Deploy the router and the test application."""
     logging.info("Deploying the router and test application")
+    constraints = {"arch": architecture.architecture}
     model_1 = Juju(model=first_model)
     model_1.deploy(
         charm=MYSQL_ROUTER_NAME,
@@ -149,6 +152,7 @@ def test_deploy_router_and_app(first_model: str) -> None:
         channel="8.0/edge",
         num_units=1,
         trust=True,
+        constraints=constraints,
     )
     model_1.deploy(
         charm=MYSQL_TEST_APP_NAME,
@@ -157,6 +161,7 @@ def test_deploy_router_and_app(first_model: str) -> None:
         channel="latest/edge",
         num_units=1,
         trust=False,
+        constraints=constraints,
     )
 
     logging.info("Relating the router and test application")

--- a/kubernetes/tests/integration/integration/high_availability/test_async_replication_upgrade.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_async_replication_upgrade.py
@@ -282,6 +282,7 @@ def run_upgrade_from_edge(juju: Juju, app_name: str, charm: str) -> None:
     juju.wait(
         ready=wait_for_unit_message(app_name, upgrade_unit, "upgrade completed"),
         timeout=10 * MINUTE_SECS,
+        delay=2,
     )
 
     logging.info("Resume upgrade")
@@ -297,6 +298,7 @@ def run_upgrade_from_edge(juju: Juju, app_name: str, charm: str) -> None:
     juju.wait(
         ready=lambda status: jubilant_backports.all_active(status, app_name),
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
     logging.info("Ensure continuous writes are incrementing")

--- a/kubernetes/tests/integration/integration/high_availability/test_async_replication_upgrade.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_async_replication_upgrade.py
@@ -88,6 +88,7 @@ def test_build_and_deploy(first_model: str, second_model: str, charm: str) -> No
         constraints=constraints,
         resources=resources,
         num_units=3,
+        trust=True,
     )
     model_2 = Juju(model=second_model)
     model_2.deploy(
@@ -98,6 +99,7 @@ def test_build_and_deploy(first_model: str, second_model: str, charm: str) -> No
         constraints=constraints,
         resources=resources,
         num_units=3,
+        trust=True,
     )
 
     logging.info("Waiting for the applications to settle")
@@ -143,6 +145,7 @@ def test_async_relate(first_model: str, second_model: str) -> None:
 def test_deploy_test_app(first_model: str) -> None:
     """Deploy the test application."""
     logging.info("Deploying the test application")
+    constraints = {"arch": architecture.architecture}
     model_1 = Juju(model=first_model)
     model_1.deploy(
         charm=MYSQL_TEST_APP_NAME,
@@ -150,6 +153,7 @@ def test_deploy_test_app(first_model: str) -> None:
         base="ubuntu@22.04",
         channel="latest/edge",
         num_units=1,
+        constraints=constraints,
     )
 
     logging.info("Relating the test application")

--- a/kubernetes/tests/integration/integration/high_availability/test_primary_switchover.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_primary_switchover.py
@@ -61,6 +61,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 

--- a/kubernetes/tests/integration/integration/high_availability/test_primary_switchover.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_primary_switchover.py
@@ -7,6 +7,7 @@ import subprocess
 import jubilant_backports
 from jubilant_backports import Juju
 
+from ... import architecture
 from ...helpers_ha import (
     CHARM_METADATA,
     get_app_name,
@@ -35,7 +36,9 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         config={"profile": "testing"},
         resources={"mysql-image": CHARM_METADATA["resources"]["mysql-image"]["upstream-source"]},
         num_units=3,
+        trust=True,
     )
+    constraints = {"arch": architecture.architecture}
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
@@ -43,6 +46,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         channel="latest/edge",
         config={"sleep_interval": 300},
         num_units=1,
+        constraints=constraints,
     )
 
     juju.integrate(

--- a/kubernetes/tests/integration/integration/high_availability/test_replication_data_consistency.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_replication_data_consistency.py
@@ -6,6 +6,7 @@ import logging
 import jubilant_backports
 from jubilant_backports import Juju
 
+from ... import architecture
 from ...helpers import generate_random_string
 from ...helpers_ha import (
     CHARM_METADATA,
@@ -32,7 +33,9 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         config={"profile": "testing"},
         resources={"mysql-image": CHARM_METADATA["resources"]["mysql-image"]["upstream-source"]},
         num_units=3,
+        trust=True,
     )
+    constraints = {"arch": architecture.architecture}
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
@@ -40,6 +43,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         channel="latest/edge",
         config={"sleep_interval": 300},
         num_units=1,
+        constraints=constraints,
     )
 
     juju.integrate(

--- a/kubernetes/tests/integration/integration/high_availability/test_replication_data_consistency.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_replication_data_consistency.py
@@ -58,6 +58,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 

--- a/kubernetes/tests/integration/integration/high_availability/test_replication_data_isolation.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_replication_data_isolation.py
@@ -56,6 +56,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -84,6 +85,7 @@ def test_cluster_data_isolation(juju: Juju, charm: str) -> None:
         ready=wait_for_apps_status(jubilant_backports.all_active, mysql_other_app_name),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
     table_name = "cluster_isolation_table"

--- a/kubernetes/tests/integration/integration/high_availability/test_replication_data_isolation.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_replication_data_isolation.py
@@ -6,6 +6,7 @@ import logging
 import jubilant_backports
 from jubilant_backports import Juju
 
+from ... import architecture
 from ...helpers_ha import (
     CHARM_METADATA,
     insert_mysql_test_data,
@@ -30,7 +31,9 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         config={"profile": "testing"},
         resources={"mysql-image": CHARM_METADATA["resources"]["mysql-image"]["upstream-source"]},
         num_units=3,
+        trust=True,
     )
+    constraints = {"arch": architecture.architecture}
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
@@ -38,6 +41,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         channel="latest/edge",
         config={"sleep_interval": 300},
         num_units=1,
+        constraints=constraints,
     )
 
     juju.integrate(
@@ -72,6 +76,7 @@ def test_cluster_data_isolation(juju: Juju, charm: str) -> None:
         config={"profile": "testing"},
         resources={"mysql-image": CHARM_METADATA["resources"]["mysql-image"]["upstream-source"]},
         num_units=1,
+        trust=True,
     )
 
     logging.info("Wait for application to become active")

--- a/kubernetes/tests/integration/integration/high_availability/test_replication_logs_rotation.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_replication_logs_rotation.py
@@ -67,6 +67,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 

--- a/kubernetes/tests/integration/integration/high_availability/test_replication_logs_rotation.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_replication_logs_rotation.py
@@ -17,6 +17,7 @@ from tenacity import (
 
 from constants import CONTAINER_NAME, MYSQL_LOG_DIR
 
+from ... import architecture
 from ...helpers_ha import (
     CHARM_METADATA,
     get_app_leader,
@@ -41,7 +42,9 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         config={"profile": "testing"},
         resources={"mysql-image": CHARM_METADATA["resources"]["mysql-image"]["upstream-source"]},
         num_units=3,
+        trust=True,
     )
+    constraints = {"arch": architecture.architecture}
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
@@ -49,6 +52,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         channel="latest/edge",
         config={"sleep_interval": 300},
         num_units=1,
+        constraints=constraints,
     )
 
     juju.integrate(

--- a/kubernetes/tests/integration/integration/high_availability/test_replication_reelection.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_replication_reelection.py
@@ -6,6 +6,7 @@ import logging
 import jubilant_backports
 from jubilant_backports import Juju
 
+from ... import architecture
 from ...helpers import generate_random_string
 from ...helpers_ha import (
     CHARM_METADATA,
@@ -34,7 +35,9 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         config={"profile": "testing"},
         resources={"mysql-image": CHARM_METADATA["resources"]["mysql-image"]["upstream-source"]},
         num_units=3,
+        trust=True,
     )
+    constraints = {"arch": architecture.architecture}
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
@@ -42,6 +45,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         channel="latest/edge",
         config={"sleep_interval": 300},
         num_units=1,
+        constraints=constraints,
     )
 
     juju.integrate(

--- a/kubernetes/tests/integration/integration/high_availability/test_replication_reelection.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_replication_reelection.py
@@ -60,6 +60,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -76,6 +77,7 @@ def test_kill_primary_check_reelection(juju: Juju) -> None:
         ready=wait_for_apps_status(jubilant_backports.all_active, MYSQL_APP_NAME),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
     # Confirm that the new primary unit is different

--- a/kubernetes/tests/integration/integration/high_availability/test_replication_scaling.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_replication_scaling.py
@@ -6,6 +6,7 @@ import logging
 import jubilant_backports
 from jubilant_backports import Juju
 
+from ... import architecture
 from ...helpers import generate_random_string
 from ...helpers_ha import (
     CHARM_METADATA,
@@ -32,7 +33,9 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         config={"profile": "testing"},
         resources={"mysql-image": CHARM_METADATA["resources"]["mysql-image"]["upstream-source"]},
         num_units=3,
+        trust=True,
     )
+    constraints = {"arch": architecture.architecture}
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
@@ -40,6 +43,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         channel="latest/edge",
         config={"sleep_interval": 300},
         num_units=1,
+        constraints=constraints,
     )
 
     juju.integrate(

--- a/kubernetes/tests/integration/integration/high_availability/test_replication_scaling.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_replication_scaling.py
@@ -58,6 +58,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 

--- a/kubernetes/tests/integration/integration/high_availability/test_replication_unit_endpoints.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_replication_unit_endpoints.py
@@ -6,6 +6,7 @@ import logging
 import jubilant_backports
 from jubilant_backports import Juju
 
+from ... import architecture
 from ...helpers_ha import (
     CHARM_METADATA,
     get_app_units,
@@ -35,7 +36,9 @@ def test_deploy_highly_available_cluster_1(juju: Juju, charm: str) -> None:
         config={"cluster-name": MYSQL_APP_CLUSTER, "profile": "testing"},
         resources={"mysql-image": CHARM_METADATA["resources"]["mysql-image"]["upstream-source"]},
         num_units=3,
+        trust=True,
     )
+    constraints = {"arch": architecture.architecture}
     juju.deploy(
         charm="mysql-test-app",
         app=MYSQL_TEST_APP_NAME_1,
@@ -43,6 +46,7 @@ def test_deploy_highly_available_cluster_1(juju: Juju, charm: str) -> None:
         channel="latest/edge",
         config={"sleep_interval": 300},
         num_units=1,
+        constraints=constraints,
     )
 
     juju.integrate(

--- a/kubernetes/tests/integration/integration/high_availability/test_replication_unit_endpoints.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_replication_unit_endpoints.py
@@ -60,11 +60,13 @@ def test_deploy_highly_available_cluster_1(juju: Juju, charm: str) -> None:
             ready=wait_for_apps_status(jubilant_backports.all_active, MYSQL_APP_NAME_1),
             error=jubilant_backports.any_blocked,
             timeout=20 * MINUTE_SECS,
+            delay=2,
         )
         juju.wait(
             ready=wait_for_apps_status(jubilant_backports.all_active, MYSQL_TEST_APP_NAME_1),
             error=jubilant_backports.any_blocked,
             timeout=20 * MINUTE_SECS,
+            delay=2,
         )
 
 
@@ -99,11 +101,13 @@ def test_deploy_highly_available_cluster_2(juju: Juju, charm: str) -> None:
             ready=wait_for_apps_status(jubilant_backports.all_active, MYSQL_APP_NAME_2),
             error=jubilant_backports.any_blocked,
             timeout=20 * MINUTE_SECS,
+            delay=2,
         )
         juju.wait(
             ready=wait_for_apps_status(jubilant_backports.all_active, MYSQL_TEST_APP_NAME_2),
             error=jubilant_backports.any_blocked,
             timeout=20 * MINUTE_SECS,
+            delay=2,
         )
 
 

--- a/kubernetes/tests/integration/integration/high_availability/test_replication_variables.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_replication_variables.py
@@ -38,6 +38,7 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, APP_NAME),
         timeout=TIMEOUT,
+        delay=2,
     )
 
 

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_network_cut.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_network_cut.py
@@ -12,6 +12,7 @@ from string import Template
 import jubilant_backports
 from jubilant_backports import Juju
 
+from ... import architecture
 from ...helpers_ha import (
     CHARM_METADATA,
     check_mysql_instances_online,
@@ -39,7 +40,9 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         config={"profile": "testing"},
         resources={"mysql-image": CHARM_METADATA["resources"]["mysql-image"]["upstream-source"]},
         num_units=3,
+        trust=True,
     )
+    constraints = {"arch": architecture.architecture}
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
@@ -47,6 +50,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         channel="latest/edge",
         config={"sleep_interval": 300},
         num_units=1,
+        constraints=constraints,
     )
 
     juju.integrate(

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_network_cut.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_network_cut.py
@@ -65,6 +65,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -98,6 +99,7 @@ def test_network_cut_affecting_an_instance(juju: Juju, continuous_writes, chaos_
         juju.wait(
             ready=wait_for_unit_status(MYSQL_APP_NAME, mysql_primary, "active"),
             timeout=20 * MINUTE_SECS,
+            delay=2,
         )
 
     logging.info("Check that all units are online")

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_node_drain.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_node_drain.py
@@ -9,6 +9,7 @@ from lightkube.core.client import Client
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.core_v1 import PersistentVolume, PersistentVolumeClaim, Pod
 
+from ... import architecture
 from ...helpers_ha import (
     CHARM_METADATA,
     check_mysql_units_writes_increment,
@@ -36,7 +37,9 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         config={"profile": "testing"},
         resources={"mysql-image": CHARM_METADATA["resources"]["mysql-image"]["upstream-source"]},
         num_units=3,
+        trust=True,
     )
+    constraints = {"arch": architecture.architecture}
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
@@ -44,6 +47,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         channel="latest/edge",
         config={"sleep_interval": 300},
         num_units=1,
+        constraints=constraints,
     )
 
     juju.integrate(

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_node_drain.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_node_drain.py
@@ -62,6 +62,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -86,6 +87,7 @@ def test_pod_eviction_and_pvc_deletion(juju: Juju, continuous_writes) -> None:
             ready=wait_for_apps_status(jubilant_backports.all_active, MYSQL_APP_NAME),
             error=jubilant_backports.any_blocked,
             timeout=20 * MINUTE_SECS,
+            delay=2,
         )
 
     logging.info("Ensuring that all instances have incrementing continuous writes")

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_pod.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_pod.py
@@ -6,6 +6,7 @@ import logging
 import jubilant_backports
 from jubilant_backports import Juju
 
+from ... import architecture
 from ...helpers import generate_random_string
 from ...helpers_ha import (
     CHARM_METADATA,
@@ -34,7 +35,9 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         config={"profile": "testing"},
         resources={"mysql-image": CHARM_METADATA["resources"]["mysql-image"]["upstream-source"]},
         num_units=3,
+        trust=True,
     )
+    constraints = {"arch": architecture.architecture}
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
@@ -42,6 +45,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         channel="latest/edge",
         config={"sleep_interval": 300},
         num_units=1,
+        constraints=constraints,
     )
 
     juju.integrate(

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_pod.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_pod.py
@@ -60,6 +60,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -78,6 +79,7 @@ def test_single_unit_pod_delete(juju: Juju) -> None:
         ready=wait_for_apps_status(jubilant_backports.all_active, MYSQL_APP_NAME),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
     logging.info("Write data to unit and verify that data was written")

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_process_frozen.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_process_frozen.py
@@ -14,6 +14,7 @@ from tenacity import (
 
 from constants import CONTAINER_NAME
 
+from ... import architecture
 from ...helpers_ha import (
     CHARM_METADATA,
     check_mysql_units_writes_increment,
@@ -41,7 +42,9 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         config={"profile": "testing"},
         resources={"mysql-image": CHARM_METADATA["resources"]["mysql-image"]["upstream-source"]},
         num_units=3,
+        trust=True,
     )
+    constraints = {"arch": architecture.architecture}
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
@@ -49,6 +52,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         channel="latest/edge",
         config={"sleep_interval": 300},
         num_units=1,
+        constraints=constraints,
     )
 
     juju.integrate(

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_process_frozen.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_process_frozen.py
@@ -67,6 +67,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -137,6 +138,7 @@ def test_freeze_db_process(juju: Juju, continuous_writes) -> None:
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, MYSQL_APP_NAME),
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
     logging.info("Ensuring that all instances have incrementing continuous writes")

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_process_killed.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_process_killed.py
@@ -9,6 +9,7 @@ from jubilant_backports import Juju
 
 from constants import CONTAINER_NAME
 
+from ... import architecture
 from ...helpers import generate_random_string
 from ...helpers_ha import (
     CHARM_METADATA,
@@ -40,7 +41,9 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         config={"profile": "testing"},
         resources={"mysql-image": CHARM_METADATA["resources"]["mysql-image"]["upstream-source"]},
         num_units=3,
+        trust=True,
     )
+    constraints = {"arch": architecture.architecture}
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
@@ -48,6 +51,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         channel="latest/edge",
         config={"sleep_interval": 300},
         num_units=1,
+        constraints=constraints,
     )
 
     juju.integrate(

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_process_killed.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_process_killed.py
@@ -66,6 +66,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_restart_graceful.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_restart_graceful.py
@@ -62,6 +62,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -102,6 +103,7 @@ def test_cluster_manual_rejoin(juju: Juju, continuous_writes) -> None:
     juju.wait(
         ready=wait_for_unit_status(MYSQL_APP_NAME, mysql_primary_unit, "active"),
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
     # Ensure continuous writes still incrementing for all units

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_restart_graceful.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_restart_graceful.py
@@ -6,6 +6,7 @@ import logging
 import jubilant_backports
 from jubilant_backports import Juju
 
+from ... import architecture
 from ...helpers import execute_queries_on_unit
 from ...helpers_ha import (
     CHARM_METADATA,
@@ -36,7 +37,9 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         config={"profile": "testing"},
         resources={"mysql-image": CHARM_METADATA["resources"]["mysql-image"]["upstream-source"]},
         num_units=3,
+        trust=True,
     )
+    constraints = {"arch": architecture.architecture}
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
@@ -44,6 +47,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         channel="latest/edge",
         config={"sleep_interval": 300},
         num_units=1,
+        constraints=constraints,
     )
 
     juju.integrate(

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_setup_crash.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_setup_crash.py
@@ -35,6 +35,7 @@ def test_deploy_single_unit_cluster(juju: Juju, charm: str) -> None:
         ready=wait_for_apps_status(jubilant_backports.all_active, MYSQL_APP_NAME),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -51,6 +52,7 @@ def test_crash_during_cluster_setup(juju: Juju, charm: str) -> None:
         ready=wait_for_apps_status(jubilant_backports.any_waiting, MYSQL_APP_NAME),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
     logging.info("Deleting pod")
@@ -61,4 +63,5 @@ def test_crash_during_cluster_setup(juju: Juju, charm: str) -> None:
         juju.wait(
             ready=wait_for_apps_status(jubilant_backports.all_active, MYSQL_APP_NAME),
             timeout=20 * MINUTE_SECS,
+            delay=2,
         )

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_stop_all.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_stop_all.py
@@ -60,6 +60,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -91,6 +92,7 @@ async def test_graceful_full_cluster_crash(juju: Juju, continuous_writes) -> Non
                 wait_for_unit_status(MYSQL_APP_NAME, f"{MYSQL_APP_NAME}/2", "maintenance")(status),
             )),
             timeout=20 * MINUTE_SECS,
+            delay=2,
         )
         logging.info("Waiting units to be back online")
         juju.wait(
@@ -100,6 +102,7 @@ async def test_graceful_full_cluster_crash(juju: Juju, continuous_writes) -> Non
                 wait_for_unit_status(MYSQL_APP_NAME, f"{MYSQL_APP_NAME}/2", "active")(status),
             )),
             timeout=20 * MINUTE_SECS,
+            delay=2,
         )
 
     logging.info("Check that all units are online")

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_stop_all.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_stop_all.py
@@ -6,6 +6,7 @@ import logging
 import jubilant_backports
 from jubilant_backports import Juju
 
+from ... import architecture
 from ...helpers_ha import (
     CHARM_METADATA,
     check_mysql_instances_online,
@@ -34,7 +35,9 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         config={"profile": "testing"},
         resources={"mysql-image": CHARM_METADATA["resources"]["mysql-image"]["upstream-source"]},
         num_units=3,
+        trust=True,
     )
+    constraints = {"arch": architecture.architecture}
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
@@ -42,6 +45,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         channel="latest/edge",
         config={"sleep_interval": 300},
         num_units=1,
+        constraints=constraints,
     )
 
     juju.integrate(

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_stop_primary.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_stop_primary.py
@@ -8,6 +8,7 @@ from jubilant_backports import Juju
 
 from constants import CONTAINER_NAME
 
+from ... import architecture
 from ...helpers_ha import (
     CHARM_METADATA,
     check_mysql_units_writes_increment,
@@ -34,7 +35,9 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         config={"profile": "testing"},
         resources={"mysql-image": CHARM_METADATA["resources"]["mysql-image"]["upstream-source"]},
         num_units=3,
+        trust=True,
     )
+    constraints = {"arch": architecture.architecture}
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
@@ -42,6 +45,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         channel="latest/edge",
         config={"sleep_interval": 300},
         num_units=1,
+        constraints=constraints,
     )
 
     juju.integrate(

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_stop_primary.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_stop_primary.py
@@ -60,6 +60,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -86,6 +87,7 @@ async def test_graceful_crash_of_primary(juju: Juju, continuous_writes) -> None:
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, MYSQL_APP_NAME),
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
     new_mysql_primary_unit = get_mysql_primary_unit(juju, MYSQL_APP_NAME)

--- a/kubernetes/tests/integration/integration/high_availability/test_upgrade.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_upgrade.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import jubilant_backports
 from jubilant_backports import Juju, TaskError
 
+from ... import architecture
 from ...helpers_ha import (
     CHARM_METADATA,
     check_mysql_units_writes_increment,
@@ -44,6 +45,7 @@ def test_deploy_latest(juju: Juju) -> None:
         num_units=3,
         trust=True,
     )
+    constraints = {"arch": architecture.architecture}
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
@@ -51,6 +53,7 @@ def test_deploy_latest(juju: Juju) -> None:
         channel="latest/edge",
         num_units=1,
         trust=False,
+        constraints=constraints,
     )
 
     juju.integrate(

--- a/kubernetes/tests/integration/integration/high_availability/test_upgrade.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_upgrade.py
@@ -68,6 +68,7 @@ def test_deploy_latest(juju: Juju) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -111,6 +112,7 @@ def test_upgrade_from_edge(juju: Juju, charm: str, continuous_writes) -> None:
     juju.wait(
         ready=wait_for_unit_message(MYSQL_APP_NAME, mysql_upgrade_unit, "upgrade completed"),
         timeout=10 * MINUTE_SECS,
+        delay=2,
     )
 
     logging.info("Resume upgrade")
@@ -126,6 +128,7 @@ def test_upgrade_from_edge(juju: Juju, charm: str, continuous_writes) -> None:
     juju.wait(
         ready=lambda status: jubilant_backports.all_active(status, MYSQL_APP_NAME),
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
     logging.info("Ensure continuous writes are incrementing")
@@ -157,6 +160,7 @@ def test_fail_and_rollback(juju: Juju, charm: str, continuous_writes) -> None:
     juju.wait(
         ready=wait_for_unit_status(MYSQL_APP_NAME, mysql_upgrade_unit, "blocked"),
         timeout=10 * MINUTE_SECS,
+        delay=2,
     )
 
     logging.info("Ensure continuous writes on remaining units")
@@ -173,6 +177,7 @@ def test_fail_and_rollback(juju: Juju, charm: str, continuous_writes) -> None:
     juju.wait(
         ready=wait_for_unit_message(MYSQL_APP_NAME, mysql_upgrade_unit, "upgrade completed"),
         timeout=10 * MINUTE_SECS,
+        delay=2,
     )
 
     logging.info("Resume upgrade")
@@ -188,6 +193,7 @@ def test_fail_and_rollback(juju: Juju, charm: str, continuous_writes) -> None:
     juju.wait(
         ready=lambda status: jubilant_backports.all_active(status, MYSQL_APP_NAME),
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
     logging.info("Ensure continuous writes after rollback procedure")

--- a/kubernetes/tests/integration/integration/high_availability/test_upgrade_from_stable.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_upgrade_from_stable.py
@@ -62,6 +62,7 @@ def test_deploy_stable(juju: Juju) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -105,6 +106,7 @@ def test_upgrade_from_stable(juju: Juju, charm: str, continuous_writes) -> None:
     juju.wait(
         ready=wait_for_unit_message(MYSQL_APP_NAME, mysql_upgrade_unit, "upgrade completed"),
         timeout=10 * MINUTE_SECS,
+        delay=2,
     )
 
     logging.info("Resume upgrade")
@@ -120,6 +122,7 @@ def test_upgrade_from_stable(juju: Juju, charm: str, continuous_writes) -> None:
     juju.wait(
         ready=lambda status: jubilant_backports.all_active(status, MYSQL_APP_NAME),
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
     logging.info("Ensure continuous writes are incrementing")

--- a/kubernetes/tests/integration/integration/high_availability/test_upgrade_from_stable.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_upgrade_from_stable.py
@@ -7,6 +7,7 @@ from contextlib import suppress
 import jubilant_backports
 from jubilant_backports import Juju, TaskError
 
+from ... import architecture
 from ...helpers_ha import (
     CHARM_METADATA,
     check_mysql_units_writes_increment,
@@ -38,13 +39,15 @@ def test_deploy_stable(juju: Juju) -> None:
         num_units=3,
         trust=True,
     )
+
+    constraints = {"arch": architecture.architecture}
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
         base="ubuntu@22.04",
         channel="latest/edge",
         num_units=1,
-        trust=False,
+        constraints=constraints,
     )
 
     juju.integrate(

--- a/kubernetes/tests/integration/integration/high_availability/test_upgrade_rollback_incompat.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_upgrade_rollback_incompat.py
@@ -51,6 +51,7 @@ def test_build_and_deploy(juju: Juju, charm: str) -> None:
         ready=wait_for_apps_status(jubilant_backports.all_active, MYSQL_APP_NAME),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -91,6 +92,7 @@ def test_upgrade_to_failing(juju: Juju, charm: str) -> None:
     juju.wait(
         ready=lambda status: jubilant_backports.any_maintenance(status, MYSQL_APP_NAME),
         timeout=10 * MINUTE_SECS,
+        delay=2,
     )
 
     logging.info("Get first upgrading unit")
@@ -100,6 +102,7 @@ def test_upgrade_to_failing(juju: Juju, charm: str) -> None:
     juju.wait(
         ready=wait_for_unit_status(MYSQL_APP_NAME, upgrade_unit, "blocked"),
         timeout=10 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -132,12 +135,14 @@ def test_rollback(juju: Juju, charm: str) -> None:
     juju.wait(
         ready=lambda status: jubilant_backports.any_maintenance(status, MYSQL_APP_NAME),
         timeout=10 * MINUTE_SECS,
+        delay=2,
     )
 
     logging.info("Wait for upgrade to complete on first upgrading unit")
     juju.wait(
         ready=wait_for_unit_message(MYSQL_APP_NAME, mysql_upgrade_unit, "upgrade completed"),
         timeout=10 * MINUTE_SECS,
+        delay=2,
     )
 
     logging.info("Ensure rollback has taken place")
@@ -157,6 +162,7 @@ def test_rollback(juju: Juju, charm: str) -> None:
     juju.wait(
         ready=lambda status: jubilant_backports.all_active(status, MYSQL_APP_NAME),
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 

--- a/kubernetes/tests/integration/integration/relations/test_database.py
+++ b/kubernetes/tests/integration/integration/relations/test_database.py
@@ -7,6 +7,8 @@ import logging
 import jubilant_backports
 from jubilant_backports import Juju
 
+from tests.integration import architecture
+
 from ... import markers
 from ...helpers_ha import (
     CHARM_METADATA,
@@ -35,11 +37,13 @@ def test_build_and_deploy(juju: Juju, charm):
         trust=True,
     )
 
+    constraints = {"arch": architecture.architecture}
     juju.deploy(
         APPLICATION_APP_NAME,
         num_units=2,
         channel="latest/edge",
         base="ubuntu@22.04",
+        constraints=constraints,
     )
 
 

--- a/kubernetes/tests/integration/integration/relations/test_database.py
+++ b/kubernetes/tests/integration/integration/relations/test_database.py
@@ -62,12 +62,14 @@ def test_relation_creation_eager(juju: Juju):
         ready=wait_for_apps_status(jubilant_backports.all_waiting, APPLICATION_APP_NAME),
         error=jubilant_backports.any_blocked,
         timeout=15 * MINUTE_SECS,
+        delay=2,
     )
     logging.info("Waiting for database app to be active...")
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
         error=jubilant_backports.any_blocked,
         timeout=15 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -77,6 +79,7 @@ def test_relation_creation_databag(juju: Juju):
     juju.wait(
         ready=jubilant_backports.all_active,
         timeout=15 * MINUTE_SECS,
+        delay=2,
     )
 
     relation_data = get_relation_data(juju, APPLICATION_APP_NAME, "database")
@@ -89,6 +92,7 @@ def test_relation_creation(juju: Juju):
     juju.wait(
         ready=jubilant_backports.all_active,
         timeout=15 * MINUTE_SECS,
+        delay=2,
     )
 
     relation_data = get_relation_data(juju, APPLICATION_APP_NAME, "database")
@@ -107,9 +111,11 @@ def test_relation_broken(juju: Juju):
         ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
         error=jubilant_backports.any_blocked,
         timeout=15 * MINUTE_SECS,
+        delay=2,
     )
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_waiting, APPLICATION_APP_NAME),
         error=jubilant_backports.any_blocked,
         timeout=15 * MINUTE_SECS,
+        delay=2,
     )

--- a/kubernetes/tests/integration/integration/relations/test_database.py
+++ b/kubernetes/tests/integration/integration/relations/test_database.py
@@ -7,9 +7,8 @@ import logging
 import jubilant_backports
 from jubilant_backports import Juju
 
-from tests.integration import architecture
-
 from ... import markers
+from ...architecture import architecture
 from ...helpers_ha import (
     CHARM_METADATA,
     MINUTE_SECS,
@@ -37,7 +36,7 @@ def test_build_and_deploy(juju: Juju, charm):
         trust=True,
     )
 
-    constraints = {"arch": architecture.architecture}
+    constraints = {"arch": architecture}
     juju.deploy(
         APPLICATION_APP_NAME,
         num_units=2,

--- a/kubernetes/tests/integration/integration/relations/test_mysql_root.py
+++ b/kubernetes/tests/integration/integration/relations/test_mysql_root.py
@@ -7,6 +7,7 @@ import logging
 import jubilant_backports
 from jubilant_backports import Juju
 
+from ... import architecture
 from ...helpers_ha import (
     CHARM_METADATA,
     MINUTE_SECS,
@@ -34,11 +35,13 @@ def test_build_and_deploy(juju: Juju, charm):
         base="ubuntu@22.04",
         trust=True,
     )
+    constraints = {"arch": architecture.architecture}
     juju.deploy(
         APPLICATION_APP_NAME,
         num_units=2,
         channel="latest/edge",
         base="ubuntu@22.04",
+        constraints=constraints,
     )
 
 

--- a/kubernetes/tests/integration/integration/relations/test_mysql_root.py
+++ b/kubernetes/tests/integration/integration/relations/test_mysql_root.py
@@ -60,10 +60,12 @@ def test_relation_creation_eager(juju: Juju):
         ready=wait_for_apps_status(jubilant_backports.all_waiting, APPLICATION_APP_NAME),
         error=jubilant_backports.any_blocked,
         timeout=15 * MINUTE_SECS,
+        delay=2,
     )
     logging.info("Waiting for database app to be active...")
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
         error=jubilant_backports.any_blocked,
         timeout=15 * MINUTE_SECS,
+        delay=2,
     )

--- a/kubernetes/tests/integration/integration/roles/test_database_dba_role.py
+++ b/kubernetes/tests/integration/integration/roles/test_database_dba_role.py
@@ -50,6 +50,7 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
         timeout=15 * MINUTE_SECS,
+        delay=2,
     )
     juju.wait(
         ready=lambda status: all((
@@ -63,6 +64,7 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
             ),
         )),
         timeout=15 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -78,6 +80,7 @@ def test_charmed_dba_role(juju: Juju):
             jubilant_backports.all_active, f"{INTEGRATOR_APP_NAME}1", DATABASE_APP_NAME
         ),
         timeout=15 * MINUTE_SECS,
+        delay=2,
     )
 
     juju.config(
@@ -90,6 +93,7 @@ def test_charmed_dba_role(juju: Juju):
             jubilant_backports.all_active, f"{INTEGRATOR_APP_NAME}2", DATABASE_APP_NAME
         ),
         timeout=15 * MINUTE_SECS,
+        delay=2,
     )
 
     primary_unit_name = get_mysql_primary_unit(juju, DATABASE_APP_NAME)

--- a/kubernetes/tests/integration/integration/roles/test_instance_dba_role.py
+++ b/kubernetes/tests/integration/integration/roles/test_instance_dba_role.py
@@ -40,6 +40,7 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
         timeout=15 * MINUTE_SECS,
+        delay=2,
     )
     juju.wait(
         ready=lambda status: all((
@@ -49,6 +50,7 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
             ),
         )),
         timeout=15 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -64,6 +66,7 @@ def test_charmed_dba_role(juju: Juju):
             jubilant_backports.all_active, INTEGRATOR_APP_NAME, DATABASE_APP_NAME
         ),
         timeout=15 * MINUTE_SECS,
+        delay=2,
     )
 
     primary_unit_name = get_mysql_primary_unit(juju, DATABASE_APP_NAME)

--- a/kubernetes/tests/integration/integration/roles/test_instance_roles.py
+++ b/kubernetes/tests/integration/integration/roles/test_instance_roles.py
@@ -51,6 +51,7 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
         timeout=15 * MINUTE_SECS,
+        delay=2,
     )
     juju.wait(
         ready=lambda status: all((
@@ -64,6 +65,7 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
             ),
         )),
         timeout=15 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -79,6 +81,7 @@ def test_charmed_read_role(juju: Juju):
             jubilant_backports.all_active, f"{INTEGRATOR_APP_NAME}1", DATABASE_APP_NAME
         ),
         timeout=15 * MINUTE_SECS,
+        delay=2,
     )
 
     primary_unit_name = get_mysql_primary_unit(juju, DATABASE_APP_NAME)
@@ -149,6 +152,7 @@ def test_charmed_read_role(juju: Juju):
             ),
         )),
         timeout=15 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -163,6 +167,7 @@ def test_charmed_dml_role(juju: Juju):
             jubilant_backports.all_active, f"{INTEGRATOR_APP_NAME}1", DATABASE_APP_NAME
         ),
         timeout=15 * MINUTE_SECS,
+        delay=2,
     )
 
     juju.config(
@@ -175,6 +180,7 @@ def test_charmed_dml_role(juju: Juju):
             jubilant_backports.all_active, f"{INTEGRATOR_APP_NAME}2", DATABASE_APP_NAME
         ),
         timeout=15 * MINUTE_SECS,
+        delay=2,
     )
 
     primary_unit_name = get_mysql_primary_unit(juju, DATABASE_APP_NAME)
@@ -260,4 +266,5 @@ def test_charmed_dml_role(juju: Juju):
             ),
         )),
         timeout=15 * MINUTE_SECS,
+        delay=2,
     )

--- a/kubernetes/tests/integration/integration/test_architecture.py
+++ b/kubernetes/tests/integration/integration/test_architecture.py
@@ -40,6 +40,7 @@ def test_arm_charm_on_amd_host(juju: Juju) -> None:
             ),
         )),
         timeout=TIMEOUT,
+        delay=2,
     )
 
 
@@ -69,6 +70,7 @@ def test_amd_charm_on_arm_host(juju: Juju) -> None:
             ),
         )),
         timeout=TIMEOUT,
+        delay=2,
     )
 
 

--- a/kubernetes/tests/integration/integration/test_architecture.py
+++ b/kubernetes/tests/integration/integration/test_architecture.py
@@ -3,6 +3,8 @@
 # See LICENSE file for licensing details.
 
 
+from time import sleep
+
 from jubilant_backports import Juju
 
 from .. import markers
@@ -25,6 +27,10 @@ def test_arm_charm_on_amd_host(juju: Juju) -> None:
         resources={"mysql-image": CHARM_METADATA["resources"]["mysql-image"]["upstream-source"]},
         base="ubuntu@22.04",
     )
+
+    # Allow some time between deploy and status call. Avoids:
+    # ERROR getting details for storage database/0: filesystem for storage instance "database/0" not found
+    sleep(30)
 
     juju.wait(
         ready=lambda status: all((
@@ -50,6 +56,10 @@ def test_amd_charm_on_arm_host(juju: Juju) -> None:
         resources={"mysql-image": CHARM_METADATA["resources"]["mysql-image"]["upstream-source"]},
         base="ubuntu@22.04",
     )
+
+    # Allow some time between deploy and status call. Avoids:
+    # ERROR getting details for storage database/0: filesystem for storage instance "database/0" not found
+    sleep(30)
 
     juju.wait(
         ready=lambda status: all((

--- a/kubernetes/tests/integration/integration/test_backup_aws.py
+++ b/kubernetes/tests/integration/integration/test_backup_aws.py
@@ -5,6 +5,7 @@
 import logging
 import socket
 from pathlib import Path
+from time import sleep
 
 import boto3
 import jubilant_backports
@@ -87,6 +88,9 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
         resources={"mysql-image": CHARM_METADATA["resources"]["mysql-image"]["upstream-source"]},
         trust=True,
     )
+    # Allow some time between deploy and status call. Avoids:
+    # ERROR getting details for storage database/0: filesystem for storage instance "database/0" not found
+    sleep(30)
 
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
@@ -384,8 +388,10 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_aws) -> None:
 
     logger.info("Waiting for blocked application status with another cluster S3 repository")
     juju.wait(  # Might take a few minutes to get past this
-        ready=lambda status: status.apps[new_mysql_application_name].app_status.message
-        == ANOTHER_S3_CLUSTER_REPOSITORY_ERROR_MESSAGE,
+        ready=lambda status: (
+            status.apps[new_mysql_application_name].app_status.message
+            == ANOTHER_S3_CLUSTER_REPOSITORY_ERROR_MESSAGE
+        ),
         timeout=TIMEOUT,
     )
 
@@ -463,7 +469,9 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_aws) -> None:
 
     logger.info("Waiting for blocked application status after restore")
     juju.wait(
-        ready=lambda status: status.apps[new_mysql_application_name].app_status.message
-        == MOVE_RESTORED_CLUSTER_TO_ANOTHER_S3_REPOSITORY_ERROR,
+        ready=lambda status: (
+            status.apps[new_mysql_application_name].app_status.message
+            == MOVE_RESTORED_CLUSTER_TO_ANOTHER_S3_REPOSITORY_ERROR
+        ),
         timeout=TIMEOUT,
     )

--- a/kubernetes/tests/integration/integration/test_backup_aws.py
+++ b/kubernetes/tests/integration/integration/test_backup_aws.py
@@ -96,6 +96,7 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
         ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
         error=jubilant_backports.any_blocked,
         timeout=15 * MINUTE_SECS,
+        delay=2,
     )
 
     primary_unit_name = get_mysql_primary_unit(juju, DATABASE_APP_NAME)
@@ -122,6 +123,7 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
             ),
         )),
         timeout=TIMEOUT,
+        delay=2,
     )
 
 
@@ -168,6 +170,7 @@ def test_backup(juju: Juju, cloud_configs_aws) -> None:
             jubilant_backports.all_active, DATABASE_APP_NAME, S3_INTEGRATOR
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # list backups
@@ -235,6 +238,7 @@ def test_restore_on_same_cluster(juju: Juju, cloud_configs_aws) -> None:
             jubilant_backports.all_active, DATABASE_APP_NAME, S3_INTEGRATOR
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # restore the backup
@@ -299,6 +303,7 @@ def test_restore_on_same_cluster(juju: Juju, cloud_configs_aws) -> None:
             ),
         )),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     logger.info("Ensuring inserted values before backup and after restore exist on all units")
@@ -340,6 +345,7 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_aws) -> None:
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, new_mysql_application_name),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # relate to S3 integrator
@@ -350,6 +356,7 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_aws) -> None:
             jubilant_backports.all_active, new_mysql_application_name, S3_INTEGRATOR
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # rotate all credentials
@@ -384,6 +391,7 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_aws) -> None:
             jubilant_backports.all_active, new_mysql_application_name, S3_INTEGRATOR
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     logger.info("Waiting for blocked application status with another cluster S3 repository")
@@ -393,6 +401,7 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_aws) -> None:
             == ANOTHER_S3_CLUSTER_REPOSITORY_ERROR_MESSAGE
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # restore the backup
@@ -452,6 +461,7 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_aws) -> None:
             ),
         )),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     logger.info("Ensuring inserted values before backup and after restore exist on all units")
@@ -474,4 +484,5 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_aws) -> None:
             == MOVE_RESTORED_CLUSTER_TO_ANOTHER_S3_REPOSITORY_ERROR
         ),
         timeout=TIMEOUT,
+        delay=2,
     )

--- a/kubernetes/tests/integration/integration/test_backup_ceph.py
+++ b/kubernetes/tests/integration/integration/test_backup_ceph.py
@@ -176,6 +176,10 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
         trust=True,
     )
 
+    # Allow some time between deploy and status call. Avoids:
+    # ERROR getting details for storage database/0: filesystem for storage instance "database/0" not found
+    time.sleep(30)
+
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
         error=jubilant_backports.any_blocked,
@@ -466,8 +470,10 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_credentials, cloud_conf
 
     logger.info("Waiting for blocked application status with another cluster S3 repository")
     juju.wait(  # Might take a few minutes to get past this
-        ready=lambda status: status.apps[new_mysql_application_name].app_status.message
-        == ANOTHER_S3_CLUSTER_REPOSITORY_ERROR_MESSAGE,
+        ready=lambda status: (
+            status.apps[new_mysql_application_name].app_status.message
+            == ANOTHER_S3_CLUSTER_REPOSITORY_ERROR_MESSAGE
+        ),
         timeout=TIMEOUT,
     )
 
@@ -545,7 +551,9 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_credentials, cloud_conf
 
     logger.info("Waiting for blocked application status after restore")
     juju.wait(
-        ready=lambda status: status.apps[new_mysql_application_name].app_status.message
-        == MOVE_RESTORED_CLUSTER_TO_ANOTHER_S3_REPOSITORY_ERROR,
+        ready=lambda status: (
+            status.apps[new_mysql_application_name].app_status.message
+            == MOVE_RESTORED_CLUSTER_TO_ANOTHER_S3_REPOSITORY_ERROR
+        ),
         timeout=TIMEOUT,
     )

--- a/kubernetes/tests/integration/integration/test_backup_ceph.py
+++ b/kubernetes/tests/integration/integration/test_backup_ceph.py
@@ -184,6 +184,7 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
         ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
         error=jubilant_backports.any_blocked,
         timeout=15 * MINUTE_SECS,
+        delay=2,
     )
 
     primary_unit_name = get_mysql_primary_unit(juju, DATABASE_APP_NAME)
@@ -210,6 +211,7 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
             ),
         )),
         timeout=TIMEOUT,
+        delay=2,
     )
 
 
@@ -254,6 +256,7 @@ def test_backup(juju: Juju, cloud_credentials, cloud_configs) -> None:
             jubilant_backports.all_active, DATABASE_APP_NAME, S3_INTEGRATOR
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # list backups
@@ -319,6 +322,7 @@ def test_restore_on_same_cluster(juju: Juju, cloud_credentials, cloud_configs) -
             jubilant_backports.all_active, DATABASE_APP_NAME, S3_INTEGRATOR
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # restore the backup
@@ -383,6 +387,7 @@ def test_restore_on_same_cluster(juju: Juju, cloud_credentials, cloud_configs) -
             ),
         )),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     logger.info("Ensuring inserted values before backup and after restore exist on all units")
@@ -422,6 +427,7 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_credentials, cloud_conf
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, new_mysql_application_name),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # relate to S3 integrator
@@ -432,6 +438,7 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_credentials, cloud_conf
             jubilant_backports.all_active, new_mysql_application_name, S3_INTEGRATOR
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # rotate all credentials
@@ -466,6 +473,7 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_credentials, cloud_conf
             jubilant_backports.all_active, new_mysql_application_name, S3_INTEGRATOR
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     logger.info("Waiting for blocked application status with another cluster S3 repository")
@@ -475,6 +483,7 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_credentials, cloud_conf
             == ANOTHER_S3_CLUSTER_REPOSITORY_ERROR_MESSAGE
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # restore the backup
@@ -534,6 +543,7 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_credentials, cloud_conf
             ),
         )),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     logger.info("Ensuring inserted values before backup and after restore exist on all units")
@@ -556,4 +566,5 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_credentials, cloud_conf
             == MOVE_RESTORED_CLUSTER_TO_ANOTHER_S3_REPOSITORY_ERROR
         ),
         timeout=TIMEOUT,
+        delay=2,
     )

--- a/kubernetes/tests/integration/integration/test_backup_gcp.py
+++ b/kubernetes/tests/integration/integration/test_backup_gcp.py
@@ -92,6 +92,7 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
         ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
         error=jubilant_backports.any_blocked,
         timeout=15 * MINUTE_SECS,
+        delay=2,
     )
 
     primary_unit_name = get_mysql_primary_unit(juju, DATABASE_APP_NAME)
@@ -118,6 +119,7 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
             ),
         )),
         timeout=TIMEOUT,
+        delay=2,
     )
 
 
@@ -164,6 +166,7 @@ def test_backup(juju: Juju, cloud_configs_gcp) -> None:
             jubilant_backports.all_active, DATABASE_APP_NAME, S3_INTEGRATOR
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # list backups
@@ -231,6 +234,7 @@ def test_restore_on_same_cluster(juju: Juju, cloud_configs_gcp) -> None:
             jubilant_backports.all_active, DATABASE_APP_NAME, S3_INTEGRATOR
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # restore the backup
@@ -295,6 +299,7 @@ def test_restore_on_same_cluster(juju: Juju, cloud_configs_gcp) -> None:
             ),
         )),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     logger.info("Ensuring inserted values before backup and after restore exist on all units")
@@ -340,6 +345,7 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_gcp) -> None:
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, new_mysql_application_name),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # relate to S3 integrator
@@ -350,6 +356,7 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_gcp) -> None:
             jubilant_backports.all_active, new_mysql_application_name, S3_INTEGRATOR
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # rotate all credentials
@@ -384,6 +391,7 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_gcp) -> None:
             jubilant_backports.all_active, new_mysql_application_name, S3_INTEGRATOR
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     logger.info("Waiting for blocked application status with another cluster S3 repository")
@@ -393,6 +401,7 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_gcp) -> None:
             == ANOTHER_S3_CLUSTER_REPOSITORY_ERROR_MESSAGE
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # restore the backup
@@ -452,6 +461,7 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_gcp) -> None:
             ),
         )),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     logger.info("Ensuring inserted values before backup and after restore exist on all units")
@@ -474,4 +484,5 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_gcp) -> None:
             == MOVE_RESTORED_CLUSTER_TO_ANOTHER_S3_REPOSITORY_ERROR
         ),
         timeout=TIMEOUT,
+        delay=2,
     )

--- a/kubernetes/tests/integration/integration/test_backup_gcp.py
+++ b/kubernetes/tests/integration/integration/test_backup_gcp.py
@@ -5,6 +5,7 @@
 import logging
 import socket
 from pathlib import Path
+from time import sleep
 
 import boto3
 import jubilant_backports
@@ -332,6 +333,10 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_gcp) -> None:
         trust=True,
     )
 
+    # Allow some time between deploy and status call. Avoids:
+    # ERROR getting details for storage database/0: filesystem for storage instance "database/0" not found
+    sleep(30)
+
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, new_mysql_application_name),
         timeout=TIMEOUT,
@@ -383,8 +388,10 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_gcp) -> None:
 
     logger.info("Waiting for blocked application status with another cluster S3 repository")
     juju.wait(  # Might take a few minutes to get past this
-        ready=lambda status: status.apps[new_mysql_application_name].app_status.message
-        == ANOTHER_S3_CLUSTER_REPOSITORY_ERROR_MESSAGE,
+        ready=lambda status: (
+            status.apps[new_mysql_application_name].app_status.message
+            == ANOTHER_S3_CLUSTER_REPOSITORY_ERROR_MESSAGE
+        ),
         timeout=TIMEOUT,
     )
 
@@ -462,7 +469,9 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_gcp) -> None:
 
     logger.info("Waiting for blocked application status after restore")
     juju.wait(
-        ready=lambda status: status.apps[new_mysql_application_name].app_status.message
-        == MOVE_RESTORED_CLUSTER_TO_ANOTHER_S3_REPOSITORY_ERROR,
+        ready=lambda status: (
+            status.apps[new_mysql_application_name].app_status.message
+            == MOVE_RESTORED_CLUSTER_TO_ANOTHER_S3_REPOSITORY_ERROR
+        ),
         timeout=TIMEOUT,
     )

--- a/kubernetes/tests/integration/integration/test_charm.py
+++ b/kubernetes/tests/integration/integration/test_charm.py
@@ -48,6 +48,7 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, APP_NAME),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     app_units = get_app_units(juju, APP_NAME)
@@ -92,6 +93,7 @@ def test_scale_up_from_zero(juju: Juju) -> None:
     juju.wait(
         ready=lambda status: len(status.apps[APP_NAME].units) == 0,
         timeout=TIMEOUT,
+        delay=2,
     )
 
     logger.info("Scaling back up to 3 units")

--- a/kubernetes/tests/integration/integration/test_cos_integration_bundle.py
+++ b/kubernetes/tests/integration/integration/test_cos_integration_bundle.py
@@ -44,4 +44,5 @@ def test_deploy_bundle_with_cos_integrations(juju: Juju, charm) -> None:
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, "mysql-k8s"),
         timeout=TIMEOUT,
+        delay=2,
     )

--- a/kubernetes/tests/integration/integration/test_multi_relations.py
+++ b/kubernetes/tests/integration/integration/test_multi_relations.py
@@ -142,6 +142,7 @@ def test_scale_in(juju: Juju):
 
 # All jubilant.Juju operations risk raising intermittent CLIErrors under CPU pressure,
 # so we wrap each of them
+# TODO: Try to remove when juju 3.6.15+ is out
 def retry_if_cli_error(fn, *, max_attempts=10):
     try:
         for attempt in Retrying(

--- a/kubernetes/tests/integration/integration/test_multi_relations.py
+++ b/kubernetes/tests/integration/integration/test_multi_relations.py
@@ -6,6 +6,7 @@ import jubilant_backports
 from jubilant_backports import CLIError, Juju
 from tenacity import RetryError, Retrying, retry_if_exception_type, stop_after_attempt, wait_fixed
 
+from .. import architecture
 from ..helpers_ha import CHARM_METADATA, MINUTE_SECS, wait_for_apps_status, wait_for_unit_status
 
 MYSQL_APP_NAME = "mysql"
@@ -27,6 +28,7 @@ def test_build_and_deploy(juju: Juju, charm):
         trust=True,
     )
 
+    constraints = {"arch": architecture.architecture}
     for idx in range(SCALE_APPS):
         juju.deploy(
             "mysql-test-app",
@@ -35,6 +37,7 @@ def test_build_and_deploy(juju: Juju, charm):
             channel="latest/edge",
             config={"database_name": f"database{idx}", "sleep_interval": "2000"},
             base="ubuntu@22.04",
+            constraints=constraints,
         )
         juju.deploy(
             "mysql-router-k8s",
@@ -43,6 +46,7 @@ def test_build_and_deploy(juju: Juju, charm):
             channel="8.0/edge",
             trust=True,
             base="ubuntu@22.04",
+            constraints=constraints,
         )
 
     # Wait until deployment is complete in attempt to reduce CPU stress

--- a/kubernetes/tests/integration/integration/test_osm_integration_bundle.py
+++ b/kubernetes/tests/integration/integration/test_osm_integration_bundle.py
@@ -99,6 +99,7 @@ def test_deploy_and_relate_osm_bundle(juju: Juju, charm) -> None:
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, APP_NAME, "mongodb"),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     logger.info("Waiting for all apps to have units")
@@ -110,6 +111,7 @@ def test_deploy_and_relate_osm_bundle(juju: Juju, charm) -> None:
             and len(status.apps["mongodb"].units) >= 1
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     logger.info("Relate kafka and zookeeper")
@@ -118,6 +120,7 @@ def test_deploy_and_relate_osm_bundle(juju: Juju, charm) -> None:
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, "zookeeper"),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     logger.info("Relate keystone and mysql")
@@ -128,6 +131,7 @@ def test_deploy_and_relate_osm_bundle(juju: Juju, charm) -> None:
         ready=wait_for_apps_status(jubilant_backports.all_active, APP_NAME, "osm-keystone"),
         error=wait_for_apps_status(jubilant_backports.any_error, APP_NAME, "osm-keystone"),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     logger.info("Relate osm-pol and mongo")

--- a/kubernetes/tests/integration/integration/test_saturate_max_connections.py
+++ b/kubernetes/tests/integration/integration/test_saturate_max_connections.py
@@ -53,6 +53,7 @@ def test_deploy_and_relate_test_app(juju: Juju) -> None:
     juju.wait(
         jubilant_backports.all_active,
         timeout=10 * MINUTE_SECS,
+        delay=2,
     )
 
 

--- a/kubernetes/tests/integration/integration/test_saturate_max_connections.py
+++ b/kubernetes/tests/integration/integration/test_saturate_max_connections.py
@@ -8,6 +8,7 @@ import pytest
 from jubilant_backports import Juju
 from mysql.connector.errors import OperationalError
 
+from .. import architecture
 from ..connector import create_db_connections
 from ..helpers_ha import CHARM_METADATA, MINUTE_SECS, get_app_units, get_unit_address
 
@@ -33,6 +34,7 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
 
 def test_deploy_and_relate_test_app(juju: Juju) -> None:
     config = {"auto_start_writes": False, "sleep_interval": "500"}
+    constraints = {"arch": architecture.architecture}
     logger.info("Deploying test app")
     juju.deploy(
         "mysql-test-app",
@@ -41,6 +43,7 @@ def test_deploy_and_relate_test_app(juju: Juju) -> None:
         base="ubuntu@22.04",
         config=config,
         channel="latest/edge",
+        constraints=constraints,
     )
 
     logger.info("Relating test app to mysql")

--- a/kubernetes/tests/integration/integration/test_tls.py
+++ b/kubernetes/tests/integration/integration/test_tls.py
@@ -66,6 +66,7 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, APP_NAME),
         timeout=TIMEOUT,
+        delay=2,
     )
 
 
@@ -111,6 +112,7 @@ def test_enable_tls(juju: Juju) -> None:
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, tls_app_name),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # Relate with TLS charm

--- a/kubernetes/tests/integration/release/high_availability/test_upgrade_from_stable.py
+++ b/kubernetes/tests/integration/release/high_availability/test_upgrade_from_stable.py
@@ -112,6 +112,7 @@ def deploy_stable(juju: Juju, revision: int, image: str) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -149,6 +150,7 @@ def upgrade_from_stable(juju: Juju, charm: str) -> None:
     juju.wait(
         ready=wait_for_unit_message(MYSQL_APP_NAME, mysql_upgrade_unit, "upgrade completed"),
         timeout=10 * MINUTE_SECS,
+        delay=2,
     )
 
     logging.info("Resume upgrade")
@@ -164,6 +166,7 @@ def upgrade_from_stable(juju: Juju, charm: str) -> None:
     juju.wait(
         ready=lambda status: jubilant_backports.all_active(status, MYSQL_APP_NAME),
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
     logging.info("Ensure continuous writes are incrementing")

--- a/machines/tests/integration/helpers_ha.py
+++ b/machines/tests/integration/helpers_ha.py
@@ -142,12 +142,14 @@ def scale_app_units(juju: Juju, app_name: str, num_units: int) -> None:
     juju.wait(
         ready=lambda status: len(status.apps[app_name].units) == num_units,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
     if num_units > 0:
         juju.wait(
             ready=wait_for_apps_status(jubilant_backports.all_active, app_name),
             timeout=20 * MINUTE_SECS,
+            delay=2,
         )
 
 

--- a/machines/tests/integration/integration/helpers_backups.py
+++ b/machines/tests/integration/integration/helpers_backups.py
@@ -84,6 +84,7 @@ def build_and_deploy_operations(
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, MYSQL_APPLICATION_NAME),
         timeout=15 * MINUTE_SECS,
+        delay=2,
     )
 
     logger.info("Rotating mysql credentials")
@@ -102,6 +103,7 @@ def build_and_deploy_operations(
             ),
         )),
         timeout=TIMEOUT,
+        delay=2,
     )
     juju.config(S3_INTEGRATOR, cloud_configs)
     s3_unit_name = get_app_units(juju, S3_INTEGRATOR)[0]
@@ -115,6 +117,7 @@ def build_and_deploy_operations(
             jubilant_backports.all_active, MYSQL_APPLICATION_NAME, S3_INTEGRATOR
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
     juju.integrate(MYSQL_APPLICATION_NAME, S3_INTEGRATOR)
     juju.wait(
@@ -122,6 +125,7 @@ def build_and_deploy_operations(
             jubilant_backports.all_active, MYSQL_APPLICATION_NAME, S3_INTEGRATOR
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
 
@@ -220,6 +224,7 @@ def pitr_operations(
             jubilant_backports.all_agents_idle(status, MYSQL_APPLICATION_NAME, S3_INTEGRATOR),
         )),
         timeout=TIMEOUT,
+        delay=2,
     )
     assert check_test_data_existence(first_mysql_ip, should_not_exist=[td1, td2]), (
         "test data should not exist"
@@ -236,6 +241,7 @@ def pitr_operations(
             jubilant_backports.all_agents_idle(status, MYSQL_APPLICATION_NAME, S3_INTEGRATOR),
         )),
         timeout=TIMEOUT,
+        delay=2,
     )
     assert check_test_data_existence(first_mysql_ip, should_exist=[td1, td2]), (
         "both test data should exist"
@@ -252,6 +258,7 @@ def pitr_operations(
             jubilant_backports.all_agents_idle(status, MYSQL_APPLICATION_NAME, S3_INTEGRATOR),
         )),
         timeout=TIMEOUT,
+        delay=2,
     )
     assert check_test_data_existence(first_mysql_ip, should_exist=[td1], should_not_exist=[td2]), (
         "only first test data should exist"
@@ -268,6 +275,7 @@ def pitr_operations(
             jubilant_backports.all_agents_idle(status, MYSQL_APPLICATION_NAME, S3_INTEGRATOR),
         )),
         timeout=TIMEOUT,
+        delay=2,
     )
     assert check_test_data_existence(first_mysql_ip, should_exist=[td1, td2]), (
         "both test data should exist"

--- a/machines/tests/integration/integration/high_availability/test_async_replication_upgrade.py
+++ b/machines/tests/integration/integration/high_availability/test_async_replication_upgrade.py
@@ -264,12 +264,14 @@ def run_upgrade_from_edge(juju: Juju, app_name: str, charm: str) -> None:
     juju.wait(
         ready=lambda status: jubilant_backports.any_maintenance(status, app_name),
         timeout=10 * MINUTE_SECS,
+        delay=2,
     )
 
     logging.info("Wait for upgrade to complete")
     juju.wait(
         ready=lambda status: jubilant_backports.all_active(status, app_name),
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
     logging.info("Ensure continuous writes are incrementing")

--- a/machines/tests/integration/integration/high_availability/test_primary_switchover.py
+++ b/machines/tests/integration/integration/high_availability/test_primary_switchover.py
@@ -55,6 +55,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 

--- a/machines/tests/integration/integration/high_availability/test_replication_data_consistency.py
+++ b/machines/tests/integration/integration/high_availability/test_replication_data_consistency.py
@@ -52,6 +52,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 

--- a/machines/tests/integration/integration/high_availability/test_replication_data_isolation.py
+++ b/machines/tests/integration/integration/high_availability/test_replication_data_isolation.py
@@ -51,6 +51,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -80,6 +81,7 @@ def test_cluster_data_isolation(juju: Juju, charm: str) -> None:
         ready=wait_for_apps_status(jubilant_backports.all_active, mysql_other_app_name),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
     table_name = "cluster_isolation_table"

--- a/machines/tests/integration/integration/high_availability/test_replication_logs_rotation.py
+++ b/machines/tests/integration/integration/high_availability/test_replication_logs_rotation.py
@@ -58,6 +58,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 

--- a/machines/tests/integration/integration/high_availability/test_replication_reelection.py
+++ b/machines/tests/integration/integration/high_availability/test_replication_reelection.py
@@ -54,6 +54,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -70,11 +71,13 @@ def test_kill_primary_check_reelection(juju: Juju) -> None:
     juju.wait(
         ready=lambda status: len(status.apps[MYSQL_APP_NAME].units) == 2,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, MYSQL_APP_NAME),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
     # Confirm that the new primary unit is different

--- a/machines/tests/integration/integration/high_availability/test_replication_scaling.py
+++ b/machines/tests/integration/integration/high_availability/test_replication_scaling.py
@@ -53,6 +53,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -75,11 +76,13 @@ def test_scaling_without_data_loss(juju: Juju) -> None:
     juju.wait(
         ready=lambda status: len(status.apps[MYSQL_APP_NAME].units) == 3,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, MYSQL_APP_NAME),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
     # Ensure that the data still exists in all the units

--- a/machines/tests/integration/integration/high_availability/test_replication_unit_endpoints.py
+++ b/machines/tests/integration/integration/high_availability/test_replication_unit_endpoints.py
@@ -63,6 +63,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 

--- a/machines/tests/integration/integration/high_availability/test_replication_variables.py
+++ b/machines/tests/integration/integration/high_availability/test_replication_variables.py
@@ -49,6 +49,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 

--- a/machines/tests/integration/integration/high_availability/test_self_healing_network_cut.py
+++ b/machines/tests/integration/integration/high_availability/test_self_healing_network_cut.py
@@ -69,6 +69,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -137,6 +138,7 @@ def test_network_cut(juju: Juju, continuous_writes) -> None:
     juju.wait(
         ready=wait_for_unit_status(MYSQL_APP_NAME, mysql_primary_unit, "active"),
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
     # Ensure continuous writes still incrementing for all units

--- a/machines/tests/integration/integration/high_availability/test_self_healing_process_frozen.py
+++ b/machines/tests/integration/integration/high_availability/test_self_healing_process_frozen.py
@@ -62,6 +62,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 

--- a/machines/tests/integration/integration/high_availability/test_self_healing_process_killed.py
+++ b/machines/tests/integration/integration/high_availability/test_self_healing_process_killed.py
@@ -56,6 +56,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 

--- a/machines/tests/integration/integration/high_availability/test_self_healing_restart_forceful.py
+++ b/machines/tests/integration/integration/high_availability/test_self_healing_restart_forceful.py
@@ -63,6 +63,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -97,12 +98,14 @@ def test_sst_test(juju: Juju, continuous_writes):
         juju.wait(
             ready=wait_for_unit_status(MYSQL_APP_NAME, mysql_primary_unit, "maintenance"),
             timeout=20 * MINUTE_SECS,
+            delay=2,
         )
 
         logging.info("Waiting unit to be back online")
         juju.wait(
             ready=wait_for_unit_status(MYSQL_APP_NAME, mysql_primary_unit, "active"),
             timeout=20 * MINUTE_SECS,
+            delay=2,
         )
 
     new_mysql_primary_unit = get_mysql_primary_unit(juju, MYSQL_APP_NAME)

--- a/machines/tests/integration/integration/high_availability/test_self_healing_restart_graceful.py
+++ b/machines/tests/integration/integration/high_availability/test_self_healing_restart_graceful.py
@@ -57,6 +57,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -104,6 +105,7 @@ def test_cluster_manual_rejoin(juju: Juju, continuous_writes) -> None:
     juju.wait(
         ready=wait_for_unit_status(MYSQL_APP_NAME, mysql_primary_unit, "active"),
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
     # Ensure continuous writes still incrementing for all units

--- a/machines/tests/integration/integration/high_availability/test_self_healing_stop_all.py
+++ b/machines/tests/integration/integration/high_availability/test_self_healing_stop_all.py
@@ -63,6 +63,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -112,6 +113,7 @@ def test_cluster_pause(juju: Juju, continuous_writes) -> None:
                 wait_for_unit_status(MYSQL_APP_NAME, f"{MYSQL_APP_NAME}/2", "maintenance")(status),
             )),
             timeout=20 * MINUTE_SECS,
+            delay=2,
         )
         logging.info("Waiting units to be back online")
         juju.wait(
@@ -121,6 +123,7 @@ def test_cluster_pause(juju: Juju, continuous_writes) -> None:
                 wait_for_unit_status(MYSQL_APP_NAME, f"{MYSQL_APP_NAME}/2", "active")(status),
             )),
             timeout=20 * MINUTE_SECS,
+            delay=2,
         )
 
     # Ensure continuous writes still incrementing for all units

--- a/machines/tests/integration/integration/high_availability/test_self_healing_stop_primary.py
+++ b/machines/tests/integration/integration/high_availability/test_self_healing_stop_primary.py
@@ -65,6 +65,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 

--- a/machines/tests/integration/integration/high_availability/test_upgrade.py
+++ b/machines/tests/integration/integration/high_availability/test_upgrade.py
@@ -57,6 +57,7 @@ def test_deploy_latest(juju: Juju) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -90,12 +91,14 @@ def test_upgrade_from_edge(juju: Juju, charm: str, continuous_writes) -> None:
     juju.wait(
         ready=lambda status: jubilant_backports.any_maintenance(status, MYSQL_APP_NAME),
         timeout=10 * MINUTE_SECS,
+        delay=2,
     )
 
     logging.info("Wait for upgrade to complete")
     juju.wait(
         ready=lambda status: jubilant_backports.all_active(status, MYSQL_APP_NAME),
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
     logging.info("Ensure continuous writes are incrementing")
@@ -126,6 +129,7 @@ def test_fail_and_rollback(juju: Juju, charm: str, continuous_writes) -> None:
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.any_blocked, MYSQL_APP_NAME),
         timeout=10 * MINUTE_SECS,
+        delay=2,
     )
 
     logging.info("Ensure continuous writes on all units")
@@ -141,12 +145,14 @@ def test_fail_and_rollback(juju: Juju, charm: str, continuous_writes) -> None:
     juju.wait(
         ready=lambda status: jubilant_backports.any_maintenance(status, MYSQL_APP_NAME),
         timeout=10 * MINUTE_SECS,
+        delay=2,
     )
 
     logging.info("Wait for upgrade to complete")
     juju.wait(
         ready=lambda status: jubilant_backports.all_active(status, MYSQL_APP_NAME),
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
     logging.info("Ensure continuous writes after rollback procedure")

--- a/machines/tests/integration/integration/high_availability/test_upgrade_rollback_incompat.py
+++ b/machines/tests/integration/integration/high_availability/test_upgrade_rollback_incompat.py
@@ -78,6 +78,7 @@ def test_build_and_deploy(juju: Juju, charm: str) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -114,6 +115,7 @@ def test_upgrade_to_failing(juju: Juju, charm: str, continuous_writes) -> None:
     juju.wait(
         ready=lambda status: jubilant_backports.any_maintenance(status, MYSQL_APP_NAME),
         timeout=10 * MINUTE_SECS,
+        delay=2,
     )
 
     logging.info("Get first upgrading unit")
@@ -125,6 +127,7 @@ def test_upgrade_to_failing(juju: Juju, charm: str, continuous_writes) -> None:
     juju.wait(
         ready=wait_for_unit_status(MYSQL_APP_NAME, upgrade_unit, "blocked"),
         timeout=10 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -165,10 +168,12 @@ def test_rollback(juju: Juju, charm: str, continuous_writes) -> None:
     juju.wait(
         ready=lambda status: jubilant_backports.any_maintenance(status, MYSQL_APP_NAME),
         timeout=10 * MINUTE_SECS,
+        delay=2,
     )
     juju.wait(
         ready=lambda status: jubilant_backports.all_active(status, MYSQL_APP_NAME),
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
     logging.info("Ensure rollback has taken place")

--- a/machines/tests/integration/integration/relations/test_database.py
+++ b/machines/tests/integration/integration/relations/test_database.py
@@ -58,11 +58,13 @@ def test_build_and_deploy(juju: Juju, charm):
         ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
         error=jubilant_backports.any_blocked,
         timeout=TIMEOUT,
+        delay=2,
     )
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_waiting, APPLICATION_APP_NAME),
         error=jubilant_backports.any_blocked,
         timeout=TIMEOUT,
+        delay=2,
     )
 
 
@@ -140,11 +142,13 @@ def test_relation_creation_databag(juju: Juju):
         ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
         error=jubilant_backports.any_blocked,
         timeout=TIMEOUT,
+        delay=2,
     )
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, APPLICATION_APP_NAME),
         error=jubilant_backports.any_blocked,
         timeout=TIMEOUT,
+        delay=2,
     )
 
     relation_data = get_relation_data(juju, APPLICATION_APP_NAME, DB_RELATION_NAME)
@@ -160,6 +164,7 @@ def test_relation_creation(juju: Juju):
         ready=wait_for_apps_status(jubilant_backports.all_active, *APPS),
         error=jubilant_backports.any_blocked,
         timeout=TIMEOUT,
+        delay=2,
     )
 
     relation_data = get_relation_data(juju, APPLICATION_APP_NAME, DB_RELATION_NAME)
@@ -187,6 +192,7 @@ def test_read_only_endpoints(juju: Juju):
             juju, app_name=DATABASE_APP_NAME, relation_name=DB_RELATION_NAME
         ),
         timeout=5 * MINUTE_SECS,
+        delay=2,
     )
 
     # increase the number of units
@@ -201,6 +207,7 @@ def test_read_only_endpoints(juju: Juju):
             juju, app_name=DATABASE_APP_NAME, relation_name=DB_RELATION_NAME
         ),
         timeout=5 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -212,11 +219,13 @@ def test_relation_broken(juju: Juju):
         ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
         error=jubilant_backports.any_blocked,
         timeout=TIMEOUT,
+        delay=2,
     )
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_waiting, APPLICATION_APP_NAME),
         error=jubilant_backports.any_blocked,
         timeout=TIMEOUT,
+        delay=2,
     )
 
 

--- a/machines/tests/integration/integration/relations/test_db_router.py
+++ b/machines/tests/integration/integration/relations/test_db_router.py
@@ -62,6 +62,7 @@ def test_keystone_bundle_db_router(juju: Juju, charm) -> None:
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, APP_NAME),
         timeout=SLOW_WAIT_TIMEOUT,
+        delay=2,
     )
     juju.wait(
         ready=lambda status: all((
@@ -72,10 +73,12 @@ def test_keystone_bundle_db_router(juju: Juju, charm) -> None:
             ),
         )),
         timeout=SLOW_WAIT_TIMEOUT,
+        delay=2,
     )
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_blocked, KEYSTONE_MYSQLROUTER_APP_NAME),
         timeout=SLOW_WAIT_TIMEOUT,
+        delay=2,
     )
 
     juju.integrate(f"{KEYSTONE_MYSQLROUTER_APP_NAME}:db-router", f"{APP_NAME}:db-router")
@@ -85,6 +88,7 @@ def test_keystone_bundle_db_router(juju: Juju, charm) -> None:
             jubilant_backports.all_active, KEYSTONE_APP_NAME, KEYSTONE_MYSQLROUTER_APP_NAME
         ),
         timeout=SLOW_WAIT_TIMEOUT,
+        delay=2,
     )
 
     mysql_units = get_app_units(juju, APP_NAME)
@@ -136,6 +140,7 @@ def test_keystone_bundle_db_router(juju: Juju, charm) -> None:
             ANOTHER_KEYSTONE_MYSQLROUTER_APP_NAME,
         ),
         timeout=SLOW_WAIT_TIMEOUT,
+        delay=2,
     )
 
     for unit_name in mysql_units:

--- a/machines/tests/integration/integration/relations/test_relation_mysql_legacy.py
+++ b/machines/tests/integration/integration/relations/test_relation_mysql_legacy.py
@@ -56,11 +56,13 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
         ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
         error=jubilant_backports.any_blocked,
         timeout=TIMEOUT,
+        delay=2,
     )
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_waiting, APPLICATION_APP_NAME),
         error=jubilant_backports.any_blocked,
         timeout=TIMEOUT,
+        delay=2,
     )
 
 
@@ -85,6 +87,7 @@ def test_relation_creation(juju: Juju):
         ),
         error=jubilant_backports.any_blocked,
         timeout=TIMEOUT,
+        delay=2,
     )
 
 
@@ -114,11 +117,13 @@ def test_relation_broken(juju: Juju):
         ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
         error=jubilant_backports.any_blocked,
         timeout=TIMEOUT,
+        delay=2,
     )
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_waiting, APPLICATION_APP_NAME),
         error=jubilant_backports.any_blocked,
         timeout=TIMEOUT,
+        delay=2,
     )
 
     logger.info(

--- a/machines/tests/integration/integration/relations/test_shared_db.py
+++ b/machines/tests/integration/integration/relations/test_shared_db.py
@@ -53,6 +53,7 @@ def test_keystone_bundle_shared_db(juju: Juju, charm) -> None:
         ready=wait_for_apps_status(jubilant_backports.all_active, APP_NAME),
         error=jubilant_backports.any_blocked,
         timeout=FAST_WAIT_TIMEOUT,
+        delay=2,
     )
 
     mysql_units = get_app_units(juju, APP_NAME)
@@ -109,6 +110,7 @@ def test_keystone_bundle_shared_db(juju: Juju, charm) -> None:
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, APP_NAME),
         timeout=FAST_WAIT_TIMEOUT,
+        delay=2,
     )
 
     # Scale mysql back up to 3 units
@@ -154,6 +156,7 @@ def deploy_and_relate_keystone_with_mysql(
             ),
         )),
         timeout=SLOW_WAIT_TIMEOUT,
+        delay=2,
     )
 
     # Relate keystone to mysql
@@ -163,4 +166,5 @@ def deploy_and_relate_keystone_with_mysql(
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, keystone_application_name),
         timeout=SLOW_WAIT_TIMEOUT,
+        delay=2,
     )

--- a/machines/tests/integration/integration/roles/test_database_dba_role.py
+++ b/machines/tests/integration/integration/roles/test_database_dba_role.py
@@ -51,12 +51,14 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
         timeout=TIMEOUT,
+        delay=2,
     )
     juju.wait(
         ready=wait_for_apps_status(
             jubilant_backports.all_blocked, f"{INTEGRATOR_APP_NAME}1", f"{INTEGRATOR_APP_NAME}2"
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
 
@@ -69,6 +71,7 @@ def test_charmed_dba_role(juju: Juju):
             jubilant_backports.all_active, f"{INTEGRATOR_APP_NAME}1", DATABASE_APP_NAME
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     juju.config(
@@ -81,6 +84,7 @@ def test_charmed_dba_role(juju: Juju):
             jubilant_backports.all_active, f"{INTEGRATOR_APP_NAME}2", DATABASE_APP_NAME
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     mysql_unit = get_app_units(juju, DATABASE_APP_NAME)[0]

--- a/machines/tests/integration/integration/roles/test_instance_dba_role.py
+++ b/machines/tests/integration/integration/roles/test_instance_dba_role.py
@@ -42,10 +42,12 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
         timeout=TIMEOUT,
+        delay=2,
     )
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_blocked, INTEGRATOR_APP_NAME),
         timeout=TIMEOUT,
+        delay=2,
     )
 
 
@@ -62,6 +64,7 @@ def test_charmed_dba_role(juju: Juju):
             jubilant_backports.all_active, INTEGRATOR_APP_NAME, DATABASE_APP_NAME
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     mysql_unit = get_app_units(juju, DATABASE_APP_NAME)[0]

--- a/machines/tests/integration/integration/roles/test_instance_roles.py
+++ b/machines/tests/integration/integration/roles/test_instance_roles.py
@@ -52,12 +52,14 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
         timeout=TIMEOUT,
+        delay=2,
     )
     juju.wait(
         ready=wait_for_apps_status(
             jubilant_backports.all_blocked, f"{INTEGRATOR_APP_NAME}1", f"{INTEGRATOR_APP_NAME}2"
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
 
@@ -74,6 +76,7 @@ def test_charmed_read_role(juju: Juju):
             jubilant_backports.all_active, f"{INTEGRATOR_APP_NAME}1", DATABASE_APP_NAME
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     mysql_units = get_app_units(juju, DATABASE_APP_NAME)
@@ -137,6 +140,7 @@ def test_charmed_read_role(juju: Juju):
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_blocked, f"{INTEGRATOR_APP_NAME}1"),
         timeout=TIMEOUT,
+        delay=2,
     )
 
 
@@ -151,6 +155,7 @@ def test_charmed_dml_role(juju: Juju):
             jubilant_backports.all_active, f"{INTEGRATOR_APP_NAME}1", DATABASE_APP_NAME
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     juju.config(
@@ -163,6 +168,7 @@ def test_charmed_dml_role(juju: Juju):
             jubilant_backports.all_active, f"{INTEGRATOR_APP_NAME}2", DATABASE_APP_NAME
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     mysql_unit = get_app_units(juju, DATABASE_APP_NAME)[0]
@@ -235,4 +241,5 @@ def test_charmed_dml_role(juju: Juju):
             jubilant_backports.all_blocked, f"{INTEGRATOR_APP_NAME}1", f"{INTEGRATOR_APP_NAME}2"
         ),
         timeout=TIMEOUT,
+        delay=2,
     )

--- a/machines/tests/integration/integration/spaces/test_spaced_db.py
+++ b/machines/tests/integration/integration/spaces/test_spaced_db.py
@@ -98,6 +98,8 @@ def test_integrate_with_isolated_space(juju: Juju):
         isolated_app_name,
         constraints={"spaces": "isolated"},
         bind={"database": "isolated"},
+        num_units=1,
+        base="ubuntu@22.04",
         channel="latest/edge",
     )
     juju.wait(

--- a/machines/tests/integration/integration/spaces/test_spaced_db.py
+++ b/machines/tests/integration/integration/spaces/test_spaced_db.py
@@ -48,10 +48,12 @@ def test_build_and_deploy(juju: Juju, lxd_spaces, charm) -> None:
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
         timeout=TIMEOUT,
+        delay=2,
     )
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_waiting, APPLICATION_APP_NAME),
         timeout=TIMEOUT,
+        delay=2,
     )
 
 
@@ -64,6 +66,7 @@ def test_integrate_with_spaces(juju: Juju):
     juju.wait(
         ready=jubilant_backports.all_active,
         timeout=TIMEOUT,
+        delay=2,
     )
 
     unit = get_app_units(juju, APPLICATION_APP_NAME)[0]
@@ -82,6 +85,7 @@ def test_integrate_with_spaces(juju: Juju):
     juju.wait(
         ready=lambda status: APPLICATION_APP_NAME not in status.apps,
         timeout=TIMEOUT,
+        delay=2,
     )
 
 
@@ -99,6 +103,7 @@ def test_integrate_with_isolated_space(juju: Juju):
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_waiting, isolated_app_name),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # Relate the database to the application
@@ -111,6 +116,7 @@ def test_integrate_with_isolated_space(juju: Juju):
             jubilant_backports.all_active, DATABASE_APP_NAME, isolated_app_name
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     unit = get_app_units(juju, isolated_app_name)[0]
@@ -139,4 +145,5 @@ def test_integrate_with_isolated_space(juju: Juju):
     juju.wait(
         ready=lambda status: isolated_app_name not in status.apps,
         timeout=TIMEOUT,
+        delay=2,
     )

--- a/machines/tests/integration/integration/test_architecture.py
+++ b/machines/tests/integration/integration/test_architecture.py
@@ -24,7 +24,9 @@ def test_arm_charm_on_amd_host(juju: Juju) -> None:
         base="ubuntu@22.04",
     )
 
-    juju.wait(ready=jubilant_backports.all_error, timeout=300,
+    juju.wait(
+        ready=jubilant_backports.all_error,
+        timeout=300,
         delay=2,
     )
 
@@ -42,7 +44,9 @@ def test_amd_charm_on_arm_host(juju: Juju) -> None:
         base="ubuntu@22.04",
     )
 
-    juju.wait(ready=jubilant_backports.all_error, timeout=300,
+    juju.wait(
+        ready=jubilant_backports.all_error,
+        timeout=300,
         delay=2,
     )
 

--- a/machines/tests/integration/integration/test_architecture.py
+++ b/machines/tests/integration/integration/test_architecture.py
@@ -2,6 +2,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+from time import sleep
 
 import jubilant_backports
 from jubilant_backports import Juju
@@ -23,6 +24,9 @@ def test_arm_charm_on_amd_host(juju: Juju) -> None:
         config={"profile": "testing"},
         base="ubuntu@22.04",
     )
+    # Allow some time between deploy and status call. Avoids:
+    # ERROR getting details for storage database/0: filesystem for storage instance "database/0" not found
+    sleep(30)
 
     juju.wait(
         ready=jubilant_backports.all_error,
@@ -43,6 +47,9 @@ def test_amd_charm_on_arm_host(juju: Juju) -> None:
         config={"profile": "testing"},
         base="ubuntu@22.04",
     )
+    # Allow some time between deploy and status call. Avoids:
+    # ERROR getting details for storage database/0: filesystem for storage instance "database/0" not found
+    sleep(30)
 
     juju.wait(
         ready=jubilant_backports.all_error,

--- a/machines/tests/integration/integration/test_architecture.py
+++ b/machines/tests/integration/integration/test_architecture.py
@@ -24,7 +24,9 @@ def test_arm_charm_on_amd_host(juju: Juju) -> None:
         base="ubuntu@22.04",
     )
 
-    juju.wait(ready=jubilant_backports.all_error, timeout=300)
+    juju.wait(ready=jubilant_backports.all_error, timeout=300,
+        delay=2,
+    )
 
 
 @markers.arm64_only
@@ -40,7 +42,9 @@ def test_amd_charm_on_arm_host(juju: Juju) -> None:
         base="ubuntu@22.04",
     )
 
-    juju.wait(ready=jubilant_backports.all_error, timeout=300)
+    juju.wait(ready=jubilant_backports.all_error, timeout=300,
+        delay=2,
+    )
 
 
 # TODO: add s390x test

--- a/machines/tests/integration/integration/test_backup_aws.py
+++ b/machines/tests/integration/integration/test_backup_aws.py
@@ -90,6 +90,7 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
         timeout=15 * MINUTE_SECS,
+        delay=2,
     )
 
     primary_unit_name = get_mysql_primary_unit(juju, DATABASE_APP_NAME)
@@ -113,6 +114,7 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
             ),
         )),
         timeout=TIMEOUT,
+        delay=2,
     )
 
 
@@ -159,6 +161,7 @@ def test_backup(juju: Juju, cloud_configs_aws) -> None:
             jubilant_backports.all_active, DATABASE_APP_NAME, S3_INTEGRATOR
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # list backups
@@ -226,6 +229,7 @@ def test_restore_on_same_cluster(juju: Juju, cloud_configs_aws) -> None:
             jubilant_backports.all_active, DATABASE_APP_NAME, S3_INTEGRATOR
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # restore the backup
@@ -290,6 +294,7 @@ def test_restore_on_same_cluster(juju: Juju, cloud_configs_aws) -> None:
             ),
         )),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     logger.info("Ensuring inserted values before backup and after restore exist on all units")
@@ -336,6 +341,7 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_aws) -> None:
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, new_mysql_application_name),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # relate to S3 integrator
@@ -346,6 +352,7 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_aws) -> None:
             jubilant_backports.all_active, new_mysql_application_name, S3_INTEGRATOR
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # rotate all credentials
@@ -380,6 +387,7 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_aws) -> None:
             jubilant_backports.all_active, new_mysql_application_name, S3_INTEGRATOR
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     logger.info("Waiting for blocked application status with another cluster S3 repository")
@@ -387,6 +395,7 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_aws) -> None:
         ready=lambda status: status.apps[new_mysql_application_name].app_status.message
         == ANOTHER_S3_CLUSTER_REPOSITORY_ERROR_MESSAGE,
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # restore the backup
@@ -440,4 +449,5 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_aws) -> None:
         ready=lambda status: status.apps[new_mysql_application_name].app_status.message
         == MOVE_RESTORED_CLUSTER_TO_ANOTHER_S3_REPOSITORY_ERROR,
         timeout=TIMEOUT,
+        delay=2,
     )

--- a/machines/tests/integration/integration/test_backup_ceph.py
+++ b/machines/tests/integration/integration/test_backup_ceph.py
@@ -180,6 +180,7 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
         timeout=15 * MINUTE_SECS,
+        delay=2,
     )
 
     primary_unit_name = get_mysql_primary_unit(juju, DATABASE_APP_NAME)
@@ -203,6 +204,7 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
             ),
         )),
         timeout=TIMEOUT,
+        delay=2,
     )
 
 
@@ -249,6 +251,7 @@ def test_backup(juju: Juju, cloud_configs_ceph) -> None:
             jubilant_backports.all_active, DATABASE_APP_NAME, S3_INTEGRATOR
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # list backups
@@ -316,6 +319,7 @@ def test_restore_on_same_cluster(juju: Juju, cloud_configs_ceph) -> None:
             jubilant_backports.all_active, DATABASE_APP_NAME, S3_INTEGRATOR
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # restore the backup
@@ -380,6 +384,7 @@ def test_restore_on_same_cluster(juju: Juju, cloud_configs_ceph) -> None:
             ),
         )),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     logger.info("Ensuring inserted values before backup and after restore exist on all units")
@@ -427,6 +432,7 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_ceph) -> None:
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, new_mysql_application_name),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # relate to S3 integrator
@@ -437,6 +443,7 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_ceph) -> None:
             jubilant_backports.all_active, new_mysql_application_name, S3_INTEGRATOR
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # rotate all credentials
@@ -471,6 +478,7 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_ceph) -> None:
             jubilant_backports.all_active, new_mysql_application_name, S3_INTEGRATOR
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     logger.info("Waiting for blocked application status with another cluster S3 repository")
@@ -478,6 +486,7 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_ceph) -> None:
         ready=lambda status: status.apps[new_mysql_application_name].app_status.message
         == ANOTHER_S3_CLUSTER_REPOSITORY_ERROR_MESSAGE,
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # restore the backup
@@ -531,4 +540,5 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_ceph) -> None:
         ready=lambda status: status.apps[new_mysql_application_name].app_status.message
         == MOVE_RESTORED_CLUSTER_TO_ANOTHER_S3_REPOSITORY_ERROR,
         timeout=TIMEOUT,
+        delay=2,
     )

--- a/machines/tests/integration/integration/test_backup_gcp.py
+++ b/machines/tests/integration/integration/test_backup_gcp.py
@@ -90,6 +90,7 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
         timeout=15 * MINUTE_SECS,
+        delay=2,
     )
 
     primary_unit_name = get_mysql_primary_unit(juju, DATABASE_APP_NAME)
@@ -113,6 +114,7 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
             ),
         )),
         timeout=TIMEOUT,
+        delay=2,
     )
 
 
@@ -159,6 +161,7 @@ def test_backup(juju: Juju, cloud_configs_gcp) -> None:
             jubilant_backports.all_active, DATABASE_APP_NAME, S3_INTEGRATOR
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # list backups
@@ -226,6 +229,7 @@ def test_restore_on_same_cluster(juju: Juju, cloud_configs_gcp) -> None:
             jubilant_backports.all_active, DATABASE_APP_NAME, S3_INTEGRATOR
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # restore the backup
@@ -290,6 +294,7 @@ def test_restore_on_same_cluster(juju: Juju, cloud_configs_gcp) -> None:
             ),
         )),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     logger.info("Ensuring inserted values before backup and after restore exist on all units")
@@ -332,6 +337,7 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_gcp) -> None:
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, new_mysql_application_name),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # A race condition in Juju 2.9 makes `juju.wait` fail if called too early
@@ -346,6 +352,7 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_gcp) -> None:
             jubilant_backports.all_active, new_mysql_application_name, S3_INTEGRATOR
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # rotate all credentials
@@ -380,6 +387,7 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_gcp) -> None:
             jubilant_backports.all_active, new_mysql_application_name, S3_INTEGRATOR
         ),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     logger.info("Waiting for blocked application status with another cluster S3 repository")
@@ -387,6 +395,7 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_gcp) -> None:
         ready=lambda status: status.apps[new_mysql_application_name].app_status.message
         == ANOTHER_S3_CLUSTER_REPOSITORY_ERROR_MESSAGE,
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # restore the backup
@@ -440,4 +449,5 @@ def test_restore_on_new_cluster(juju: Juju, charm, cloud_configs_gcp) -> None:
         ready=lambda status: status.apps[new_mysql_application_name].app_status.message
         == MOVE_RESTORED_CLUSTER_TO_ANOTHER_S3_REPOSITORY_ERROR,
         timeout=TIMEOUT,
+        delay=2,
     )

--- a/machines/tests/integration/integration/test_saturate_max_connections.py
+++ b/machines/tests/integration/integration/test_saturate_max_connections.py
@@ -49,6 +49,7 @@ def test_deploy_and_relate_test_app(juju: Juju) -> None:
     juju.wait(
         jubilant_backports.all_active,
         timeout=10 * MINUTE_SECS,
+        delay=2,
     )
 
 

--- a/machines/tests/integration/integration/test_subordinate_charms.py
+++ b/machines/tests/integration/integration/test_subordinate_charms.py
@@ -45,6 +45,7 @@ def test_ubuntu_pro(juju: Juju, charm):
     juju.wait(
         jubilant_backports.all_active,
         timeout=TIMEOUT,
+        delay=2,
     )
 
 
@@ -65,4 +66,5 @@ def test_landscape_client(juju: Juju):
     juju.wait(
         jubilant_backports.all_active,
         timeout=TIMEOUT,
+        delay=2,
     )

--- a/machines/tests/integration/integration/test_tls.py
+++ b/machines/tests/integration/integration/test_tls.py
@@ -63,6 +63,7 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, APP_NAME),
         timeout=TIMEOUT,
+        delay=2,
     )
 
 
@@ -108,6 +109,7 @@ def test_enable_tls(juju: Juju) -> None:
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, tls_app_name),
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # Relate with TLS charm
@@ -122,6 +124,7 @@ def test_enable_tls(juju: Juju) -> None:
     juju.wait(
         jubilant_backports.all_active,
         timeout=TIMEOUT,
+        delay=2,
     )
 
     # After relating to only encrypted connection should be possible

--- a/machines/tests/integration/integration/test_vm_reboot.py
+++ b/machines/tests/integration/integration/test_vm_reboot.py
@@ -36,6 +36,7 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     juju.wait(
         jubilant_backports.all_active,
         timeout=TIMEOUT,
+        delay=2,
     )
 
 
@@ -54,6 +55,7 @@ def test_reboot_1_of_3_units(juju: Juju) -> None:
     juju.wait(
         jubilant_backports.all_active,
         timeout=TIMEOUT,
+        delay=2,
     )
 
 
@@ -72,6 +74,7 @@ def test_reboot_2_of_3_units(juju: Juju) -> None:
     juju.wait(
         jubilant_backports.all_active,
         timeout=TIMEOUT,
+        delay=2,
     )
 
 
@@ -90,6 +93,7 @@ def test_reboot_3_of_3_units(juju: Juju) -> None:
     juju.wait(
         jubilant_backports.all_active,
         timeout=TIMEOUT,
+        delay=2,
     )
 
 

--- a/machines/tests/integration/release/high_availability/test_upgrade_from_stable.py
+++ b/machines/tests/integration/release/high_availability/test_upgrade_from_stable.py
@@ -103,6 +103,7 @@ def deploy_stable(juju: Juju, revision: int) -> None:
         ),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
 
@@ -130,12 +131,14 @@ async def upgrade_from_stable(juju: Juju, charm: str) -> None:
     juju.wait(
         ready=lambda status: jubilant_backports.any_maintenance(status, MYSQL_APP_NAME),
         timeout=10 * MINUTE_SECS,
+        delay=2,
     )
 
     logging.info("Wait for upgrade to complete")
     juju.wait(
         ready=lambda status: jubilant_backports.all_active(status, MYSQL_APP_NAME),
         timeout=20 * MINUTE_SECS,
+        delay=2,
     )
 
     logging.info("Ensure continuous writes are incrementing")


### PR DESCRIPTION
This PR proposes couple fixes from observed behavior:
* add missing `trust` on k8s - though not always relevant, keeps it consistent
* add architecture constraints to router/test-app - when missing, juju might select wrong revision/arch on k8s - resulting in test timeout due to app pod(s) never being scheduled, as it will have a architecture bound node affinity rule
* increased default `juju.wait` calls delay from 1sec to 2sec - mitigate test failure due cli errors, more present since juju 3.6.14
* adds a sleep between some `juju.deploy` and `juju.wait` - mitigate the infamous `filesystem for storage instance "database/x" not found` error
* 
* ~~attempt to remove the `retry_on_cli_error` wrapper on k8s multi relations test~~
* ~~and last but no least, fix test_spaced_db by setting bases for the isolated mysql-test-app, as incorrect bases is pick when not set.~~

Generally, I've observed that failed tests on first run decreased from ~25 to ~15, with the remaining failures related to the cli errors, some setup errors and the remaining, due to timeouts.