### PR TITLE
[DPE-9167] Fix cluster not initialized 8.0

### DIFF
--- a/kubernetes/lib/charms/mysql/v0/async_replication.py
+++ b/kubernetes/lib/charms/mysql/v0/async_replication.py
@@ -704,6 +704,10 @@ class MySQLAsyncReplicationConsumer(MySQLAsyncReplication):
         """Handle the async_replica relation being created on the leader unit."""
         if not self._charm.unit.is_leader():
             return
+        if not self._charm._is_peer_data_set:
+            logger.info("Peer data not set, deferring event")
+            event.defer()
+            return
         if not self._charm.unit_initialized() and not self.returning_cluster:
             # avoid running too early for non returning clusters
             self._charm.unit.status = BlockedStatus(
@@ -741,6 +745,10 @@ class MySQLAsyncReplicationConsumer(MySQLAsyncReplication):
     def _on_consumer_changed(self, event):  # noqa: C901
         """Handle the async_replica relation being changed."""
         if not self._charm.unit.is_leader():
+            return
+        if not self._charm._is_peer_data_set:
+            logger.info("Peer data not set, deferring event")
+            event.defer()
             return
         state = self.state
         logger.debug(f"Replica cluster {state.value=}")

--- a/kubernetes/tests/unit/test_async_replication.py
+++ b/kubernetes/tests/unit/test_async_replication.py
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 
 from ops.testing import Harness
 
@@ -20,29 +20,21 @@ class TestAsyncReplication(unittest.TestCase):
         self.restart_relation_id = self.harness.add_relation("restart", "restart")
         self.harness.set_leader(True)
 
-    def test_consumer_relation_created_deferred_when_peer_data_not_set(self):
+    @patch("charm.MySQLOperatorCharm._is_peer_data_set", new_callable=PropertyMock, return_value=False)
+    @patch("ops.framework.EventBase.defer")
+    def test_consumer_relation_created_deferred_when_peer_data_not_set(self, mock_defer, mock_peer_data):
         """Test that consumer relation created event is deferred when peer data is not set."""
-        with (
-            patch.object(
-                type(self.harness.charm), "_is_peer_data_set", property(lambda self: False)
-            ),
-            patch("ops.framework.EventBase.defer") as mock_defer,
-        ):
-            relation_id = self.harness.add_relation("replication", "remote")
-            self.harness.add_relation_unit(relation_id, "remote/0")
+        relation_id = self.harness.add_relation("replication", "remote")
+        self.harness.add_relation_unit(relation_id, "remote/0")
 
-            mock_defer.assert_called()
+        mock_defer.assert_called()
 
-    def test_consumer_relation_changed_deferred_when_peer_data_not_set(self):
+    @patch("charm.MySQLOperatorCharm._is_peer_data_set", new_callable=PropertyMock, return_value=False)
+    @patch("ops.framework.EventBase.defer")
+    def test_consumer_relation_changed_deferred_when_peer_data_not_set(self, mock_defer, mock_peer_data):
         """Test that consumer relation changed event is deferred when peer data is not set."""
-        with (
-            patch.object(
-                type(self.harness.charm), "_is_peer_data_set", property(lambda self: False)
-            ),
-            patch("ops.framework.EventBase.defer") as mock_defer,
-        ):
-            relation_id = self.harness.add_relation("replication", "remote")
-            self.harness.add_relation_unit(relation_id, "remote/0")
-            self.harness.update_relation_data(relation_id, "remote/0", {"key": "value"})
+        relation_id = self.harness.add_relation("replication", "remote")
+        self.harness.add_relation_unit(relation_id, "remote/0")
+        self.harness.update_relation_data(relation_id, "remote/0", {"key": "value"})
 
-            mock_defer.assert_called()
+        mock_defer.assert_called()

--- a/kubernetes/tests/unit/test_async_replication.py
+++ b/kubernetes/tests/unit/test_async_replication.py
@@ -22,19 +22,27 @@ class TestAsyncReplication(unittest.TestCase):
 
     def test_consumer_relation_created_deferred_when_peer_data_not_set(self):
         """Test that consumer relation created event is deferred when peer data is not set."""
-        with patch.object(type(self.harness.charm), "_is_peer_data_set", property(lambda self: False)):
-            with patch("ops.framework.EventBase.defer") as mock_defer:
-                relation_id = self.harness.add_relation("replication", "remote")
-                self.harness.add_relation_unit(relation_id, "remote/0")
-                
-                mock_defer.assert_called()
+        with (
+            patch.object(
+                type(self.harness.charm), "_is_peer_data_set", property(lambda self: False)
+            ),
+            patch("ops.framework.EventBase.defer") as mock_defer,
+        ):
+            relation_id = self.harness.add_relation("replication", "remote")
+            self.harness.add_relation_unit(relation_id, "remote/0")
+
+            mock_defer.assert_called()
 
     def test_consumer_relation_changed_deferred_when_peer_data_not_set(self):
         """Test that consumer relation changed event is deferred when peer data is not set."""
-        with patch.object(type(self.harness.charm), "_is_peer_data_set", property(lambda self: False)):
-            with patch("ops.framework.EventBase.defer") as mock_defer:
-                relation_id = self.harness.add_relation("replication", "remote")
-                self.harness.add_relation_unit(relation_id, "remote/0")
-                self.harness.update_relation_data(relation_id, "remote/0", {"key": "value"})
-                
-                mock_defer.assert_called()
+        with (
+            patch.object(
+                type(self.harness.charm), "_is_peer_data_set", property(lambda self: False)
+            ),
+            patch("ops.framework.EventBase.defer") as mock_defer,
+        ):
+            relation_id = self.harness.add_relation("replication", "remote")
+            self.harness.add_relation_unit(relation_id, "remote/0")
+            self.harness.update_relation_data(relation_id, "remote/0", {"key": "value"})
+
+            mock_defer.assert_called()

--- a/kubernetes/tests/unit/test_async_replication.py
+++ b/kubernetes/tests/unit/test_async_replication.py
@@ -20,18 +20,26 @@ class TestAsyncReplication(unittest.TestCase):
         self.restart_relation_id = self.harness.add_relation("restart", "restart")
         self.harness.set_leader(True)
 
-    @patch("charm.MySQLOperatorCharm._is_peer_data_set", new_callable=PropertyMock, return_value=False)
+    @patch(
+        "charm.MySQLOperatorCharm._is_peer_data_set", new_callable=PropertyMock, return_value=False
+    )
     @patch("ops.framework.EventBase.defer")
-    def test_consumer_relation_created_deferred_when_peer_data_not_set(self, mock_defer, mock_peer_data):
+    def test_consumer_relation_created_deferred_when_peer_data_not_set(
+        self, mock_defer, mock_peer_data
+    ):
         """Test that consumer relation created event is deferred when peer data is not set."""
         relation_id = self.harness.add_relation("replication", "remote")
         self.harness.add_relation_unit(relation_id, "remote/0")
 
         mock_defer.assert_called()
 
-    @patch("charm.MySQLOperatorCharm._is_peer_data_set", new_callable=PropertyMock, return_value=False)
+    @patch(
+        "charm.MySQLOperatorCharm._is_peer_data_set", new_callable=PropertyMock, return_value=False
+    )
     @patch("ops.framework.EventBase.defer")
-    def test_consumer_relation_changed_deferred_when_peer_data_not_set(self, mock_defer, mock_peer_data):
+    def test_consumer_relation_changed_deferred_when_peer_data_not_set(
+        self, mock_defer, mock_peer_data
+    ):
         """Test that consumer relation changed event is deferred when peer data is not set."""
         relation_id = self.harness.add_relation("replication", "remote")
         self.harness.add_relation_unit(relation_id, "remote/0")

--- a/kubernetes/tests/unit/test_async_replication.py
+++ b/kubernetes/tests/unit/test_async_replication.py
@@ -1,0 +1,40 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import unittest
+from unittest.mock import patch
+
+from ops.testing import Harness
+
+from charm import MySQLOperatorCharm
+
+
+class TestAsyncReplication(unittest.TestCase):
+    def setUp(self) -> None:
+        self.patcher = patch("lightkube.core.client.GenericSyncClient")
+        self.patcher.start()
+        self.harness = Harness(MySQLOperatorCharm)
+        self.addCleanup(self.harness.cleanup)
+        self.harness.begin()
+        self.peer_relation_id = self.harness.add_relation("database-peers", "database-peers")
+        self.restart_relation_id = self.harness.add_relation("restart", "restart")
+        self.harness.set_leader(True)
+
+    def test_consumer_relation_created_deferred_when_peer_data_not_set(self):
+        """Test that consumer relation created event is deferred when peer data is not set."""
+        with patch.object(type(self.harness.charm), "_is_peer_data_set", property(lambda self: False)):
+            with patch("ops.framework.EventBase.defer") as mock_defer:
+                relation_id = self.harness.add_relation("replication", "remote")
+                self.harness.add_relation_unit(relation_id, "remote/0")
+                
+                mock_defer.assert_called()
+
+    def test_consumer_relation_changed_deferred_when_peer_data_not_set(self):
+        """Test that consumer relation changed event is deferred when peer data is not set."""
+        with patch.object(type(self.harness.charm), "_is_peer_data_set", property(lambda self: False)):
+            with patch("ops.framework.EventBase.defer") as mock_defer:
+                relation_id = self.harness.add_relation("replication", "remote")
+                self.harness.add_relation_unit(relation_id, "remote/0")
+                self.harness.update_relation_data(relation_id, "remote/0", {"key": "value"})
+                
+                mock_defer.assert_called()

--- a/machines/lib/charms/mysql/v0/async_replication.py
+++ b/machines/lib/charms/mysql/v0/async_replication.py
@@ -703,6 +703,10 @@ class MySQLAsyncReplicationConsumer(MySQLAsyncReplication):
         """Handle the async_replica relation being created on the leader unit."""
         if not self._charm.unit.is_leader():
             return
+        if not self._charm._is_peer_data_set:
+            logger.info("Peer data not set, deferring event")
+            event.defer()
+            return
         if not self._charm.unit_initialized() and not self.returning_cluster:
             # avoid running too early for non returning clusters
             self._charm.unit.status = BlockedStatus(
@@ -740,6 +744,10 @@ class MySQLAsyncReplicationConsumer(MySQLAsyncReplication):
     def _on_consumer_changed(self, event):  # noqa: C901
         """Handle the async_replica relation being changed."""
         if not self._charm.unit.is_leader():
+            return
+        if not self._charm._is_peer_data_set:
+            logger.info("Peer data not set, deferring event")
+            event.defer()
             return
         state = self.state
         logger.debug(f"Replica cluster {state.value=}")

--- a/machines/tests/unit/test_async_replication.py
+++ b/machines/tests/unit/test_async_replication.py
@@ -511,6 +511,7 @@ class TestAsyncRelation(unittest.TestCase):
 
     def test_consumer_relation_created_deferred_when_peer_data_not_set(self, _):
         """Test that consumer relation created event is deferred when peer data is not set."""
+        self.harness.set_leader(True)
         with (
             patch.object(
                 type(self.harness.charm), "_is_peer_data_set", property(lambda self: False)
@@ -524,6 +525,7 @@ class TestAsyncRelation(unittest.TestCase):
 
     def test_consumer_relation_changed_deferred_when_peer_data_not_set(self, _):
         """Test that consumer relation changed event is deferred when peer data is not set."""
+        self.harness.set_leader(True)
         with (
             patch.object(
                 type(self.harness.charm), "_is_peer_data_set", property(lambda self: False)

--- a/machines/tests/unit/test_async_replication.py
+++ b/machines/tests/unit/test_async_replication.py
@@ -509,31 +509,23 @@ class TestAsyncRelation(unittest.TestCase):
 
         _mysql.rejoin_cluster.assert_called_once_with(self.charm.app_peer_data["cluster-name"])
 
-    def test_consumer_relation_created_deferred_when_peer_data_not_set(self, _):
+    @patch("charm.MySQLOperatorCharm._is_peer_data_set", new_callable=PropertyMock, return_value=False)
+    @patch("ops.framework.EventBase.defer")
+    def test_consumer_relation_created_deferred_when_peer_data_not_set(self, _, mock_defer, mock_peer_data):
         """Test that consumer relation created event is deferred when peer data is not set."""
         self.harness.set_leader(True)
-        with (
-            patch.object(
-                type(self.harness.charm), "_is_peer_data_set", property(lambda self: False)
-            ),
-            patch("ops.framework.EventBase.defer") as mock_defer,
-        ):
-            relation_id = self.harness.add_relation("replication", "remote")
-            self.harness.add_relation_unit(relation_id, "remote/0")
+        relation_id = self.harness.add_relation("replication", "remote")
+        self.harness.add_relation_unit(relation_id, "remote/0")
 
-            mock_defer.assert_called()
+        mock_defer.assert_called()
 
-    def test_consumer_relation_changed_deferred_when_peer_data_not_set(self, _):
+    @patch("charm.MySQLOperatorCharm._is_peer_data_set", new_callable=PropertyMock, return_value=False)
+    @patch("ops.framework.EventBase.defer")
+    def test_consumer_relation_changed_deferred_when_peer_data_not_set(self, _, mock_defer, mock_peer_data):
         """Test that consumer relation changed event is deferred when peer data is not set."""
         self.harness.set_leader(True)
-        with (
-            patch.object(
-                type(self.harness.charm), "_is_peer_data_set", property(lambda self: False)
-            ),
-            patch("ops.framework.EventBase.defer") as mock_defer,
-        ):
-            relation_id = self.harness.add_relation("replication", "remote")
-            self.harness.add_relation_unit(relation_id, "remote/0")
-            self.harness.update_relation_data(relation_id, "remote/0", {"key": "value"})
+        relation_id = self.harness.add_relation("replication", "remote")
+        self.harness.add_relation_unit(relation_id, "remote/0")
+        self.harness.update_relation_data(relation_id, "remote/0", {"key": "value"})
 
-            mock_defer.assert_called()
+        mock_defer.assert_called()

--- a/machines/tests/unit/test_async_replication.py
+++ b/machines/tests/unit/test_async_replication.py
@@ -509,9 +509,13 @@ class TestAsyncRelation(unittest.TestCase):
 
         _mysql.rejoin_cluster.assert_called_once_with(self.charm.app_peer_data["cluster-name"])
 
-    @patch("charm.MySQLOperatorCharm._is_peer_data_set", new_callable=PropertyMock, return_value=False)
+    @patch(
+        "charm.MySQLOperatorCharm._is_peer_data_set", new_callable=PropertyMock, return_value=False
+    )
     @patch("ops.framework.EventBase.defer")
-    def test_consumer_relation_created_deferred_when_peer_data_not_set(self, _, mock_defer, mock_peer_data):
+    def test_consumer_relation_created_deferred_when_peer_data_not_set(
+        self, _, mock_defer, mock_peer_data
+    ):
         """Test that consumer relation created event is deferred when peer data is not set."""
         self.harness.set_leader(True)
         relation_id = self.harness.add_relation("replication", "remote")
@@ -519,9 +523,13 @@ class TestAsyncRelation(unittest.TestCase):
 
         mock_defer.assert_called()
 
-    @patch("charm.MySQLOperatorCharm._is_peer_data_set", new_callable=PropertyMock, return_value=False)
+    @patch(
+        "charm.MySQLOperatorCharm._is_peer_data_set", new_callable=PropertyMock, return_value=False
+    )
     @patch("ops.framework.EventBase.defer")
-    def test_consumer_relation_changed_deferred_when_peer_data_not_set(self, _, mock_defer, mock_peer_data):
+    def test_consumer_relation_changed_deferred_when_peer_data_not_set(
+        self, _, mock_defer, mock_peer_data
+    ):
         """Test that consumer relation changed event is deferred when peer data is not set."""
         self.harness.set_leader(True)
         relation_id = self.harness.add_relation("replication", "remote")

--- a/machines/tests/unit/test_async_replication.py
+++ b/machines/tests/unit/test_async_replication.py
@@ -508,3 +508,30 @@ class TestAsyncRelation(unittest.TestCase):
         )
 
         _mysql.rejoin_cluster.assert_called_once_with(self.charm.app_peer_data["cluster-name"])
+
+    def test_consumer_relation_created_deferred_when_peer_data_not_set(self, _):
+        """Test that consumer relation created event is deferred when peer data is not set."""
+        with (
+            patch.object(
+                type(self.harness.charm), "_is_peer_data_set", property(lambda self: False)
+            ),
+            patch("ops.framework.EventBase.defer") as mock_defer,
+        ):
+            relation_id = self.harness.add_relation("replication", "remote")
+            self.harness.add_relation_unit(relation_id, "remote/0")
+
+            mock_defer.assert_called()
+
+    def test_consumer_relation_changed_deferred_when_peer_data_not_set(self, _):
+        """Test that consumer relation changed event is deferred when peer data is not set."""
+        with (
+            patch.object(
+                type(self.harness.charm), "_is_peer_data_set", property(lambda self: False)
+            ),
+            patch("ops.framework.EventBase.defer") as mock_defer,
+        ):
+            relation_id = self.harness.add_relation("replication", "remote")
+            self.harness.add_relation_unit(relation_id, "remote/0")
+            self.harness.update_relation_data(relation_id, "remote/0", {"key": "value"})
+
+            mock_defer.assert_called()


### PR DESCRIPTION
## Issue
This fixes #8 where relation data would be accessed before it was initialized causing the k8s charm to crash. Child of #116 

## Solution
It's enough to check for this case in the hook code and defer the event if the data is not yet available

## Checklist
- [X] I have added or updated any relevant documentation.
- [X] I have cleaned any remaining cloud resources from my accounts.
