### PR TITLE
[MISC] Cleanup 8.4 release leftovers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,7 +98,6 @@ jobs:
           - machines
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v40.0.0
     with:
-      cache: false  # TODO: cleanup
       path-to-charm-directory: ${{ matrix.path }}
 
   integration-test:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,6 @@ jobs:
           - machines
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v40.0.0
     with:
-      cache: false  # TODO: cleanup
       path-to-charm-directory: ${{ matrix.path }}
 
   integration-test:

--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -21,7 +21,6 @@ jobs:
           - machines
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v40.0.0
     with:
-      cache: false  # TODO: cleanup
       path-to-charm-directory: ${{ matrix.path }}
 
   integration-test:

--- a/kubernetes/tests/spread/integration/test_upgrade.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_upgrade.py/task.yaml
@@ -2,8 +2,6 @@ summary: test_upgrade.py
 environment:
   TEST_MODULE: high_availability/test_upgrade.py
 execute: |
-  # TODO: Un-comment when we release a 8.4/edge charm
-  # tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
-  exit 0
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_upgrade.py/task.yaml
+++ b/machines/tests/spread/integration/test_upgrade.py/task.yaml
@@ -2,8 +2,6 @@ summary: test_upgrade.py
 environment:
   TEST_MODULE: high_availability/test_upgrade.py
 execute: |
-  # TODO: Un-comment when we release a 8.4/edge charm
-  # tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
-  exit 0
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results


### PR DESCRIPTION
This PR:

- Enables MySQL 8.4 CI build cache, only possible whenever the Ubuntu 24.04 cache is built.
- Enables MySQL 8.4 upgrade tests, only possible when the new charm gets released to the `8.4/edge` channel.
