### PR TITLE
Add HTML meta descriptions to all docs

### DIFF
--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Understand the architecture of Charmed MySQL for VM and Kubernetes deployments, built on the charmed-mysql snap and MySQL InnoDB ClusterSet."
+---
+
 (architecture)=
 # Architecture
 

--- a/docs/explanation/flowcharts.md
+++ b/docs/explanation/flowcharts.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Explore Mermaid flowchart diagrams illustrating the Charmed MySQL charm lifecycle, including leader election and pebble ready hook events."
+---
+
 (flowcharts)=
 # Charm lifecycle flowcharts
 

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Conceptual documentation for Charmed MySQL covering architecture, Juju integration, users, roles, logs, security, and key interfaces."
+---
+
 (explanation)=
 # Explanation
 

--- a/docs/explanation/interfaces-and-endpoints.md
+++ b/docs/explanation/interfaces-and-endpoints.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Reference for Charmed MySQL interfaces and endpoints, including mysql_client and legacy mysql, mysql-shared, and mysql-router interfaces."
+---
+
 (interfaces-and-endpoints)=
 # Interfaces and endpoints
 

--- a/docs/explanation/juju.md
+++ b/docs/explanation/juju.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Understand how Juju orchestrates Charmed MySQL and learn about command differences between Juju 2.9 and Juju 3.x relevant to this documentation."
+---
+
 (juju)=
 # Juju 
 

--- a/docs/explanation/legacy-charm.md
+++ b/docs/explanation/legacy-charm.md
@@ -1,5 +1,8 @@
 ---
 relatedlinks: "[Charm&#32generations](https://documentation.ubuntu.com/charmcraft/stable/)"
+myst:
+  html_meta:
+    description: "Learn about legacy MySQL and MariaDB charms, their history, and how to migrate from them to the modern Charmed MySQL operator."
 ---
 
 (legacy-charm)=

--- a/docs/explanation/logs/audit-logs.md
+++ b/docs/explanation/logs/audit-logs.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Understand how the Audit Log plugin works in Charmed MySQL, including output samples, storage paths, rotation frequency, and configuration options."
+---
+
 (audit-logs)=
 # Audit logs
 

--- a/docs/explanation/logs/index.md
+++ b/docs/explanation/logs/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn about Charmed MySQL logging: audit logs, error logs, log rotation configuration, and storage locations for VM and K8s deployments."
+---
+
 (logs)=
 # Logs
 

--- a/docs/explanation/roles.md
+++ b/docs/explanation/roles.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: "Reference for predefined database roles in Charmed MySQL, including charmed_backup, charmed_dba, charmed_router, and other custom MySQL roles."
+    description: "Reference for predefined roles in Charmed MySQL, including charmed_backup, charmed_dba, charmed_router, and other custom MySQL roles."
 ---
 
 (roles)=

--- a/docs/explanation/roles.md
+++ b/docs/explanation/roles.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Reference for predefined database roles in Charmed MySQL, including charmed_backup, charmed_dba, charmed_router, and other custom MySQL roles."
+---
+
 (roles)=
 # Roles
 

--- a/docs/explanation/security/cryptography.md
+++ b/docs/explanation/security/cryptography.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn about cryptographic mechanisms in Charmed MySQL including resource verification, signed commits, and TLS encryption for cluster connections."
+---
+
 (cryptography)=
 # Cryptography
 

--- a/docs/explanation/security/index.md
+++ b/docs/explanation/security/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Security hardening guide for Charmed MySQL covering cloud environments, Juju security, OS hardening, encryption, authentication, and monitoring."
+---
+
 (security-hardening)=
 # Security hardening
 

--- a/docs/explanation/users.md
+++ b/docs/explanation/users.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Understand the types of MySQL users in Charmed MySQL: internal operator users and relation users created for integrated applications."
+---
+
 (users)=
 # Users
 

--- a/docs/how-to/back-up-and-restore/configure-s3-aws.md
+++ b/docs/how-to/back-up-and-restore/configure-s3-aws.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Configure the s3-integrator charm for AWS S3 to enable Charmed MySQL backups, including credentials, bucket setup, and application integration."
+---
+
 (configure-s3-aws)=
 # Configure S3 for AWS
 

--- a/docs/how-to/back-up-and-restore/configure-s3-radosgw.md
+++ b/docs/how-to/back-up-and-restore/configure-s3-radosgw.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Configure the s3-integrator charm to use Ceph RadosGW S3-compatible storage for Charmed MySQL backups using the MinIO client."
+---
+
 (configure-s3-radosgw)=
 # Configure S3 for RadosGW
 

