### PR TITLE
[MISC] Use Juju `3.6/candidate` to fix "connection shutdown" errors

### DIFF
--- a/kubernetes/spread.yaml
+++ b/kubernetes/spread.yaml
@@ -107,7 +107,7 @@ path: /root/spread_project
 kill-timeout: 3h
 environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
-  CONCIERGE_JUJU_CHANNEL/juju36: 3.6/stable
+  CONCIERGE_JUJU_CHANNEL/juju36: 3.6/candidate
 prepare: |
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"

--- a/kubernetes/tests/integration/integration/test_multi_relations.py
+++ b/kubernetes/tests/integration/integration/test_multi_relations.py
@@ -3,8 +3,7 @@
 # See LICENSE file for licensing details.
 
 import jubilant
-from jubilant import CLIError, Juju
-from tenacity import RetryError, Retrying, retry_if_exception_type, stop_after_attempt, wait_fixed
+from jubilant import Juju
 
 from ..helpers_ha import CHARM_METADATA, MINUTE_SECS, wait_for_apps_status, wait_for_unit_status
 
@@ -46,109 +45,71 @@ def test_build_and_deploy(juju: Juju, charm):
         )
 
     # Wait until deployment is complete in attempt to reduce CPU stress
-    retry_if_cli_error(
-        lambda: juju.wait(
-            wait_for_apps_status(
-                jubilant.all_active,
-                MYSQL_APP_NAME,
-            ),
-            delay=5.0,
-            timeout=25 * MINUTE_SECS,
-        )
+    juju.wait(
+        wait_for_apps_status(
+            jubilant.all_active,
+            MYSQL_APP_NAME,
+        ),
+        delay=5.0,
+        timeout=25 * MINUTE_SECS,
     )
-    retry_if_cli_error(
-        lambda: juju.wait(
-            wait_for_apps_status(
-                jubilant.all_waiting,
-                *(f"app{idx}" for idx in range(SCALE_APPS)),
-            ),
-            delay=5.0,
-            timeout=25 * MINUTE_SECS,
-        )
+
+    juju.wait(
+        wait_for_apps_status(
+            jubilant.all_waiting,
+            *(f"app{idx}" for idx in range(SCALE_APPS)),
+        ),
+        delay=5.0,
+        timeout=25 * MINUTE_SECS,
     )
-    retry_if_cli_error(
-        lambda: juju.wait(
-            ready=lambda status: all((
-                *(
-                    wait_for_unit_status(f"router{idx}", unit_name, "waiting")(status)
-                    for idx in range(SCALE_APPS)
-                    for unit_name in status.get_units(f"router{idx}")
-                ),
-            )),
-            delay=5.0,
-            timeout=25 * MINUTE_SECS,
-        )
+
+    juju.wait(
+        ready=lambda status: all((
+            *(
+                wait_for_unit_status(f"router{idx}", unit_name, "waiting")(status)
+                for idx in range(SCALE_APPS)
+                for unit_name in status.get_units(f"router{idx}")
+            ),
+        )),
+        delay=5.0,
+        timeout=25 * MINUTE_SECS,
     )
 
 
 def test_relate_all(juju: Juju):
     """Relate all the applications to the database."""
     for idx in range(SCALE_APPS):
-        retry_if_cli_error(
-            lambda idx=idx: juju.integrate(
-                f"{MYSQL_APP_NAME}:database", f"router{idx}:backend-database"
-            )
-        )
-        retry_if_cli_error(
-            lambda idx=idx: juju.integrate(f"app{idx}:database", f"router{idx}:database")
-        )
+        juju.integrate(f"{MYSQL_APP_NAME}:database", f"router{idx}:backend-database")
+        juju.integrate(f"app{idx}:database", f"router{idx}:database")
 
-    retry_if_cli_error(
-        lambda: juju.wait(
-            jubilant.all_active,
-            delay=5.0,
-            timeout=25 * MINUTE_SECS,
-        )
+    juju.wait(
+        jubilant.all_active,
+        delay=5.0,
+        timeout=25 * MINUTE_SECS,
     )
 
 
 def test_scale_out(juju: Juju):
     """Scale database and routers."""
-    retry_if_cli_error(lambda: juju.add_unit(MYSQL_APP_NAME, num_units=SCALE_UNITS - 1))
+    juju.add_unit(MYSQL_APP_NAME, num_units=SCALE_UNITS - 1)
     for idx in range(SCALE_APPS):
-        retry_if_cli_error(
-            lambda idx=idx: juju.add_unit(f"router{idx}", num_units=SCALE_UNITS - 1)
-        )
+        juju.add_unit(f"router{idx}", num_units=SCALE_UNITS - 1)
 
-    retry_if_cli_error(
-        lambda: juju.wait(
-            jubilant.all_active,
-            delay=5.0,
-            timeout=30 * MINUTE_SECS,
-        )
+    juju.wait(
+        jubilant.all_active,
+        delay=5.0,
+        timeout=30 * MINUTE_SECS,
     )
 
 
 def test_scale_in(juju: Juju):
     """Scale database and routers."""
-    retry_if_cli_error(lambda: juju.remove_unit(MYSQL_APP_NAME, num_units=SCALE_UNITS - 1))
+    juju.remove_unit(MYSQL_APP_NAME, num_units=SCALE_UNITS - 1)
     for idx in range(SCALE_APPS):
-        retry_if_cli_error(
-            lambda idx=idx: juju.remove_unit(f"router{idx}", num_units=SCALE_UNITS - 1)
-        )
+        juju.remove_unit(f"router{idx}", num_units=SCALE_UNITS - 1)
 
-    retry_if_cli_error(
-        lambda: juju.wait(
-            jubilant.all_active,
-            delay=5.0,
-            timeout=15 * MINUTE_SECS,
-        )
+    juju.wait(
+        jubilant.all_active,
+        delay=5.0,
+        timeout=15 * MINUTE_SECS,
     )
-
-
-# All jubilant.Juju operations risk raising intermittent CLIErrors under CPU pressure,
-# so we wrap each of them
-def retry_if_cli_error(fn, *, max_attempts=10):
-    try:
-        for attempt in Retrying(
-            retry=retry_if_exception_type(CLIError),
-            stop=stop_after_attempt(max_attempts),
-            wait=wait_fixed(10),
-        ):
-            with attempt:
-                fn()
-
-    except RetryError as exc:
-        raise AssertionError(
-            f"Operation failed after {max_attempts} attempts"
-        ) from exc.last_attempt.exception()

--- a/machines/spread.yaml
+++ b/machines/spread.yaml
@@ -110,7 +110,7 @@ path: /root/spread_project
 kill-timeout: 3h
 environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
-  CONCIERGE_JUJU_CHANNEL/juju36: 3.6/stable
+  CONCIERGE_JUJU_CHANNEL/juju36: 3.6/candidate
 prepare: |
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"


### PR DESCRIPTION
## Issue

https://github.com/canonical/mysql-operators/pull/79 has zero such errors so far 🎉 

This should make our CI way more robust.

I removed the snowflake retry wrapper in `test_multi_relations.py`.

## Solution

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
