### PR TITLE
[DPE-8064] Rework app status

### DIFF
--- a/kubernetes/lib/charms/mysql/v0/async_replication.py
+++ b/kubernetes/lib/charms/mysql/v0/async_replication.py
@@ -247,7 +247,7 @@ class MySQLAsyncReplication(Object):
 
                         self._charm._mysql.remove_replica_cluster(cluster_name, force=force)
                         logger.info(f"Replica cluster {cluster_name} removed")
-                        self._charm.unit.status = self._charm.unit_workload_status
+                        self._charm.unit.status = self._charm.build_unit_workload_status()
                     else:
                         logger.warning(
                             f"Replica cluster {cluster_name} not found in cluster set, skipping removal"

--- a/kubernetes/lib/charms/mysql/v0/async_replication.py
+++ b/kubernetes/lib/charms/mysql/v0/async_replication.py
@@ -247,7 +247,7 @@ class MySQLAsyncReplication(Object):
 
                         self._charm._mysql.remove_replica_cluster(cluster_name, force=force)
                         logger.info(f"Replica cluster {cluster_name} removed")
-                        self._charm.unit.status = ActiveStatus(self._charm.active_status_message)
+                        self._charm.unit.status = self._charm.unit_workload_status
                     else:
                         logger.warning(
                             f"Replica cluster {cluster_name} not found in cluster set, skipping removal"

--- a/kubernetes/lib/charms/mysql/v0/mysql.py
+++ b/kubernetes/lib/charms/mysql/v0/mysql.py
@@ -827,19 +827,44 @@ class MySQLCharmBase(CharmBase, ABC):
         return len(active_cos_relations) > 0
 
     @property
-    def active_status_message(self) -> str:
-        """Active status message."""
-        if self.unit_peer_data.get("member-role") != "primary":
-            return ""
+    def app_workload_status(self) -> ops.StatusBase:
+        """App status generated from the workload."""
+        status = self._mysql.get_cluster_status()
+        if not status:
+            return ops.MaintenanceStatus("Unknown")
+
+        units = status["defaultReplicaSet"]["topology"].keys()
+        status = status["defaultReplicaSet"]["status"]
+
+        if status in [ClusterStatus.OK, ClusterStatus.OK_PARTIAL]:
+            return ops.ActiveStatus("Healthy")
+        if status in [ClusterStatus.OK_NO_TOLERANCE, ClusterStatus.OK_NO_TOLERANCE_PARTIAL]:
+            return ops.ActiveStatus("Healthy") if len(units) < 3 else ops.ActiveStatus("Degraded")
+        if status in [ClusterStatus.NO_QUORUM]:
+            return ops.BlockedStatus("No quorum")
+        if status in [ClusterStatus.OFFLINE, ClusterStatus.ERROR]:
+            return ops.BlockedStatus("No online members")
+        if status in [ClusterStatus.UNREACHABLE]:
+            return ops.BlockedStatus("No connectivity")
+
+        return ops.MaintenanceStatus("Unknown")
+
+    @property
+    def unit_workload_status(self) -> ops.StatusBase:
+        """Unit status generated from the workload."""
+        if self.unit_peer_data.get("member-state") != InstanceState.ONLINE:
+            return ops.MaintenanceStatus("")
+        if self.unit_peer_data.get("member-role") != InstanceRole.PRIMARY:
+            return ops.ActiveStatus("")
 
         if self._mysql.is_cluster_replica() is False:
-            return "Primary"
+            return ops.ActiveStatus("Primary")
 
         status = self._mysql.get_replica_cluster_status()
         if status == ClusterGlobalStatus.OK:
-            return "Standby"
+            return ops.ActiveStatus("Standby")
         else:
-            return f"Standby ({status})"
+            return ops.ActiveStatus(f"Standby ({status})")
 
     @property
     def removing_unit(self) -> bool:

--- a/kubernetes/lib/charms/mysql/v0/mysql.py
+++ b/kubernetes/lib/charms/mysql/v0/mysql.py
@@ -651,8 +651,8 @@ class MySQLCharmBase(CharmBase, ABC):
         logger.info("Recreating cluster")
         try:
             self.create_cluster()
-            self.unit.status = ops.ActiveStatus(self.active_status_message)
-            self.app.status = ops.ActiveStatus()
+            self.unit.status = self.build_unit_workload_status()
+            self.app.status = self.build_app_workload_status()
         except (MySQLCreateClusterError, MySQLCreateClusterSetError) as e:
             logger.exception("Failed to recreate cluster")
             event.fail(str(e))
@@ -827,7 +827,11 @@ class MySQLCharmBase(CharmBase, ABC):
         return len(active_cos_relations) > 0
 
     @property
-    def app_workload_status(self) -> ops.StatusBase:
+    def removing_unit(self) -> bool:
+        """Check if the unit is being removed."""
+        return self.unit_peer_data.get("unit-status") == "removing"
+
+    def build_app_workload_status(self) -> ops.StatusBase:
         """App status generated from the workload."""
         status = self._mysql.get_cluster_status()
         if not status:
@@ -849,8 +853,7 @@ class MySQLCharmBase(CharmBase, ABC):
 
         return ops.MaintenanceStatus("Unknown")
 
-    @property
-    def unit_workload_status(self) -> ops.StatusBase:
+    def build_unit_workload_status(self) -> ops.StatusBase:
         """Unit status generated from the workload."""
         if self.unit_peer_data.get("member-state") != InstanceState.ONLINE:
             return ops.MaintenanceStatus("")
@@ -865,11 +868,6 @@ class MySQLCharmBase(CharmBase, ABC):
             return ops.ActiveStatus("Standby")
         else:
             return ops.ActiveStatus(f"Standby ({status})")
-
-    @property
-    def removing_unit(self) -> bool:
-        """Check if the unit is being removed."""
-        return self.unit_peer_data.get("unit-status") == "removing"
 
     def unit_initialized(self, raise_exceptions: bool = False) -> bool:
         """Check if the unit is added to the cluster."""

--- a/kubernetes/src/charm.py
+++ b/kubernetes/src/charm.py
@@ -54,7 +54,6 @@ from charms.rolling_ops.v0.rollingops import RollingOpsManager
 from ops import EventBase, ModelError, RelationBrokenEvent, RelationCreatedEvent
 from ops.charm import RelationChangedEvent, RelationDepartedEvent, UpdateStatusEvent
 from ops.model import (
-    ActiveStatus,
     BlockedStatus,
     Container,
     MaintenanceStatus,
@@ -358,7 +357,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             logger.info(f"Creating cluster {self.app_peer_data['cluster-name']}")
             self.create_cluster()
             self.unit.set_ports(3306, 33060)
-            self.unit.status = ops.ActiveStatus(self.active_status_message)
+            self.unit.status = self.unit_workload_status
         except (
             MySQLCreateClusterError,
             MySQLCreateClusterSetError,
@@ -478,7 +477,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
                 return
 
         self.unit_peer_data["member-state"] = InstanceState.ONLINE.value
-        self.unit.status = ActiveStatus(self.active_status_message)
+        self.unit.status = self.unit_workload_status
         logger.info(f"Instance {instance_label} added to cluster")
 
     def _reconcile_pebble_layer(self, container: Container) -> None:
@@ -827,43 +826,15 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         self._create_cluster()
         self._mysql.reconcile_binlogs_collection(force_restart=True)
 
-    def _handle_potential_cluster_crash_scenario(self) -> bool:  # noqa: C901
+    def _handle_potential_cluster_crash_scenario(self, state: str) -> bool:
         """Handle potential full cluster crash scenarios.
 
         Returns:
             bool indicating whether the caller should return
         """
-        if not self._mysql.is_mysqld_running():
+        single_node_cluster = self.only_one_cluster_node_thats_uninitialized
+        if not single_node_cluster and not self.cluster_initialized:
             return True
-
-        only_single_uninitialized_node_across_cluster = (
-            self.only_one_cluster_node_thats_uninitialized
-        )
-
-        if (
-            not self.cluster_initialized and not only_single_uninitialized_node_across_cluster
-        ) or not self.unit_peer_data.get("member-role"):
-            return True
-
-        # retrieve and persist state for every unit
-        try:
-            role = self._mysql.get_member_role()
-            state = self._mysql.get_member_state()
-        except MySQLUnableToGetMemberStateError:
-            logger.error("Error getting member state. Avoiding potential cluster crash recovery")
-            self.unit.status = MaintenanceStatus("Unable to get member state")
-            return True
-        else:
-            logger.info(f"Unit workload member-state is {state} with member-role {role}")
-            self.unit_peer_data["member-role"] = role
-            self.unit_peer_data["member-state"] = state
-
-        # set unit status based on member-{state,role}
-        self.unit.status = (
-            ActiveStatus(self.active_status_message)
-            if state == InstanceState.ONLINE
-            else MaintenanceStatus(state)
-        )
 
         if state == InstanceState.RECOVERING:
             return True
@@ -875,22 +846,21 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             }
 
             if (all_states | {state} == {state} and self.unit.is_leader()) or (
-                only_single_uninitialized_node_across_cluster and all_states == {"waiting"}
+                single_node_cluster and all_states == {"waiting"}
             ):
                 # All instance are off, reboot cluster from outage from the leader unit
-
                 logger.info("Attempting reboot from complete outage.")
                 try:
                     # Need condition to avoid rebooting on all units of application
-                    if self.unit.is_leader() or only_single_uninitialized_node_across_cluster:
+                    if self.unit.is_leader() or single_node_cluster:
                         self._mysql.reboot_from_complete_outage()
                 except MySQLRebootFromCompleteOutageError:
                     logger.error("Failed to reboot cluster from complete outage.")
 
-                    if only_single_uninitialized_node_across_cluster and all_states == {"waiting"}:
+                    if single_node_cluster and all_states == {"waiting"}:
                         self._mysql.drop_group_replication_metadata_schema()
                         self.create_cluster()
-                        self.unit.status = ActiveStatus(self.active_status_message)
+                        self.unit.status = self.unit_workload_status
                     else:
                         self.unit.status = BlockedStatus("failed to recover cluster.")
                 return True
@@ -994,39 +964,43 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         if self._is_cluster_blocked():
             logger.info("Cluster is blocked. Skipping.")
             return
+
         del self.restart_peers.data[self.unit]["state"]
 
-        container = self.unit.get_container(CONTAINER_NAME)
-        if not container.can_connect():
+        if not self._mysql.is_mysqld_running():
             logger.info("Cannot connect to pebble in the mysql container")
             return
 
-        if self._handle_potential_cluster_crash_scenario():
-            return
-
-        if not self.unit.is_leader():
-            return
-
-        self._set_app_status()
-
-    def _set_app_status(self) -> None:
-        """Set the application status based on the cluster state."""
+        # retrieve and persist state for every unit
         try:
-            primary_address = self._mysql.get_cluster_primary_address()
-        except MySQLGetClusterPrimaryAddressError:
+            role = self._mysql.get_member_role()
+            state = self._mysql.get_member_state()
+        except MySQLUnableToGetMemberStateError:
+            logger.error("Error getting member state. Avoiding potential cluster crash recovery")
+            self.unit.status = MaintenanceStatus("Unable to get member state")
             return
 
-        if not primary_address:
-            logger.error("Cluster has no primary. Check cluster status on online units.")
-            self.app.status = MaintenanceStatus("Cluster has no primary.")
+        logger.info(f"Unit workload member-state is {state} with member-role {role}")
+        self.unit_peer_data["member-role"] = role
+        self.unit_peer_data["member-state"] = state
+        self.unit.status = self.unit_workload_status
+
+        if self._handle_potential_cluster_crash_scenario(state):
             return
 
-        if "s3-block-message" in self.app_peer_data:
-            self.app.status = BlockedStatus(self.app_peer_data["s3-block-message"])
+        self._set_app_status(state)
+
+    def _set_app_status(self, state: str) -> None:
+        """Set the application status based on the cluster state."""
+        if not self.unit.is_leader() or state != InstanceState.ONLINE:
             return
 
-        # Set active status when primary is known
-        self.app.status = ActiveStatus()
+        block_message = self.app_peer_data.get("s3-block-message")
+        if block_message:
+            self.app.status = BlockedStatus(block_message)
+            return
+
+        self.app.status = self.app_workload_status
 
     def _on_peer_relation_changed(self, event: RelationChangedEvent) -> None:
         """Handle the relation changed event."""

--- a/kubernetes/src/charm.py
+++ b/kubernetes/src/charm.py
@@ -357,7 +357,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             logger.info(f"Creating cluster {self.app_peer_data['cluster-name']}")
             self.create_cluster()
             self.unit.set_ports(3306, 33060)
-            self.unit.status = self.unit_workload_status
+            self.unit.status = self.build_unit_workload_status()
         except (
             MySQLCreateClusterError,
             MySQLCreateClusterSetError,
@@ -477,7 +477,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
                 return
 
         self.unit_peer_data["member-state"] = InstanceState.ONLINE.value
-        self.unit.status = self.unit_workload_status
+        self.unit.status = self.build_unit_workload_status()
         logger.info(f"Instance {instance_label} added to cluster")
 
     def _reconcile_pebble_layer(self, container: Container) -> None:
@@ -860,7 +860,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
                     if single_node_cluster and all_states == {"waiting"}:
                         self._mysql.drop_group_replication_metadata_schema()
                         self.create_cluster()
-                        self.unit.status = self.unit_workload_status
+                        self.unit.status = self.build_unit_workload_status()
                     else:
                         self.unit.status = BlockedStatus("failed to recover cluster.")
                 return True
@@ -983,7 +983,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         logger.info(f"Unit workload member-state is {state} with member-role {role}")
         self.unit_peer_data["member-role"] = role
         self.unit_peer_data["member-state"] = state
-        self.unit.status = self.unit_workload_status
+        self.unit.status = self.build_unit_workload_status()
 
         if self._handle_potential_cluster_crash_scenario(state):
             return
@@ -1000,7 +1000,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             self.app.status = BlockedStatus(block_message)
             return
 
-        self.app.status = self.app_workload_status
+        self.app.status = self.build_app_workload_status()
 
     def _on_peer_relation_changed(self, event: RelationChangedEvent) -> None:
         """Handle the relation changed event."""

--- a/kubernetes/tests/integration/integration/high_availability/test_primary_switchover.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_primary_switchover.py
@@ -16,7 +16,6 @@ from ...helpers_ha import (
     get_mysql_primary_unit,
     update_interval,
     wait_for_apps_status,
-    wait_for_unit_message,
     wait_for_unit_status,
 )
 
@@ -116,8 +115,8 @@ def test_cluster_failover_after_majority_loss(juju: Juju) -> None:
         juju.wait(
             ready=lambda status: all((
                 wait_for_unit_status(app_name, unit_to_promote, "active")(status),
-                wait_for_unit_message(app_name, units_to_kill[0], "OFFLINE")(status),
-                wait_for_unit_message(app_name, units_to_kill[1], "OFFLINE")(status),
+                wait_for_unit_status(app_name, units_to_kill[0], "maintenance")(status),
+                wait_for_unit_status(app_name, units_to_kill[1], "maintenance")(status),
             )),
             timeout=15 * MINUTE_SECS,
             delay=15,

--- a/kubernetes/tests/unit/test_charm.py
+++ b/kubernetes/tests/unit/test_charm.py
@@ -149,7 +149,7 @@ class TestCharm(unittest.TestCase):
     @patch("mysql_k8s_helpers.MySQL.install_components")
     @patch("mysql_k8s_helpers.MySQL.cluster_metadata_exists", return_value=False)
     @patch("mysql_k8s_helpers.MySQL.rescan_cluster")
-    @patch("charms.mysql.v0.mysql.MySQLCharmBase.active_status_message", return_value="")
+    @patch("charms.mysql.v0.mysql.MySQLCharmBase.unit_workload_status", new_callable=PropertyMock)
     @patch("upgrade.MySQLK8sUpgrade.idle", return_value=True)
     @patch("mysql_k8s_helpers.MySQL.write_content_to_file")
     @patch("mysql_k8s_helpers.MySQL.is_data_dir_initialised", return_value=False)
@@ -197,12 +197,14 @@ class TestCharm(unittest.TestCase):
         _is_data_dir_initialised,
         _write_content_to_file,
         _upgrade_idle,
-        _active_status_message,
+        _unit_workload_status,
         _rescan_cluster,
         _cluster_metadata_exists,
         _install_components,
         _get_unit_address,
     ):
+        _unit_workload_status.return_value = ActiveStatus()
+
         # Check if initial plan is empty
         self.harness.set_can_connect("mysql", True)
         initial_plan = self.harness.get_container_pebble_plan("mysql")

--- a/kubernetes/tests/unit/test_charm.py
+++ b/kubernetes/tests/unit/test_charm.py
@@ -149,7 +149,7 @@ class TestCharm(unittest.TestCase):
     @patch("mysql_k8s_helpers.MySQL.install_components")
     @patch("mysql_k8s_helpers.MySQL.cluster_metadata_exists", return_value=False)
     @patch("mysql_k8s_helpers.MySQL.rescan_cluster")
-    @patch("charms.mysql.v0.mysql.MySQLCharmBase.unit_workload_status", new_callable=PropertyMock)
+    @patch("charms.mysql.v0.mysql.MySQLCharmBase.build_unit_workload_status")
     @patch("upgrade.MySQLK8sUpgrade.idle", return_value=True)
     @patch("mysql_k8s_helpers.MySQL.write_content_to_file")
     @patch("mysql_k8s_helpers.MySQL.is_data_dir_initialised", return_value=False)
@@ -197,13 +197,13 @@ class TestCharm(unittest.TestCase):
         _is_data_dir_initialised,
         _write_content_to_file,
         _upgrade_idle,
-        _unit_workload_status,
+        _build_unit_workload_status,
         _rescan_cluster,
         _cluster_metadata_exists,
         _install_components,
         _get_unit_address,
     ):
-        _unit_workload_status.return_value = ActiveStatus()
+        _build_unit_workload_status.return_value = ActiveStatus()
 
         # Check if initial plan is empty
         self.harness.set_can_connect("mysql", True)

--- a/machines/lib/charms/mysql/v0/async_replication.py
+++ b/machines/lib/charms/mysql/v0/async_replication.py
@@ -34,7 +34,6 @@ from mysql_shell.models import (
 )
 from ops import (
     ActionEvent,
-    ActiveStatus,
     BlockedStatus,
     MaintenanceStatus,
     Relation,
@@ -247,7 +246,7 @@ class MySQLAsyncReplication(Object):
 
                         self._charm._mysql.remove_replica_cluster(cluster_name, force=force)
                         logger.info(f"Replica cluster {cluster_name} removed")
-                        self._charm.unit.status = ActiveStatus(self._charm.active_status_message)
+                        self._charm.unit.status = self._charm.unit_workload_status
                     else:
                         logger.warning(
                             f"Replica cluster {cluster_name} not found in cluster set, skipping removal"

--- a/machines/lib/charms/mysql/v0/async_replication.py
+++ b/machines/lib/charms/mysql/v0/async_replication.py
@@ -246,7 +246,7 @@ class MySQLAsyncReplication(Object):
 
                         self._charm._mysql.remove_replica_cluster(cluster_name, force=force)
                         logger.info(f"Replica cluster {cluster_name} removed")
-                        self._charm.unit.status = self._charm.unit_workload_status
+                        self._charm.unit.status = self._charm.build_unit_workload_status()
                     else:
                         logger.warning(
                             f"Replica cluster {cluster_name} not found in cluster set, skipping removal"

--- a/machines/lib/charms/mysql/v0/mysql.py
+++ b/machines/lib/charms/mysql/v0/mysql.py
@@ -829,19 +829,44 @@ class MySQLCharmBase(CharmBase, ABC):
         return len(active_cos_relations) > 0
 
     @property
-    def active_status_message(self) -> str:
-        """Active status message."""
-        if self.unit_peer_data.get("member-role") != "primary":
-            return ""
+    def app_workload_status(self) -> ops.StatusBase:
+        """App status generated from the workload."""
+        status = self._mysql.get_cluster_status()
+        if not status:
+            return ops.MaintenanceStatus("Unknown")
+
+        units = status["defaultReplicaSet"]["topology"].keys()
+        status = status["defaultReplicaSet"]["status"]
+
+        if status in [ClusterStatus.OK, ClusterStatus.OK_PARTIAL]:
+            return ops.ActiveStatus("Healthy")
+        if status in [ClusterStatus.OK_NO_TOLERANCE, ClusterStatus.OK_NO_TOLERANCE_PARTIAL]:
+            return ops.ActiveStatus("Healthy") if len(units) < 3 else ops.ActiveStatus("Degraded")
+        if status in [ClusterStatus.NO_QUORUM]:
+            return ops.BlockedStatus("No quorum")
+        if status in [ClusterStatus.OFFLINE, ClusterStatus.ERROR]:
+            return ops.BlockedStatus("No online members")
+        if status in [ClusterStatus.UNREACHABLE]:
+            return ops.BlockedStatus("No connectivity")
+
+        return ops.MaintenanceStatus("Unknown")
+
+    @property
+    def unit_workload_status(self) -> ops.StatusBase:
+        """Unit status generated from the workload."""
+        if self.unit_peer_data.get("member-state") != InstanceState.ONLINE:
+            return ops.MaintenanceStatus("")
+        if self.unit_peer_data.get("member-role") != InstanceRole.PRIMARY:
+            return ops.ActiveStatus("")
 
         if self._mysql.is_cluster_replica() is False:
-            return "Primary"
+            return ops.ActiveStatus("Primary")
 
         status = self._mysql.get_replica_cluster_status()
         if status == ClusterGlobalStatus.OK:
-            return "Standby"
+            return ops.ActiveStatus("Standby")
         else:
-            return f"Standby ({status})"
+            return ops.ActiveStatus(f"Standby ({status})")
 
     @property
     def removing_unit(self) -> bool:

--- a/machines/lib/charms/mysql/v0/mysql.py
+++ b/machines/lib/charms/mysql/v0/mysql.py
@@ -653,8 +653,8 @@ class MySQLCharmBase(CharmBase, ABC):
         logger.info("Recreating cluster")
         try:
             self.create_cluster()
-            self.unit.status = ops.ActiveStatus(self.active_status_message)
-            self.app.status = ops.ActiveStatus()
+            self.unit.status = self.build_unit_workload_status()
+            self.app.status = self.build_app_workload_status()
         except (MySQLCreateClusterError, MySQLCreateClusterSetError) as e:
             logger.exception("Failed to recreate cluster")
             event.fail(str(e))
@@ -829,7 +829,11 @@ class MySQLCharmBase(CharmBase, ABC):
         return len(active_cos_relations) > 0
 
     @property
-    def app_workload_status(self) -> ops.StatusBase:
+    def removing_unit(self) -> bool:
+        """Check if the unit is being removed."""
+        return self.unit_peer_data.get("unit-status") == "removing"
+
+    def build_app_workload_status(self) -> ops.StatusBase:
         """App status generated from the workload."""
         status = self._mysql.get_cluster_status()
         if not status:
@@ -851,8 +855,7 @@ class MySQLCharmBase(CharmBase, ABC):
 
         return ops.MaintenanceStatus("Unknown")
 
-    @property
-    def unit_workload_status(self) -> ops.StatusBase:
+    def build_unit_workload_status(self) -> ops.StatusBase:
         """Unit status generated from the workload."""
         if self.unit_peer_data.get("member-state") != InstanceState.ONLINE:
             return ops.MaintenanceStatus("")
@@ -867,11 +870,6 @@ class MySQLCharmBase(CharmBase, ABC):
             return ops.ActiveStatus("Standby")
         else:
             return ops.ActiveStatus(f"Standby ({status})")
-
-    @property
-    def removing_unit(self) -> bool:
-        """Check if the unit is being removed."""
-        return self.unit_peer_data.get("unit-status") == "removing"
 
     def unit_initialized(self, raise_exceptions: bool = False) -> bool:
         """Check if the unit is added to the cluster."""

--- a/machines/src/charm.py
+++ b/machines/src/charm.py
@@ -521,7 +521,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             self.app.status = BlockedStatus(block_message)
             return
 
-        self.app.status = self.app_workload_status
+        self.app.status = self.build_app_workload_status()
 
     def _on_update_status(self, _) -> None:
         """Handle update status.
@@ -574,7 +574,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         logger.info(f"Unit workload member-state is {state} with member-role {role}")
         self.unit_peer_data["member-role"] = role
         self.unit_peer_data["member-state"] = state
-        self.unit.status = self.unit_workload_status
+        self.unit.status = self.build_unit_workload_status()
 
         if not self._handle_non_online_instance_status(state):
             return
@@ -846,7 +846,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             logger.info(f"Creating cluster {self.app_peer_data['cluster-name']}")
             self.create_cluster()
             self.unit.set_ports(3306, 33060)
-            self.unit.status = self.unit_workload_status
+            self.unit.status = self.build_unit_workload_status()
         except (
             MySQLCreateClusterError,
             MySQLCreateClusterSetError,
@@ -945,7 +945,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
                 return
 
         self.unit_peer_data["member-state"] = InstanceState.ONLINE.value
-        self.unit.status = self.unit_workload_status
+        self.unit.status = self.build_unit_workload_status()
         logger.info(f"Instance {instance_label} added to cluster")
 
     def recover_unit_after_restart(self) -> None:

--- a/machines/src/charm.py
+++ b/machines/src/charm.py
@@ -51,7 +51,6 @@ from charms.mysql.v0.mysql import (
 from charms.mysql.v0.tls import MySQLTLS
 from charms.rolling_ops.v0.rollingops import RollingOpsManager
 from ops import (
-    ActiveStatus,
     BlockedStatus,
     EventBase,
     InstallEvent,
@@ -512,7 +511,19 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             from_instance=cluster_primary,
         )
 
-    def _on_update_status(self, _) -> None:  # noqa: C901
+    def _set_app_status(self, state: str) -> None:
+        """Set the application status based on the cluster state."""
+        if not self.unit.is_leader() or state != InstanceState.ONLINE:
+            return
+
+        block_message = self.app_peer_data.get("s3-block-message")
+        if block_message:
+            self.app.status = BlockedStatus(block_message)
+            return
+
+        self.app.status = self.app_workload_status
+
+    def _on_update_status(self, _) -> None:
         """Handle update status.
 
         Takes care of workload health checks.
@@ -563,34 +574,12 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         logger.info(f"Unit workload member-state is {state} with member-role {role}")
         self.unit_peer_data["member-role"] = role
         self.unit_peer_data["member-state"] = state
-
-        # set unit status based on member-{state,role}
-        self.unit.status = (
-            ActiveStatus(self.active_status_message)
-            if state == InstanceState.ONLINE
-            else MaintenanceStatus(state)
-        )
+        self.unit.status = self.unit_workload_status
 
         if not self._handle_non_online_instance_status(state):
             return
 
-        if self.unit.is_leader() and state == InstanceState.ONLINE:
-            try:
-                primary_address = self._mysql.get_cluster_primary_address()
-            except MySQLGetClusterPrimaryAddressError:
-                primary_address = None
-
-            if not primary_address:
-                logger.error("Cluster has no primary. Check cluster status on online units.")
-                self.app.status = MaintenanceStatus("Cluster has no primary.")
-                return
-
-            if "s3-block-message" in self.app_peer_data:
-                self.app.status = BlockedStatus(self.app_peer_data["s3-block-message"])
-                return
-
-            # Set active status when primary is known
-            self.app.status = ActiveStatus()
+        self._set_app_status(state)
 
     def _on_cos_agent_relation_created(self, event: RelationCreatedEvent) -> None:
         """Handle the cos_agent relation created event.
@@ -857,7 +846,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             logger.info(f"Creating cluster {self.app_peer_data['cluster-name']}")
             self.create_cluster()
             self.unit.set_ports(3306, 33060)
-            self.unit.status = ActiveStatus(self.active_status_message)
+            self.unit.status = self.unit_workload_status
         except (
             MySQLCreateClusterError,
             MySQLCreateClusterSetError,
@@ -956,7 +945,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
                 return
 
         self.unit_peer_data["member-state"] = InstanceState.ONLINE.value
-        self.unit.status = ActiveStatus(self.active_status_message)
+        self.unit.status = self.unit_workload_status
         logger.info(f"Instance {instance_label} added to cluster")
 
     def recover_unit_after_restart(self) -> None:

--- a/machines/tests/integration/integration/high_availability/test_primary_switchover.py
+++ b/machines/tests/integration/integration/high_availability/test_primary_switchover.py
@@ -14,7 +14,6 @@ from ...helpers_ha import (
     get_unit_machine,
     update_interval,
     wait_for_apps_status,
-    wait_for_unit_message,
     wait_for_unit_status,
 )
 
@@ -114,8 +113,8 @@ def test_cluster_failover_after_majority_loss(juju: Juju) -> None:
         juju.wait(
             ready=lambda status: all((
                 wait_for_unit_status(app_name, unit_to_promote, "active")(status),
-                wait_for_unit_message(app_name, units_to_kill[0], "OFFLINE")(status),
-                wait_for_unit_message(app_name, units_to_kill[1], "OFFLINE")(status),
+                wait_for_unit_status(app_name, units_to_kill[0], "maintenance")(status),
+                wait_for_unit_status(app_name, units_to_kill[1], "maintenance")(status),
             )),
             timeout=15 * MINUTE_SECS,
             delay=15,

--- a/machines/tests/unit/test_charm.py
+++ b/machines/tests/unit/test_charm.py
@@ -168,7 +168,7 @@ class TestCharm(unittest.TestCase):
         _create_cluster.assert_called_once()
         _can_start.assert_called_once()
 
-        self.assertTrue(isinstance(self.harness.model.unit.status, ActiveStatus))
+        self.assertTrue(isinstance(self.harness.model.unit.status, MaintenanceStatus))
 
         self.harness.set_leader(False)
         self.charm.on.start.emit()
@@ -236,10 +236,10 @@ class TestCharm(unittest.TestCase):
         new_callable=PropertyMock(return_value=True),
     )
     @patch("charm.MySQLOperatorCharm.unit_initialized", return_value=True)
-    @patch("charms.mysql.v0.mysql.MySQLCharmBase.active_status_message", return_value="")
+    @patch("charms.mysql.v0.mysql.MySQLCharmBase.unit_workload_status", new_callable=PropertyMock)
     @patch("mysql_vm_helpers.MySQL.get_member_state")
     @patch("mysql_vm_helpers.MySQL.get_member_role")
-    @patch("mysql_vm_helpers.MySQL.get_cluster_primary_address")
+    @patch("mysql_vm_helpers.MySQL.get_cluster_status")
     @patch("charm.is_volume_mounted", return_value=True)
     @patch("mysql_vm_helpers.MySQL.reboot_from_complete_outage")
     @patch("charm.snap_service_operation")
@@ -258,10 +258,10 @@ class TestCharm(unittest.TestCase):
         _snap_service_operation,
         _reboot_from_complete_outage,
         _is_volume_mounted,
-        _get_cluster_primary_address,
+        _get_cluster_status,
         _get_member_role,
         _get_member_state,
-        _active_status_message,
+        _unit_workload_status,
         _unit_initialized,
         _cluster_initialized,
     ):
@@ -286,6 +286,7 @@ class TestCharm(unittest.TestCase):
         )
         _get_member_role.return_value = "PRIMARY"
         _get_member_state.return_value = "ONLINE"
+        _unit_workload_status.return_value = ActiveStatus()
 
         self.charm.on.update_status.emit()
         _get_member_role.assert_called_once()
@@ -293,17 +294,19 @@ class TestCharm(unittest.TestCase):
         _reboot_from_complete_outage.assert_not_called()
         _snap_service_operation.assert_not_called()
         _is_volume_mounted.assert_called_once()
-        _get_cluster_primary_address.assert_called_once()
+        _get_cluster_status.assert_called_once()
 
         self.assertTrue(isinstance(self.harness.model.unit.status, ActiveStatus))
 
         # test instance state = offline
         _get_member_role.reset_mock()
         _get_member_state.reset_mock()
-        _get_cluster_primary_address.reset_mock()
+        _unit_workload_status.reset_mock()
+        _get_cluster_status.reset_mock()
 
         _get_member_role.return_value = "PRIMARY"
         _get_member_state.return_value = "OFFLINE"
+        _unit_workload_status.return_value = MaintenanceStatus()
         self.harness.update_relation_data(
             self.peer_relation_id,
             self.charm.unit.name,
@@ -317,25 +320,27 @@ class TestCharm(unittest.TestCase):
         _get_member_state.assert_called_once()
         _reboot_from_complete_outage.assert_called_once()
         _snap_service_operation.assert_called()
-        _get_cluster_primary_address.assert_not_called()
+        _get_cluster_status.assert_not_called()
 
         self.assertTrue(isinstance(self.harness.model.unit.status, MaintenanceStatus))
         # test instance state = unreachable
         _get_member_role.reset_mock()
         _get_member_state.reset_mock()
-        _get_cluster_primary_address.reset_mock()
+        _unit_workload_status.reset_mock()
+        _get_cluster_status.reset_mock()
         _snap_service_operation.reset_mock()
 
         _reboot_from_complete_outage.reset_mock()
         _snap_service_operation.return_value = False
         _get_member_role.return_value = "PRIMARY"
         _get_member_state.return_value = "UNREACHABLE"
+        _unit_workload_status.return_value = BlockedStatus()
 
         self.charm.on.update_status.emit()
         _get_member_role.assert_called_once()
         _get_member_state.assert_called_once()
         _reboot_from_complete_outage.assert_not_called()
         _snap_service_operation.assert_called_once()
-        _get_cluster_primary_address.assert_not_called()
+        _get_cluster_status.assert_not_called()
 
         self.assertTrue(isinstance(self.harness.model.unit.status, BlockedStatus))

--- a/machines/tests/unit/test_charm.py
+++ b/machines/tests/unit/test_charm.py
@@ -236,7 +236,7 @@ class TestCharm(unittest.TestCase):
         new_callable=PropertyMock(return_value=True),
     )
     @patch("charm.MySQLOperatorCharm.unit_initialized", return_value=True)
-    @patch("charms.mysql.v0.mysql.MySQLCharmBase.unit_workload_status", new_callable=PropertyMock)
+    @patch("charms.mysql.v0.mysql.MySQLCharmBase.build_unit_workload_status")
     @patch("mysql_vm_helpers.MySQL.get_member_state")
     @patch("mysql_vm_helpers.MySQL.get_member_role")
     @patch("mysql_vm_helpers.MySQL.get_cluster_status")
@@ -261,7 +261,7 @@ class TestCharm(unittest.TestCase):
         _get_cluster_status,
         _get_member_role,
         _get_member_state,
-        _unit_workload_status,
+        _build_unit_workload_status,
         _unit_initialized,
         _cluster_initialized,
     ):
@@ -286,7 +286,7 @@ class TestCharm(unittest.TestCase):
         )
         _get_member_role.return_value = "PRIMARY"
         _get_member_state.return_value = "ONLINE"
-        _unit_workload_status.return_value = ActiveStatus()
+        _build_unit_workload_status.return_value = ActiveStatus()
 
         self.charm.on.update_status.emit()
         _get_member_role.assert_called_once()
@@ -301,12 +301,12 @@ class TestCharm(unittest.TestCase):
         # test instance state = offline
         _get_member_role.reset_mock()
         _get_member_state.reset_mock()
-        _unit_workload_status.reset_mock()
+        _build_unit_workload_status.reset_mock()
         _get_cluster_status.reset_mock()
 
         _get_member_role.return_value = "PRIMARY"
         _get_member_state.return_value = "OFFLINE"
-        _unit_workload_status.return_value = MaintenanceStatus()
+        _build_unit_workload_status.return_value = MaintenanceStatus()
         self.harness.update_relation_data(
             self.peer_relation_id,
             self.charm.unit.name,
@@ -326,7 +326,7 @@ class TestCharm(unittest.TestCase):
         # test instance state = unreachable
         _get_member_role.reset_mock()
         _get_member_state.reset_mock()
-        _unit_workload_status.reset_mock()
+        _build_unit_workload_status.reset_mock()
         _get_cluster_status.reset_mock()
         _snap_service_operation.reset_mock()
 
@@ -334,7 +334,7 @@ class TestCharm(unittest.TestCase):
         _snap_service_operation.return_value = False
         _get_member_role.return_value = "PRIMARY"
         _get_member_state.return_value = "UNREACHABLE"
-        _unit_workload_status.return_value = BlockedStatus()
+        _build_unit_workload_status.return_value = BlockedStatus()
 
         self.charm.on.update_status.emit()
         _get_member_role.assert_called_once()


### PR DESCRIPTION
This PR reworks the app status setting by doing a mapping between the MySQL cluster status and the Juju app status:

- When MySQL cluster has > 3 instances and cluster state is `OK_*` -> Active and healthy.
- When MySQL cluster has > 3 instances and cluster state is `OK_NOT_TOLERANCE_*` -> Active but degraded.
- When MySQL cluster is in any other known state -> Blocked.
- When MySQL cluster is in any unknown state -> Maintenance.

#### References:
- MySQL cluster statuses [documentation](https://dev.mysql.com/doc/mysql-shell/8.4/en/monitoring-innodb-cluster.html#:~:text=status%3A%20The%20status%20of%20the%20InnoDB%20Cluster.%20The%20status%20describes%20the%20high%20availability%20provided%20by%20this%20cluster.%20The%20status%20is%20one%20of%20the%20following).