### PR TITLE
[MISC] Cleanup CI cache flag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,7 +98,6 @@ jobs:
           - machines
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v40.0.0
     with:
-      cache: false  # TODO: cleanup
       path-to-charm-directory: ${{ matrix.path }}
 
   integration-test:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,28 +41,29 @@ jobs:
       path-to-charm-directory: ${{ matrix.path }}
     secrets: inherit
 
-  release-test:
-    name: Release tests
-    needs:
-      - build
-    strategy:
-      fail-fast: false
-      matrix:
-        path:
-          - kubernetes
-          - machines
-    uses: ./.github/workflows/release_test.yaml
-    with:
-      artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
-      path-to-charm-directory: ${{ matrix.path }}
-    secrets: inherit
+# TODO: Uncomment when MySQL 8.4/stable channel has releases
+#  release-test:
+#    name: Release tests
+#    needs:
+#      - build
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        path:
+#          - kubernetes
+#          - machines
+#    uses: ./.github/workflows/release_test.yaml
+#    with:
+#      artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
+#      path-to-charm-directory: ${{ matrix.path }}
+#    secrets: inherit
 
   release:
     name: Release charm | ${{ matrix.charm.path }}
     needs:
       - build
       - integration-test
-      - release-test
+      # - release-test
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,6 @@ jobs:
           - machines
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v40.0.0
     with:
-      cache: false  # TODO: cleanup
       path-to-charm-directory: ${{ matrix.path }}
 
   integration-test:

--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -21,7 +21,6 @@ jobs:
           - machines
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v40.0.0
     with:
-      cache: false  # TODO: cleanup
       path-to-charm-directory: ${{ matrix.path }}
 
   integration-test:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # MySQL operators
-[![Charmhub](https://charmhub.io/mysql/badge.svg)](https://charmhub.io/mysql)
-[![Charmhub](https://charmhub.io/mysql-k8s/badge.svg)](https://charmhub.io/mysql-k8s)
-[![Release](https://github.com/canonical/mysql-operators/actions/workflows/release.yaml/badge.svg?branch=8.0/edge)](https://github.com/canonical/mysql-operators/actions/workflows/release.yaml)
-[![Tests](https://github.com/canonical/mysql-operators/actions/workflows/ci.yaml/badge.svg?branch=8.0/edge)](https://github.com/canonical/mysql-operators/actions/workflows/ci.yaml)
+[![Charmhub](https://charmhub.io/mysql/badge.svg?channel=8.4/edge)](https://charmhub.io/mysql)
+[![Charmhub](https://charmhub.io/mysql-k8s/badge.svg?channel=8.4/edge)](https://charmhub.io/mysql-k8s)
+[![Release](https://github.com/canonical/mysql-operators/actions/workflows/release.yaml/badge.svg?branch=8.4/edge)](https://github.com/canonical/mysql-operators/actions/workflows/release.yaml)
+[![Tests](https://github.com/canonical/mysql-operators/actions/workflows/ci.yaml/badge.svg?branch=8.4/edge)](https://github.com/canonical/mysql-operators/actions/workflows/ci.yaml)
 
 ## Description
 


### PR DESCRIPTION
This PR cleans up the usage of the build step cache flag, now that the Python packages cache is available.

In addition:
- It disables the release test (designed to test upgrade / refresh between stable versions).
- It updates the README badges.
