### PR TITLE
[MISC] Update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MySQL operators
-[![Charmhub](https://charmhub.io/mysql/badge.svg)](https://charmhub.io/mysql)
-[![Charmhub](https://charmhub.io/mysql-k8s/badge.svg)](https://charmhub.io/mysql-k8s)
+[![Charmhub](https://charmhub.io/mysql/badge.svg?channel=8.0/edge)](https://charmhub.io/mysql)
+[![Charmhub](https://charmhub.io/mysql-k8s/badge.svg?channel=8.0/edge)](https://charmhub.io/mysql-k8s)
 [![Release](https://github.com/canonical/mysql-operators/actions/workflows/release.yaml/badge.svg?branch=8.0/edge)](https://github.com/canonical/mysql-operators/actions/workflows/release.yaml)
 [![Tests](https://github.com/canonical/mysql-operators/actions/workflows/ci.yaml/badge.svg?branch=8.0/edge)](https://github.com/canonical/mysql-operators/actions/workflows/ci.yaml)
 


### PR DESCRIPTION
This PR updates README badges on the `8.0/edge` branch, so they no longer depend on which is the default channel.