--- a/docs/how-to/back-up-and-restore/create-a-backup.md
+++ b/docs/how-to/back-up-and-restore/create-a-backup.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Create and manage Charmed MySQL backups using the create-backup Juju action, with cluster state validation and force override option."
+---
+
 (create-a-backup)=
 # How to create a backup
 

--- a/docs/how-to/back-up-and-restore/index.md
+++ b/docs/how-to/back-up-and-restore/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How-to guides for backing up and restoring Charmed MySQL, covering S3 configuration, creating backups, restoring, and cluster migration."
+---
+
 (back-up-and-restore)=
 # How to back up and restore
 

--- a/docs/how-to/back-up-and-restore/migrate-a-cluster.md
+++ b/docs/how-to/back-up-and-restore/migrate-a-cluster.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Migrate a Charmed MySQL cluster by restoring a backup from a source cluster to a new cluster, including password synchronization steps."
+---
+
 (migrate-a-cluster)=
 # How to migrate a cluster
 

--- a/docs/how-to/back-up-and-restore/restore-a-backup.md
+++ b/docs/how-to/back-up-and-restore/restore-a-backup.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Restore a Charmed MySQL backup from S3 storage by listing available backups and running the restore Juju action, with point-in-time recovery notes."
+---
+
 (restore-a-backup)=
 # How to restore a local backup
 

--- a/docs/how-to/charm-development/index.md
+++ b/docs/how-to/charm-development/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Charm development guides for integrating with Charmed MySQL and migrating data using mysqldump, mydumper, or backup/restore methods."
+---
+
 (charm-development)=
 # Charm development
 

--- a/docs/how-to/charm-development/integrate-with-your-charm.md
+++ b/docs/how-to/charm-development/integrate-with-your-charm.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Integrate your Juju charm with Charmed MySQL using data-platform-libs, supported interfaces, and mysql-test-app as a reference implementation."
+---
+
 (integrate-with-your-charm)=
 # How to integrate a database with your charm
 

--- a/docs/how-to/charm-development/migrate-data-via-backup-restore.md
+++ b/docs/how-to/charm-development/migrate-data-via-backup-restore.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Migrate database data to Charmed MySQL using Percona XtraBackup and S3 storage, applicable to legacy charm migrations and external MySQL imports."
+---
+
 (migrate-data-backup-restore)=
 # How to migrate data via backup/restore
 

--- a/docs/how-to/charm-development/migrate-data-via-mydumper.md
+++ b/docs/how-to/charm-development/migrate-data-via-mydumper.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Migrate MySQL data using mydumper and myloader: install tools, dump from source with serverconfig credentials, and import into Charmed MySQL."
+---
+
 (migrate-data-mydumper)=
 # Migrate data via mydumper
 

--- a/docs/how-to/charm-development/migrate-data-via-mysqldump.md
+++ b/docs/how-to/charm-development/migrate-data-via-mysqldump.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Migrate database data from legacy MySQL or MariaDB charms to modern Charmed MySQL using mysqldump, with environment preparation and migration checks."
+---
+
 (migrate-data-mysqldump)=
 # Migrate database data via `mysqldump`
 

--- a/docs/how-to/cluster-cluster-replication/clients.md
+++ b/docs/how-to/cluster-cluster-replication/clients.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Connect client applications to a Charmed MySQL cluster-cluster replication setup by offering and consuming database endpoints across Juju models."
+---
+
 (cluster-cluster-clients)=
 # Clients
 

--- a/docs/how-to/cluster-cluster-replication/deploy.md
+++ b/docs/how-to/cluster-cluster-replication/deploy.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Deploy two MySQL clusters for cluster-to-cluster async replication by configuring ClusterSet endpoints to link primary and standby clusters."
+---
+
 (cluster-cluster-deploy)=
 # Deploy
 

--- a/docs/how-to/cluster-cluster-replication/index.md
+++ b/docs/how-to/cluster-cluster-replication/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Overview of Charmed MySQL cluster-to-cluster async replication (ClusterSet) for disaster recovery, with links to deploy, failover, and recovery guides."
+---
+
 (cluster-cluster-replication)=
 # Cluster-cluster replication
 

--- a/docs/how-to/cluster-cluster-replication/recovery.md
+++ b/docs/how-to/cluster-cluster-replication/recovery.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Recover a Charmed MySQL ClusterSet from failure scenarios including detached clusters, lost clusters, and invalidated replication states."
+---
+
 (cluster-cluster-recovery)=
 # Recovery
 

