### PR TITLE
[DPE-8295] Refresh V3 (I) - Bump incompatible deps

### DIFF
--- a/kubernetes/charmcraft.yaml
+++ b/kubernetes/charmcraft.yaml
@@ -49,7 +49,7 @@ parts:
       apt-get install rustup -y
 
       rustup set profile minimal
-      rustup default 1.90.0  # renovate: charmcraft-rust-latest
+      rustup default 1.93.1  # renovate: charmcraft-rust-latest
 
       craftctl default
       

--- a/kubernetes/poetry.lock
+++ b/kubernetes/poetry.lock
@@ -617,6 +617,34 @@ files = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.3.0"
+description = "Pure-Python HTTP/2 protocol implementation"
+optional = false
+python-versions = ">=3.9"
+groups = ["main", "charm-libs", "integration"]
+files = [
+    {file = "h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd"},
+    {file = "h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1"},
+]
+
+[package.dependencies]
+hpack = ">=4.1,<5"
+hyperframe = ">=6.1,<7"
+
+[[package]]
+name = "hpack"
+version = "4.1.0"
+description = "Pure-Python HPACK header encoding"
+optional = false
+python-versions = ">=3.9"
+groups = ["main", "charm-libs", "integration"]
+files = [
+    {file = "hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496"},
+    {file = "hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca"},
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 description = "A minimal low-level HTTP client."
@@ -640,28 +668,29 @@ trio = ["trio (>=0.22.0,<1.0)"]
 
 [[package]]
 name = "httpx"
-version = "0.27.0"
+version = "0.28.1"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "charm-libs", "integration"]
 files = [
-    {file = "httpx-0.27.0-py3-none-any.whl", hash = "sha256:71d5465162c13681bff01ad59b2cc68dd838ea1f10e51574bac27103f00c91a5"},
-    {file = "httpx-0.27.0.tar.gz", hash = "sha256:a0cb88a46f32dc874e04ee956e4c2764aba2aa228f650b06788ba6bda2962ab5"},
+    {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
+    {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
 ]
 
 [package.dependencies]
 anyio = "*"
 certifi = "*"
+h2 = {version = ">=3,<5", optional = true, markers = "extra == \"http2\""}
 httpcore = "==1.*"
 idna = "*"
-sniffio = "*"
 
 [package.extras]
 brotli = ["brotli ; platform_python_implementation == \"CPython\"", "brotlicffi ; platform_python_implementation != \"CPython\""]
 cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
+zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "hvac"
@@ -680,6 +709,18 @@ requests = ">=2.27.1,<3.0.0"
 
 [package.extras]
 parser = ["pyhcl (>=0.4.4,<0.5.0)"]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+description = "Pure-Python HTTP/2 framing"
+optional = false
+python-versions = ">=3.9"
+groups = ["main", "charm-libs", "integration"]
+files = [
+    {file = "hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5"},
+    {file = "hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08"},
+]
 
 [[package]]
 name = "idna"
@@ -866,23 +907,23 @@ adal = ["adal (>=1.0.2)"]
 
 [[package]]
 name = "lightkube"
-version = "0.15.8"
+version = "0.19.1"
 description = "Lightweight kubernetes client library"
 optional = false
-python-versions = "*"
+python-versions = ">=3.8"
 groups = ["main", "charm-libs", "integration"]
 files = [
-    {file = "lightkube-0.15.8-py3-none-any.whl", hash = "sha256:236f6d11e9281764a8ae896ab2c28a4bc943dc0576822445064577eaa90677ba"},
-    {file = "lightkube-0.15.8.tar.gz", hash = "sha256:ac950d24ddbb59904708730f13ce254b05b6255a471dfab027cbe44c4123bfc6"},
+    {file = "lightkube-0.19.1-py3-none-any.whl", hash = "sha256:49fef08a1c7aa42082820111ffd5dbbaf78f54c99385810690fc9d94eef5c80d"},
+    {file = "lightkube-0.19.1.tar.gz", hash = "sha256:4c8526068024c194c02fbc0ca6021922feb4b1b9d741d330129f873b27e0fe97"},
 ]
 
 [package.dependencies]
-httpx = ">=0.24.0,<0.28.0"
+httpx = {version = ">=0.28.1,<1.0.0", extras = ["http2"]}
 lightkube-models = ">=1.15.12.0"
-PyYAML = "*"
+pyyaml = "*"
 
 [package.extras]
-dev = ["pytest", "pytest-asyncio (<0.17.0)", "respx"]
+jinja-templates = ["jinja2"]
 
 [[package]]
 name = "lightkube-models"

--- a/kubernetes/pyproject.toml
+++ b/kubernetes/pyproject.toml
@@ -5,7 +5,7 @@
 main = [
     "boto3~=1.28",
     "jinja2~=3.1",
-    "lightkube~=0.15.0",
+    "lightkube~=0.19.0",
     "ops[tracing]~=3.5",
     "pyyaml~=6.0",
     "tenacity~=8.2",
@@ -51,7 +51,7 @@ integration = [
     "boto3~=1.28",
     "pyyaml~=6.0",
     "urllib3~=2.0",
-    "lightkube~=0.15.0",
+    "lightkube~=0.19.0",
     "kubernetes~=27.2.0",
     "allure-pytest~=2.13",
     "allure-pytest-default-results~=0.1.2",

--- a/machines/charmcraft.yaml
+++ b/machines/charmcraft.yaml
@@ -49,7 +49,7 @@ parts:
       apt-get install rustup -y
 
       rustup set profile minimal
-      rustup default 1.90.0  # renovate: charmcraft-rust-latest
+      rustup default 1.93.1  # renovate: charmcraft-rust-latest
 
       craftctl default
       


### PR DESCRIPTION
**This is the 1st PR from the refresh V3 implementation efforts**

This PR bumps the refresh V3 incompatible dependencies. The version of `lightkube` that we were using (i.e. 0.15.0), is incompatible with the upcoming version of `httpx`. Bumping it requires a newer version of Rust as well.