### PR TITLE
[MISC] Logging improvements

### DIFF
--- a/kubernetes/tests/integration/conftest.py
+++ b/kubernetes/tests/integration/conftest.py
@@ -10,6 +10,8 @@ import pytest
 
 from . import architecture
 
+logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
+
 
 def pytest_configure(config):
     """Configure pytest logging format with timestamps."""
@@ -21,9 +23,6 @@ def pytest_configure(config):
         "%(asctime)s %(levelname)-8s %(name)s:%(filename)s:%(lineno)d %(message)s"
     )
     config.option.log_date_format = "%b %d %H:%M:%S"
-
-
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
 
 
 @pytest.fixture(scope="session")

--- a/machines/tests/integration/conftest.py
+++ b/machines/tests/integration/conftest.py
@@ -13,6 +13,18 @@ from . import architecture
 logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
 
 
+def pytest_configure(config):
+    """Configure pytest logging format with timestamps."""
+    config.option.log_cli_format = (
+        "%(asctime)s %(levelname)-8s %(name)s:%(filename)s:%(lineno)d %(message)s"
+    )
+    config.option.log_cli_date_format = "%b %d %H:%M:%S"
+    config.option.log_format = (
+        "%(asctime)s %(levelname)-8s %(name)s:%(filename)s:%(lineno)d %(message)s"
+    )
+    config.option.log_date_format = "%b %d %H:%M:%S"
+
+
 @pytest.fixture(scope="session")
 def charm():
     # Return str instead of pathlib.Path since python-libjuju's model.deploy(), juju deploy, and


### PR DESCRIPTION
## Issue

- As pointed out in https://github.com/canonical/mysql-operators/pull/79#discussion_r2832351609, #90 already added some logging, but only to one of the substrates. I contend that this is a worthy addition, so I'm adding it in the other one.
- ~~To the extent that we're keeping the snowflake Juju retry in `test_multi_relations.py` for now, added some extra diagnostics information that can be valuable for debugging.~~

## Solution

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