--- a/docs/how-to/cluster-cluster-replication/removal.md
+++ b/docs/how-to/cluster-cluster-replication/removal.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Remove or detach a Charmed MySQL cluster from a ClusterSet, with options to rejoin, permanently remove, or recreate as a standalone cluster."
+---
+
 (cluster-cluster-removal)=
 # Removal
 

--- a/docs/how-to/cluster-cluster-replication/switchover-failover.md
+++ b/docs/how-to/cluster-cluster-replication/switchover-failover.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Perform a planned switchover or emergency failover for Charmed MySQL ClusterSet to promote a standby cluster to primary."
+---
+
 (cluster-cluster-switchover-failover)=
 # Switchover / Failover
 

--- a/docs/how-to/contribute.md
+++ b/docs/how-to/contribute.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to contribute to Charmed MySQL by reporting bugs, submitting code changes, and providing documentation feedback via GitHub and Matrix."
+---
+
 (contribute)=
 # How to contribute
 

--- a/docs/how-to/deploy/airgapped.md
+++ b/docs/how-to/deploy/airgapped.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Deploy Charmed MySQL in an offline or airgapped environment without internet access using Juju 3 and locally available resources."
+---
+
 (airgapped)=
 # Deploy in an offline or airgapped environment
 

--- a/docs/how-to/deploy/index.md
+++ b/docs/how-to/deploy/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Deploy Charmed MySQL via Juju CLI or Terraform on VM or Kubernetes clouds, with guides for multi-AZ and airgapped environments."
+---
+
 (deploy)=
 # How to deploy MySQL
 

--- a/docs/how-to/deploy/juju-spaces.md
+++ b/docs/how-to/deploy/juju-spaces.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Deploy Charmed MySQL using Juju network spaces to control network binding and isolate traffic between application components."
+---
+
 (juju-spaces)=
 # Deploy on Juju spaces
 

--- a/docs/how-to/deploy/k8s-clouds/aks.md
+++ b/docs/how-to/deploy/k8s-clouds/aks.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Deploy Charmed MySQL K8s on Azure Kubernetes Service (AKS): install tooling, authenticate, and bootstrap a Juju controller on AKS."
+---
+
 (aks)=
 # How to deploy on AKS
 

--- a/docs/how-to/deploy/k8s-clouds/canonical-k8s.md
+++ b/docs/how-to/deploy/k8s-clouds/canonical-k8s.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Deploy Charmed MySQL K8s on Canonical Kubernetes, Ubuntu's optimized Kubernetes distribution, using Juju for orchestration."
+---
+
 (canonical-k8s)=
 # How to deploy on Canonical Kubernetes
 

--- a/docs/how-to/deploy/k8s-clouds/eks.md
+++ b/docs/how-to/deploy/k8s-clouds/eks.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Deploy Charmed MySQL K8s on Amazon Elastic Kubernetes Service (EKS): install tools, authenticate with AWS, and bootstrap Juju."
+---
+
 (eks)=
 # How to deploy on EKS
 

--- a/docs/how-to/deploy/k8s-clouds/gke.md
+++ b/docs/how-to/deploy/k8s-clouds/gke.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Deploy Charmed MySQL K8s on Google Kubernetes Engine (GKE): set up Google Cloud CLI, authenticate, bootstrap Juju, and deploy the charm."
+---
+
 (gke)=
 # How to deploy on GKE
 

--- a/docs/how-to/deploy/k8s-clouds/index.md
+++ b/docs/how-to/deploy/k8s-clouds/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Overview of supported Kubernetes clouds for Charmed MySQL K8s, including Canonical K8s, MicroK8s, AKS, EKS, and GKE deployments."
+---
+
 (k8s-clouds)=
 # Kubernetes clouds
 

--- a/docs/how-to/deploy/k8s-clouds/microk8s.md
+++ b/docs/how-to/deploy/k8s-clouds/microk8s.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Deploy Charmed MySQL K8s on MicroK8s with an existing Juju and MicroK8s setup. See the tutorial for a full end-to-end walkthrough."
+---
+
 (microk8s)=
 # How to deploy on MicroK8s
 

--- a/docs/how-to/deploy/multi-az/gce.md
+++ b/docs/how-to/deploy/multi-az/gce.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Deploy a Charmed MySQL VM cluster across three availability zones on Google Compute Engine using Juju zone constraints for high availability."
+---
+
 (multi-az-gce)=
 # Multi-AZ example on GCE
 

