### PR TITLE
[MISC] Fix scheduled allure results

### DIFF
--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -95,7 +95,8 @@ jobs:
         uses: actions/download-artifact@v5
         with:
           path: allure-default-results/
-          name: allure-default-results-integration-test
+          pattern: allure-default-results-integration-test-*
+          merge-multiple: true
       - name: Download test results
         uses: actions/download-artifact@v5
         with:


### PR DESCRIPTION
This PR fixes the scheduled allure results publication, failing since we migrated to the mono-repo setup. See:

- MySQL Server last failing [CI job](https://github.com/canonical/mysql-operators/actions/runs/22377864518/job/64775430310).
- MySQL Router equivalent [snippet](https://github.com/canonical/mysql-router-operators/blob/39ffbe50e88ce98c0dfa6efa9cc16fdbac1f27e4/.github/workflows/integration_test_charms.yaml#L62-L66).
