### PR TITLE
[DPE-7896] Switch to MySQL Router 8.4

### DIFF
--- a/kubernetes/src/relations/mysql_provider.py
+++ b/kubernetes/src/relations/mysql_provider.py
@@ -139,6 +139,7 @@ class MySQLProvider(Object):
         ) as e:
             logger.exception("Failed to set up database relation", exc_info=e)
             self.charm.unit.status = BlockedStatus("Failed to create scoped user")
+            return
 
         try:
             # create k8s services for endpoints
@@ -158,6 +159,7 @@ class MySQLProvider(Object):
                 "Permission to create k8s services denied. `juju trust`"
             )
             event.defer()
+            return
 
         # Set relation data
         self.database.set_endpoints(relation_id, f"{primary_endpoint}:3306")

--- a/kubernetes/tests/integration/integration/high_availability/test_async_replication.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_async_replication.py
@@ -141,8 +141,8 @@ def test_deploy_router_and_app(first_model: str) -> None:
     model_1.deploy(
         charm=MYSQL_ROUTER_NAME,
         app=MYSQL_ROUTER_NAME,
-        base="ubuntu@22.04",
-        channel="8.0/edge",
+        base="ubuntu@24.04",
+        channel="8.4/edge",
         num_units=1,
         trust=True,
     )

--- a/kubernetes/tests/integration/integration/high_availability/test_async_replication.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_async_replication.py
@@ -149,7 +149,7 @@ def test_deploy_router_and_app(first_model: str) -> None:
     model_1.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         num_units=1,
         trust=False,

--- a/kubernetes/tests/integration/integration/high_availability/test_async_replication_upgrade.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_async_replication_upgrade.py
@@ -143,7 +143,7 @@ def test_deploy_test_app(first_model: str) -> None:
     model_1.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         num_units=1,
     )

--- a/kubernetes/tests/integration/integration/high_availability/test_primary_switchover.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_primary_switchover.py
@@ -39,7 +39,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         config={"sleep_interval": 300},
         num_units=1,

--- a/kubernetes/tests/integration/integration/high_availability/test_replication_data_consistency.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_replication_data_consistency.py
@@ -36,7 +36,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         config={"sleep_interval": 300},
         num_units=1,

--- a/kubernetes/tests/integration/integration/high_availability/test_replication_data_isolation.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_replication_data_isolation.py
@@ -34,7 +34,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         config={"sleep_interval": 300},
         num_units=1,

--- a/kubernetes/tests/integration/integration/high_availability/test_replication_logs_rotation.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_replication_logs_rotation.py
@@ -45,7 +45,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         config={"sleep_interval": 300},
         num_units=1,

--- a/kubernetes/tests/integration/integration/high_availability/test_replication_reelection.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_replication_reelection.py
@@ -38,7 +38,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         config={"sleep_interval": 300},
         num_units=1,

--- a/kubernetes/tests/integration/integration/high_availability/test_replication_scaling.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_replication_scaling.py
@@ -36,7 +36,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         config={"sleep_interval": 300},
         num_units=1,

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_network_cut.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_network_cut.py
@@ -43,7 +43,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         config={"sleep_interval": 300},
         num_units=1,

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_node_drain.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_node_drain.py
@@ -40,7 +40,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         config={"sleep_interval": 300},
         num_units=1,

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_pod.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_pod.py
@@ -38,7 +38,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         config={"sleep_interval": 300},
         num_units=1,

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_process_frozen.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_process_frozen.py
@@ -45,7 +45,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         config={"sleep_interval": 300},
         num_units=1,

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_process_killed.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_process_killed.py
@@ -44,7 +44,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         config={"sleep_interval": 300},
         num_units=1,

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_restart_graceful.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_restart_graceful.py
@@ -40,7 +40,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         config={"sleep_interval": 300},
         num_units=1,

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_stop_all.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_stop_all.py
@@ -38,7 +38,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         config={"sleep_interval": 300},
         num_units=1,

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_stop_primary.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_stop_primary.py
@@ -38,7 +38,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         config={"sleep_interval": 300},
         num_units=1,