--- a/docs/how-to/deploy/multi-az/gke.md
+++ b/docs/how-to/deploy/multi-az/gke.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Deploy Charmed MySQL K8s across three availability zones on Google Kubernetes Engine using Juju zone constraints and pod anti-affinity rules."
+---
+
 (multi-az-gke)=
 # Multi-AZ example on GKE
 

--- a/docs/how-to/deploy/multi-az/index.md
+++ b/docs/how-to/deploy/multi-az/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Deploy Charmed MySQL across multiple availability zones for high availability, eliminating single points of failure on GCE and GKE."
+---
+
 (multi-az)=
 # Deploy on multiple availability zones (AZ) 
 

--- a/docs/how-to/deploy/terraform/charm-module.md
+++ b/docs/how-to/deploy/terraform/charm-module.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Deploy the Charmed MySQL Terraform charm module using the Juju provider: install Terraform, clone the repo, initialize, and verify deployment."
+---
+
 (charm-module)=
 # Deploy charm module
 

--- a/docs/how-to/deploy/terraform/index.md
+++ b/docs/how-to/deploy/terraform/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Deploy Charmed MySQL using Terraform and the Juju Terraform Provider, using either a charm module or a full product module."
+---
+
 (terraform)=
 # How to deploy using Terraform
 

--- a/docs/how-to/deploy/terraform/product-module.md
+++ b/docs/how-to/deploy/terraform/product-module.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Deploy the Charmed MySQL Terraform product module for a recommended stack including optional TLS and COS monitoring integrations."
+---
+
 (product-module)=
 # Deploy product module
 

--- a/docs/how-to/deploy/vm-clouds/aws-ec2.md
+++ b/docs/how-to/deploy/vm-clouds/aws-ec2.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Deploy Charmed MySQL on Amazon Web Services EC2: install Juju and AWS CLI, create IAM credentials, and bootstrap a Juju controller."
+---
+
 (aws-ec2)=
 # How to deploy on AWS EC2
 

--- a/docs/how-to/deploy/vm-clouds/azure.md
+++ b/docs/how-to/deploy/vm-clouds/azure.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Deploy Charmed MySQL on Microsoft Azure: install Juju and Azure CLI, authenticate via browser, and bootstrap a Juju controller on Azure."
+---
+
 (azure)=
 # How to deploy on Azure
 

--- a/docs/how-to/deploy/vm-clouds/gce.md
+++ b/docs/how-to/deploy/vm-clouds/gce.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Deploy Charmed MySQL on Google Compute Engine: install Juju and gcloud CLI, create a service account, and bootstrap a Juju controller."
+---
+
 (gce)=
 # How to deploy on GCE
 

--- a/docs/how-to/deploy/vm-clouds/index.md
+++ b/docs/how-to/deploy/vm-clouds/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Overview of supported machine and VM clouds for Charmed MySQL deployments, including LXD, Sunbeam, MAAS, AWS EC2, GCE, and Azure."
+---
+
 (vm-clouds)=
 # Machine clouds
 

--- a/docs/how-to/deploy/vm-clouds/lxd.md
+++ b/docs/how-to/deploy/vm-clouds/lxd.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Deploy Charmed MySQL on LXD with an existing Juju and LXD environment. See the tutorial for a complete step-by-step walkthrough."
+---
+
 (lxd)=
 # Deploy on LXD
 

--- a/docs/how-to/deploy/vm-clouds/maas.md
+++ b/docs/how-to/deploy/vm-clouds/maas.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Deploy Charmed MySQL on MAAS (Metal as a Service) using a test environment with Multipass, pre-configured MAAS, and LXD cloud-init."
+---
+
 (maas)=
 # How to deploy on MAAS
 

--- a/docs/how-to/deploy/vm-clouds/sunbeam.md
+++ b/docs/how-to/deploy/vm-clouds/sunbeam.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Deploy Charmed MySQL on Sunbeam (OpenStack): install Sunbeam, enable image sync, set up a Juju bastion, and deploy the MySQL charm."
+---
+
 (sunbeam)=
 # How to deploy on Sunbeam
 

--- a/docs/how-to/enable-tls.md
+++ b/docs/how-to/enable-tls.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to enable TLS encryption for Charmed MySQL using the self-signed-certificates operator, including deployment and key rotation steps."
+---
+
 (enable-tls)=
 # How to enable TLS encryption
 

--- a/docs/how-to/external-network-access.md
+++ b/docs/how-to/external-network-access.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Connect to Charmed MySQL from outside the local network using MySQL Router with virtual IPs or cross-controller Juju relations."
+---
+
 (external-network-access)=
 # How to connect to your database outside the local network
 

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How-to guides for Charmed MySQL covering deployment, backup and restore, monitoring, upgrades, charm development, and cluster replication."
+---
+
 (how-to)=
 # How-to guides
 

--- a/docs/how-to/integrate-with-applications.md
+++ b/docs/how-to/integrate-with-applications.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Integrate Charmed MySQL with charmed applications via mysql_client interface or with non-charmed apps using the data-integrator charm."
+---
+
 (integrate-with-applications)=
 # How to integrate with applications
 

--- a/docs/how-to/manage-passwords.md
+++ b/docs/how-to/manage-passwords.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to retrieve and rotate passwords for Charmed MySQL users using the get-password and set-password Juju actions on the leader unit."
+---
+
 (manage-passwords)=
 # How to manage passwords
 

--- a/docs/how-to/monitoring/enable-alert-rules.md
+++ b/docs/how-to/monitoring/enable-alert-rules.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Configure COS alert notifications for Charmed MySQL using AlertManager with Pushover, including credentials setup and receiver configuration."
+---
+
 (enable-alert-rules)=
 # How to enable alert rules
 

--- a/docs/how-to/monitoring/enable-monitoring.md
+++ b/docs/how-to/monitoring/enable-monitoring.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Integrate Charmed MySQL with COS Lite (Grafana, Prometheus, Loki) for observability via cross-model offers and Juju integrations."
+---
+
 (enable-monitoring)=
 # How to enable monitoring (COS)
 

--- a/docs/how-to/monitoring/enable-tracing.md
+++ b/docs/how-to/monitoring/enable-tracing.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Enable Grafana Tempo distributed tracing for Charmed MySQL (development preview) by deploying Tempo HA and integrating via cross-model offers."
+---
+
 (enable-tracing)=
 # Enable tracing
 

--- a/docs/how-to/monitoring/index.md
+++ b/docs/how-to/monitoring/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How-to guides for monitoring Charmed MySQL using COS, covering COS Lite integration, alert rules configuration, and Grafana Tempo tracing."
+---
+
 (monitoring)=
 # Monitoring (COS)
 

--- a/docs/how-to/primary-switchover.md
+++ b/docs/how-to/primary-switchover.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Perform a primary switchover in Charmed MySQL by promoting a chosen unit to primary using the promote-to-primary Juju action."
+---
+
 (primary-switchover)=
 # How to do a primary switchover
 

--- a/docs/how-to/refresh/index.md
+++ b/docs/how-to/refresh/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Overview of in-place charm upgrades for Charmed MySQL using juju refresh, with upgrade paths for VM and K8s single and multi-cluster deployments."
+---
+
 (refresh)=
 # Refresh (upgrade)
 

--- a/docs/how-to/refresh/multi-cluster/index.md
+++ b/docs/how-to/refresh/multi-cluster/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How-to guides for refreshing a Charmed MySQL multi-cluster (ClusterSet) deployment, including upgrade and roll-back procedures."
+---
+
 (multi-cluster)=
 # Refresh a multi-cluster deployment
 

--- a/docs/how-to/refresh/multi-cluster/refresh-multi-cluster.md
+++ b/docs/how-to/refresh/multi-cluster/refresh-multi-cluster.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Upgrade a Charmed MySQL ClusterSet by refreshing each cluster starting with standbys and ending with the primary to minimize disruption."
+---
+
 (refresh-multi-cluster)=
 # How to refresh a multi-cluster deployment
 

--- a/docs/how-to/refresh/multi-cluster/roll-back-multi-cluster.md
+++ b/docs/how-to/refresh/multi-cluster/roll-back-multi-cluster.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Roll back a Charmed MySQL multi-cluster deployment by applying the single-cluster rollback procedure to each upgraded cluster in the set."
+---
+
 # Roll back a multi-cluster deployment
 
 A multi-cluster rollback is the same as a single-cluster rollback, but repeated for each cluster that was fully or partially upgraded.

--- a/docs/how-to/refresh/single-cluster/index.md
+++ b/docs/how-to/refresh/single-cluster/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How-to guides for upgrading and rolling back a single Charmed MySQL cluster, with step-by-step refresh and rollback procedures."
+---
+
 (single-cluster)=
 # Refresh a single cluster
 