--- a/kubernetes/tests/integration/integration/high_availability/test_upgrade.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_upgrade.py
@@ -47,7 +47,7 @@ def test_deploy_latest(juju: Juju) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         num_units=1,
         trust=False,

--- a/kubernetes/tests/integration/integration/high_availability/test_upgrade_from_stable.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_upgrade_from_stable.py
@@ -41,7 +41,7 @@ def test_deploy_stable(juju: Juju) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         num_units=1,
         trust=False,

--- a/kubernetes/tests/integration/release/high_availability/test_upgrade_from_stable.py
+++ b/kubernetes/tests/integration/release/high_availability/test_upgrade_from_stable.py
@@ -94,7 +94,7 @@ def deploy_stable(juju: Juju, revision: int, image: str) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         num_units=1,
         trust=False,

--- a/machines/src/relations/mysql_provider.py
+++ b/machines/src/relations/mysql_provider.py
@@ -241,6 +241,7 @@ class MySQLProvider(Object):
                 "%",
                 extra_roles=extra_user_roles,
             )
+
             db_version = self.charm._mysql.get_mysql_version()
         except (
             MySQLCreateApplicationDatabaseError,
@@ -249,6 +250,7 @@ class MySQLProvider(Object):
         ) as e:
             logger.exception("Failed to set up database relation", exc_info=e)
             self.charm.unit.status = BlockedStatus("Failed to set up relation")
+            return
 
         rw_endpoints, ro_endpoints, _ = self.charm.get_cluster_endpoints(DB_RELATION_NAME)
         self.database.set_database(relation_id, db_name)

--- a/machines/tests/integration/integration/high_availability/test_async_replication.py
+++ b/machines/tests/integration/integration/high_availability/test_async_replication.py
@@ -142,7 +142,7 @@ def test_deploy_router_and_app(first_model: str) -> None:
     model_1.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         num_units=1,
         trust=False,

--- a/machines/tests/integration/integration/high_availability/test_async_replication.py
+++ b/machines/tests/integration/integration/high_availability/test_async_replication.py
@@ -134,8 +134,8 @@ def test_deploy_router_and_app(first_model: str) -> None:
     model_1.deploy(
         charm=MYSQL_ROUTER_NAME,
         app=MYSQL_ROUTER_NAME,
-        base="ubuntu@22.04",
-        channel="dpe/edge",
+        base="ubuntu@24.04",
+        channel="8.4/edge",
         num_units=1,
         trust=True,
     )

--- a/machines/tests/integration/integration/high_availability/test_async_replication_upgrade.py
+++ b/machines/tests/integration/integration/high_availability/test_async_replication_upgrade.py
@@ -135,7 +135,7 @@ def test_deploy_test_app(first_model: str) -> None:
     model_1.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         num_units=1,
     )

--- a/machines/tests/integration/integration/high_availability/test_primary_switchover.py
+++ b/machines/tests/integration/integration/high_availability/test_primary_switchover.py
@@ -37,7 +37,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         config={"sleep_interval": 500},
         num_units=1,

--- a/machines/tests/integration/integration/high_availability/test_replication_data_consistency.py
+++ b/machines/tests/integration/integration/high_availability/test_replication_data_consistency.py
@@ -34,7 +34,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         config={"sleep_interval": 500},
         num_units=1,

--- a/machines/tests/integration/integration/high_availability/test_replication_data_isolation.py
+++ b/machines/tests/integration/integration/high_availability/test_replication_data_isolation.py
@@ -32,7 +32,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         config={"sleep_interval": 500},
         num_units=1,

--- a/machines/tests/integration/integration/high_availability/test_replication_logs_rotation.py
+++ b/machines/tests/integration/integration/high_availability/test_replication_logs_rotation.py
@@ -40,7 +40,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         config={"sleep_interval": 500},
         num_units=1,

--- a/machines/tests/integration/integration/high_availability/test_replication_reelection.py
+++ b/machines/tests/integration/integration/high_availability/test_replication_reelection.py
@@ -36,7 +36,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         config={"sleep_interval": 500},
         num_units=1,