--- a/docs/how-to/refresh/single-cluster/refresh-single-cluster.md
+++ b/docs/how-to/refresh/single-cluster/refresh-single-cluster.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Upgrade a single Charmed MySQL cluster using juju refresh, with pre-upgrade checks, revision recording, optional K8s scale-up, and health verification."
+---
+
 (refresh-single-cluster)=
 # How to refresh a single cluster
 

--- a/docs/how-to/refresh/single-cluster/roll-back-single-cluster.md
+++ b/docs/how-to/refresh/single-cluster/roll-back-single-cluster.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Roll back a failed Charmed MySQL upgrade to a previous revision using prepare, rollback, and post-rollback health check steps."
+---
+
 (roll-back-single-cluster)=
 # How to roll back a single cluster
 

--- a/docs/how-to/refresh/upgrade-juju.md
+++ b/docs/how-to/refresh/upgrade-juju.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Upgrade Juju for Charmed MySQL deployments, covering patch upgrades and major/minor version upgrades with model migration steps."
+---
+
 (upgrade-juju)=
 # How to upgrade Juju for a new database revision
 

--- a/docs/how-to/scale.md
+++ b/docs/how-to/scale.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Scale your Charmed MySQL cluster by adding or removing Juju units, with guidance on initial replica count and scaling up or down after deployment."
+---
+
 (scale)=
 # How to scale your cluster
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,8 @@
 ---
 relatedlinks: "[Charmhub&#32;|&#32;MySQL&#32;VM](https://charmhub.io/mysql?channel=8.0/stable), [Charmhub&#32;|&#32;MySQL&#32;K8s](https://charmhub.io/mysql-k8s?channel=8.0/stable)"
+myst:
+  html_meta:
+    description: "Official documentation for Charmed MySQL operator. Deploy and manage MySQL Community Edition on VMs and Kubernetes using Juju."
 ---
 
 # Charmed MySQL documentation

--- a/docs/reference/alert-rules.md
+++ b/docs/reference/alert-rules.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Complete reference for Prometheus alert rules bundled with Charmed MySQL, covering connectivity, connection, slow query, and replication alerts."
+---
+
 (alert-rules)=
 # Alert rules
 

--- a/docs/reference/charm-statuses.md
+++ b/docs/reference/charm-statuses.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Complete reference for all Juju application statuses for Charmed MySQL, with descriptions and recommended operator actions for each status."
+---
+
 (charm-statuses)=
 # Charm statuses
 

--- a/docs/reference/charm-testing.md
+++ b/docs/reference/charm-testing.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Reference overview of software test types for Charmed MySQL, including smoke and integration tests, for charm developers and contributors."
+---
+
 (charm-testing)=
 # Charm testing
 

--- a/docs/reference/contacts.md
+++ b/docs/reference/contacts.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Contact information for Charmed MySQL: GitHub for bug reports, Launchpad for security issues, Matrix channel, and other useful resources."
+---
+
 (contacts)=
 # Contact
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Reference documentation for Charmed MySQL including release notes, system requirements, profiles, plugins, alert rules, statuses, and contacts."
+---
+
 (reference)=
 # Reference
 

--- a/docs/reference/plugins-extensions.md
+++ b/docs/reference/plugins-extensions.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Complete reference listing all plugins and extensions supported by Charmed MySQL, with the charm revision that introduced each one for VM and K8s."
+---
+
 (plugins-extensions)=
 # Supported plugins/extensions
 

--- a/docs/reference/profiles.md
+++ b/docs/reference/profiles.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Reference for Charmed MySQL resource profiles (production and testing), their configuration parameters, and how to set or change them with juju config."
+---
+
 (profiles)=
 # Profiles
 

--- a/docs/reference/release-notes/index.md
+++ b/docs/reference/release-notes/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Release notes index for Charmed MySQL, linking to version histories for the VM charm and the Kubernetes charm with all stable revisions listed."
+---
+
 (release-notes)=
 # Release notes
 

--- a/docs/reference/release-notes/k8s/index.md
+++ b/docs/reference/release-notes/k8s/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Overview of all stable Charmed MySQL K8s charm revisions with MySQL versions, Juju requirements, and supported features per release."
+---
+
 (release-notes-k8s)=
 # Release notes (K8s)
 

--- a/docs/reference/release-notes/k8s/revision-113.md
+++ b/docs/reference/release-notes/k8s/revision-113.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: "Release notes for Charmed MySQL K8s revision 113: profile-limit-memory config option, log rotation for error and slow query logs, secret labels."
+    description: "Release notes for Charmed MySQL K8s revision 113 (MySQL 8.0.34): profile-limit-memory config option, log rotation for error and slow query logs, secret labels."
 ---
 
 (revision-113)=

--- a/docs/reference/release-notes/k8s/revision-113.md
+++ b/docs/reference/release-notes/k8s/revision-113.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Release notes for Charmed MySQL K8s revision 113: profile-limit-memory config option, log rotation for error and slow query logs, secret labels."
+---
+
 (revision-113)=
 # Revision 113
 

--- a/docs/reference/release-notes/k8s/revision-127.md
+++ b/docs/reference/release-notes/k8s/revision-127.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Release notes for Charmed MySQL K8s revision 127 (MySQL 8.0.35): Juju 3.1.7+ compatibility and CA chain support for TLS encryption."
+---
+
 (revision-127)=
 # Revision 127
 

--- a/docs/reference/release-notes/k8s/revision-153.md
+++ b/docs/reference/release-notes/k8s/revision-153.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Release notes for Charmed MySQL K8s revision 153 (MySQL 8.0.36): async cluster-cluster replication, COS Tempo tracing, and max connections config."
+---
+
 (revision-153)=
 # Revision 153
 

--- a/docs/reference/release-notes/k8s/revision-75.md
+++ b/docs/reference/release-notes/k8s/revision-75.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Release notes for Charmed MySQL K8s revision 75 (MySQL 8.0.32): HA via InnoDB Group replication, S3 backups, TLS, and legacy interface support."
+---
+
 (revision-75)=
 # Revision 75
 

--- a/docs/reference/release-notes/k8s/revision-99.md
+++ b/docs/reference/release-notes/k8s/revision-99.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Release notes for Charmed MySQL K8s revision 99 (MySQL 8.0.34): Juju 3 support, Juju secrets, in-place upgrades, profiles, and bug fixes."
+---
+
 (revision-99)=
 # Revision 99
 

--- a/docs/reference/release-notes/k8s/revisions-180-181.md
+++ b/docs/reference/release-notes/k8s/revisions-180-181.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Release notes for Charmed MySQL K8s revisions 180/181 (MySQL 8.0.37): first ARM64 support, Audit Log plugin, and Prometheus alert rules."
+---
+
 (revisions-180-181)=
 # Revisions 180, 181
 

--- a/docs/reference/release-notes/k8s/revisions-210-211.md
+++ b/docs/reference/release-notes/k8s/revisions-210-211.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Release notes for Charmed MySQL K8s revisions 210 and 211 (MySQL 8.0.39 for amd64 and arm64), requiring Juju 3.5.4 or later."
+---
+
 (revisions-210-211)=
 # Revisions 210, 211
 

--- a/docs/reference/release-notes/k8s/revisions-210-211.md
+++ b/docs/reference/release-notes/k8s/revisions-210-211.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: "Release notes for Charmed MySQL K8s revisions 210 and 211 (MySQL 8.0.39 for amd64 and arm64), requiring Juju 3.5.4 or later."
+    description: "Release notes for Charmed MySQL K8s revisions 210 and 211 (MySQL 8.0.39), requiring Juju 3.5.4 or later."
 ---
 
 (revisions-210-211)=

--- a/docs/reference/release-notes/k8s/revisions-240-241.md
+++ b/docs/reference/release-notes/k8s/revisions-240-241.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Release notes for Charmed MySQL K8s revisions 240 and 241 for amd64 and arm64 architectures, upgrading MySQL to version 8.0.41."
+---
+
 (revisions-240-241)=
 # Revisions 240, 241
 

--- a/docs/reference/release-notes/k8s/revisions-254-255.md
+++ b/docs/reference/release-notes/k8s/revisions-254-255.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Release notes for Charmed MySQL K8s revisions 254 and 255 (MySQL 8.0.41), fixing root user password reset initialization behavior."
+---
+
 (revisions-254-255)=
 # Revisions 254, 255
 

--- a/docs/reference/release-notes/k8s/revisions-342-344.md
+++ b/docs/reference/release-notes/k8s/revisions-342-344.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Release notes for Charmed MySQL K8s revisions 342–344 (MySQL 8.0.44): first s390x architecture support for amd64, arm64, and s390x."
+---
+
 (revisions-342-344)=
 # Revisions 342, 343, 344
 