--- a/machines/tests/integration/integration/high_availability/test_replication_scaling.py
+++ b/machines/tests/integration/integration/high_availability/test_replication_scaling.py
@@ -35,7 +35,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         config={"sleep_interval": 500},
         num_units=1,

--- a/machines/tests/integration/integration/high_availability/test_replication_unit_endpoints.py
+++ b/machines/tests/integration/integration/high_availability/test_replication_unit_endpoints.py
@@ -45,7 +45,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         config={"sleep_interval": 500},
         num_units=1,

--- a/machines/tests/integration/integration/high_availability/test_replication_variables.py
+++ b/machines/tests/integration/integration/high_availability/test_replication_variables.py
@@ -31,7 +31,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         config={"sleep_interval": 500},
         num_units=1,

--- a/machines/tests/integration/integration/high_availability/test_self_healing_network_cut.py
+++ b/machines/tests/integration/integration/high_availability/test_self_healing_network_cut.py
@@ -51,7 +51,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         config={"sleep_interval": 500},
         num_units=1,

--- a/machines/tests/integration/integration/high_availability/test_self_healing_process_frozen.py
+++ b/machines/tests/integration/integration/high_availability/test_self_healing_process_frozen.py
@@ -44,7 +44,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         config={"sleep_interval": 500},
         num_units=1,

--- a/machines/tests/integration/integration/high_availability/test_self_healing_process_killed.py
+++ b/machines/tests/integration/integration/high_availability/test_self_healing_process_killed.py
@@ -38,7 +38,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         config={"sleep_interval": 500},
         num_units=1,

--- a/machines/tests/integration/integration/high_availability/test_self_healing_restart_forceful.py
+++ b/machines/tests/integration/integration/high_availability/test_self_healing_restart_forceful.py
@@ -45,7 +45,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         config={"sleep_interval": 500},
         num_units=1,

--- a/machines/tests/integration/integration/high_availability/test_self_healing_restart_graceful.py
+++ b/machines/tests/integration/integration/high_availability/test_self_healing_restart_graceful.py
@@ -39,7 +39,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         config={"sleep_interval": 500},
         num_units=1,

--- a/machines/tests/integration/integration/high_availability/test_self_healing_stop_all.py
+++ b/machines/tests/integration/integration/high_availability/test_self_healing_stop_all.py
@@ -45,7 +45,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         config={"sleep_interval": 500},
         num_units=1,

--- a/machines/tests/integration/integration/high_availability/test_self_healing_stop_primary.py
+++ b/machines/tests/integration/integration/high_availability/test_self_healing_stop_primary.py
@@ -47,7 +47,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         config={"sleep_interval": 500},
         num_units=1,

--- a/machines/tests/integration/integration/high_availability/test_upgrade.py
+++ b/machines/tests/integration/integration/high_availability/test_upgrade.py
@@ -40,7 +40,7 @@ def test_deploy_latest(juju: Juju) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         num_units=1,
     )

--- a/machines/tests/integration/integration/high_availability/test_upgrade_rollback_incompat.py
+++ b/machines/tests/integration/integration/high_availability/test_upgrade_rollback_incompat.py
@@ -60,7 +60,7 @@ def test_build_and_deploy(juju: Juju, charm: str) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         config={"auto_start_writes": False, "sleep_interval": 500},
         num_units=1,

--- a/machines/tests/integration/release/high_availability/test_upgrade_from_stable.py
+++ b/machines/tests/integration/release/high_availability/test_upgrade_from_stable.py
@@ -86,7 +86,7 @@ def deploy_stable(juju: Juju, revision: int) -> None:
     juju.deploy(
         charm=MYSQL_TEST_APP_NAME,
         app=MYSQL_TEST_APP_NAME,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
         channel="latest/edge",
         num_units=1,
     )


### PR DESCRIPTION
This PR switches the default channel for MySQL Router within the integration tests to target `8.4/edge`.

When making this change, and given the _subordinate nature_ of the MySQL Router VM operator, we also needed to bump the base of the MySQL Test app to use the Ubuntu 24.04 one. So, instead of doing so in a single test, I am doing that across the board.

---

Depends on the publication of MySQL Router to the `8.4/edge` channel.