--- a/docs/reference/release-notes/vm/index.md
+++ b/docs/reference/release-notes/vm/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Overview of all stable Charmed MySQL VM charm revisions with MySQL versions, Juju requirements, and supported features per release."
+---
+
 (release-notes-vm)=
 # Release notes (VM)
 

--- a/docs/reference/release-notes/vm/revision-151.md
+++ b/docs/reference/release-notes/vm/revision-151.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Release notes for Charmed MySQL VM revision 151 (MySQL 8.0.32): first stable VM release with HA, S3 backups, TLS, and LXD/MAAS support."
+---
+
 (revision-151)=
 # Revision 151
 

--- a/docs/reference/release-notes/vm/revision-196.md
+++ b/docs/reference/release-notes/vm/revision-196.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Release notes for Charmed MySQL VM revision 196 (MySQL 8.0.34): Juju 3 support, Juju secrets, in-place upgrades, and profiles configuration."
+---
+
 (revision-196)=
 # Revision 196
 

--- a/docs/reference/release-notes/vm/revision-240.md
+++ b/docs/reference/release-notes/vm/revision-240.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Release notes for Charmed MySQL VM revision 240 (MySQL 8.0.36): async cluster-cluster replication, Ubuntu Pro support, and COS Tempo tracing."
+---
+
 (revision-240)=
 # Revision 240
 

--- a/docs/reference/release-notes/vm/revisions-312-313.md
+++ b/docs/reference/release-notes/vm/revisions-312-313.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Release notes for Charmed MySQL VM revisions 312 and 313 (MySQL 8.0.39): ARM64 support, Audit Log plugin, and Prometheus alert rules."
+---
+
 (revisions-312-313)=
 # Revisions 312, 313
 

--- a/docs/reference/release-notes/vm/revisions-366-367.md
+++ b/docs/reference/release-notes/vm/revisions-366-367.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Release notes for Charmed MySQL VM revisions 366 and 367 (MySQL 8.0.41): new log rotation options and operator-managed self-rejoin for cluster members."
+---
+
 (revisions-366-367)=
 # Revisions 366, 367
 

--- a/docs/reference/release-notes/vm/revisions-442-444.md
+++ b/docs/reference/release-notes/vm/revisions-442-444.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Release notes for Charmed MySQL VM revisions 442–444 (MySQL 8.0.44): point-in-time backup recovery and Juju network spaces support added."
+---
+
 (revisions-442-444)=
 # Revisions 442, 443, 444
 

--- a/docs/reference/system-requirements.md
+++ b/docs/reference/system-requirements.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "System requirements for Charmed MySQL: Ubuntu and Kubernetes versions, supported Juju releases, MySQL group replication requirements, and hardware specs."
+---
+
 (system-requirements)=
 # System requirements
 

--- a/docs/reference/troubleshooting/index.md
+++ b/docs/reference/troubleshooting/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Troubleshoot Charmed MySQL by checking Juju statuses, logs, and running services, with links to specific known scenarios and recovery guides."
+---
+
 (troubleshooting)=
 # Troubleshooting
 

--- a/docs/reference/troubleshooting/known-scenarios.md
+++ b/docs/reference/troubleshooting/known-scenarios.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Reference of known Charmed MySQL operational issues with step-by-step solutions, including K8s primary reelection failures and read-only unit scenarios."
+---
+
 (known-scenarios)=
 # Known scenarios
 

--- a/docs/reference/troubleshooting/recover-from-quorum-loss.md
+++ b/docs/reference/troubleshooting/recover-from-quorum-loss.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Manually recover a Charmed MySQL cluster from quorum loss when a majority of nodes are unavailable, with data loss warnings and recovery steps."
+---
+
 (recover-from-quorum-loss)=
 # Recover from quorum loss
 

--- a/docs/reference/troubleshooting/sos-report.md
+++ b/docs/reference/troubleshooting/sos-report.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Collect support data and logs from Charmed MySQL units using the SoS reporting tool, with options for built-in or latest SoS plugin versions."
+---
+
 (sos-report)=
 # SoS report
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Follow this hands-on tutorial to deploy, scale, and manage Charmed MySQL on virtual machines using Juju from setup to clean up."
+---
+
 (tutorial)=
 # Tutorial
 


### PR DESCRIPTION
This PR adds [HTML metadata](https://library.canonical.com/documentation/documentation-practice/html-metadata) to all documentation pages for better Search Engine Optimization.

Solves [DPE-9542](https://warthogs.atlassian.net/browse/DPE-9542).

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.


[DPE-9542]: https://warthogs.atlassian.net/browse/DPE-9542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