### PR TITLE
[DPE-8295] Refresh V3 (II) - Harmonize config parsing

### DIFF
--- a/kubernetes/charmcraft.yaml
+++ b/kubernetes/charmcraft.yaml
@@ -49,7 +49,7 @@ parts:
       apt-get install rustup -y
 
       rustup set profile minimal
-      rustup default 1.90.0  # renovate: charmcraft-rust-latest
+      rustup default 1.93.1  # renovate: charmcraft-rust-latest
 
       craftctl default
       

--- a/kubernetes/lib/charms/mysql/v0/mysql.py
+++ b/kubernetes/lib/charms/mysql/v0/mysql.py
@@ -2965,6 +2965,23 @@ class MySQLBase(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def write_content_to_file(
+        self,
+        path: str,
+        content: str,
+        owner: str,
+        group: str,
+        permission: int,
+    ) -> None:
+        """Write content to file."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def read_file_content(self, path: str) -> str | None:
+        """Reads a file content."""
+        raise NotImplementedError
+
+    @abstractmethod
     def reset_data_dir(self) -> None:
         """Reset the data directory."""
         raise NotImplementedError

--- a/kubernetes/poetry.lock
+++ b/kubernetes/poetry.lock
@@ -617,6 +617,34 @@ files = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.3.0"
+description = "Pure-Python HTTP/2 protocol implementation"
+optional = false
+python-versions = ">=3.9"
+groups = ["main", "charm-libs", "integration"]
+files = [
+    {file = "h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd"},
+    {file = "h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1"},
+]
+
+[package.dependencies]
+hpack = ">=4.1,<5"
+hyperframe = ">=6.1,<7"
+
+[[package]]
+name = "hpack"
+version = "4.1.0"
+description = "Pure-Python HPACK header encoding"
+optional = false
+python-versions = ">=3.9"
+groups = ["main", "charm-libs", "integration"]
+files = [
+    {file = "hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496"},
+    {file = "hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca"},
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 description = "A minimal low-level HTTP client."
@@ -640,28 +668,29 @@ trio = ["trio (>=0.22.0,<1.0)"]
 
 [[package]]
 name = "httpx"
-version = "0.27.0"
+version = "0.28.1"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "charm-libs", "integration"]
 files = [
-    {file = "httpx-0.27.0-py3-none-any.whl", hash = "sha256:71d5465162c13681bff01ad59b2cc68dd838ea1f10e51574bac27103f00c91a5"},
-    {file = "httpx-0.27.0.tar.gz", hash = "sha256:a0cb88a46f32dc874e04ee956e4c2764aba2aa228f650b06788ba6bda2962ab5"},
+    {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
+    {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
 ]
 
 [package.dependencies]
 anyio = "*"
 certifi = "*"
+h2 = {version = ">=3,<5", optional = true, markers = "extra == \"http2\""}
 httpcore = "==1.*"
 idna = "*"
-sniffio = "*"
 
 [package.extras]
 brotli = ["brotli ; platform_python_implementation == \"CPython\"", "brotlicffi ; platform_python_implementation != \"CPython\""]
 cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
+zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "hvac"
@@ -680,6 +709,18 @@ requests = ">=2.27.1,<3.0.0"
 
 [package.extras]
 parser = ["pyhcl (>=0.4.4,<0.5.0)"]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+description = "Pure-Python HTTP/2 framing"
+optional = false
+python-versions = ">=3.9"
+groups = ["main", "charm-libs", "integration"]
+files = [
+    {file = "hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5"},
+    {file = "hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08"},
+]
 
 [[package]]
 name = "idna"
@@ -866,23 +907,23 @@ adal = ["adal (>=1.0.2)"]
 
 [[package]]
 name = "lightkube"
-version = "0.15.8"
+version = "0.19.1"
 description = "Lightweight kubernetes client library"
 optional = false
-python-versions = "*"
+python-versions = ">=3.8"
 groups = ["main", "charm-libs", "integration"]
 files = [
-    {file = "lightkube-0.15.8-py3-none-any.whl", hash = "sha256:236f6d11e9281764a8ae896ab2c28a4bc943dc0576822445064577eaa90677ba"},
-    {file = "lightkube-0.15.8.tar.gz", hash = "sha256:ac950d24ddbb59904708730f13ce254b05b6255a471dfab027cbe44c4123bfc6"},
+    {file = "lightkube-0.19.1-py3-none-any.whl", hash = "sha256:49fef08a1c7aa42082820111ffd5dbbaf78f54c99385810690fc9d94eef5c80d"},
+    {file = "lightkube-0.19.1.tar.gz", hash = "sha256:4c8526068024c194c02fbc0ca6021922feb4b1b9d741d330129f873b27e0fe97"},
 ]
 
 [package.dependencies]
-httpx = ">=0.24.0,<0.28.0"
+httpx = {version = ">=0.28.1,<1.0.0", extras = ["http2"]}
 lightkube-models = ">=1.15.12.0"
-PyYAML = "*"
+pyyaml = "*"
 
 [package.extras]
-dev = ["pytest", "pytest-asyncio (<0.17.0)", "respx"]
+jinja-templates = ["jinja2"]
 
 [[package]]
 name = "lightkube-models"

--- a/kubernetes/pyproject.toml
+++ b/kubernetes/pyproject.toml
@@ -5,7 +5,7 @@
 main = [
     "boto3~=1.28",
     "jinja2~=3.1",
-    "lightkube~=0.15.0",
+    "lightkube~=0.19.0",
     "ops[tracing]~=3.5",
     "pyyaml~=6.0",
     "tenacity~=8.2",
@@ -51,7 +51,7 @@ integration = [
     "boto3~=1.28",
     "pyyaml~=6.0",
     "urllib3~=2.0",
-    "lightkube~=0.15.0",
+    "lightkube~=0.19.0",
     "kubernetes~=27.2.0",
     "allure-pytest~=2.13",
     "allure-pytest-default-results~=0.1.2",

--- a/kubernetes/src/charm.py
+++ b/kubernetes/src/charm.py
@@ -614,14 +614,13 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         if not config_content:
             return
 
-        old_config = self.mysql_config.custom_config(config_content)
-        new_config = self._write_mysqld_configuration()
-
-        # always setup log rotation
-        self.log_rotate_setup.setup()
-
         logger.info("Persisting configuration changes to file")
+        old_config = self.mysql_config.get_custom_config(config_content)
+        new_config = self._write_mysqld_configuration()
         changed_config = compare_dictionaries(old_config, new_config)
+
+        # Override log rotation
+        self.log_rotate_setup.setup()
 
         if (
             self.mysql_config.keys_requires_restart(changed_config)

--- a/kubernetes/src/charm.py
+++ b/kubernetes/src/charm.py
@@ -612,17 +612,16 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
 
         config_content = self._mysql.read_file_content(MYSQLD_CONFIG_FILE)
         if not config_content:
-            # empty config means not initialized, skipping
             return
 
-        previous_config_dict = self.mysql_config.custom_config(config_content)
+        old_config = self.mysql_config.custom_config(config_content)
+        new_config = self._write_mysqld_configuration()
 
         # always setup log rotation
         self.log_rotate_setup.setup()
 
         logger.info("Persisting configuration changes to file")
-        new_config_dict = self._write_mysqld_configuration()
-        changed_config = compare_dictionaries(previous_config_dict, new_config_dict)
+        changed_config = compare_dictionaries(old_config, new_config)
 
         if (
             self.mysql_config.keys_requires_restart(changed_config)
@@ -637,9 +636,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             # if only dynamic config changed, apply it
             logger.info("Configuration does not requires restart")
             for config in dynamic_config:
-                self._mysql.set_dynamic_variable(
-                    config.removeprefix("loose-"), new_config_dict[config]
-                )
+                self._mysql.set_dynamic_variable(config.removeprefix("loose-"), new_config[config])
 
     def _on_leader_elected(self, _) -> None:
         """Handle the leader elected event.

--- a/kubernetes/src/config.py
+++ b/kubernetes/src/config.py
@@ -39,7 +39,7 @@ class MySQLConfig:
         return keys - self.static_config
 
     @staticmethod
-    def custom_config(config_content: str) -> dict:
+    def get_custom_config(config_content: str) -> dict:
         """Convert config content to dict."""
         cp = configparser.ConfigParser(interpolation=None)
         cp.read_string(config_content)

--- a/machines/charmcraft.yaml
+++ b/machines/charmcraft.yaml
@@ -49,7 +49,7 @@ parts:
       apt-get install rustup -y
 
       rustup set profile minimal
-      rustup default 1.90.0  # renovate: charmcraft-rust-latest
+      rustup default 1.93.1  # renovate: charmcraft-rust-latest
 
       craftctl default
       

--- a/machines/lib/charms/mysql/v0/mysql.py
+++ b/machines/lib/charms/mysql/v0/mysql.py
@@ -2967,6 +2967,23 @@ class MySQLBase(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def write_content_to_file(
+        self,
+        path: str,
+        content: str,
+        owner: str,
+        group: str,
+        permission: int,
+    ) -> None:
+        """Write content to file."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def read_file_content(self, path: str) -> str | None:
+        """Reads a file content."""
+        raise NotImplementedError
+
+    @abstractmethod
     def reset_data_dir(self) -> None:
         """Reset the data directory."""
         raise NotImplementedError

--- a/machines/src/charm.py
+++ b/machines/src/charm.py
@@ -258,9 +258,9 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         if not config_content:
             return
 
-        old_config = self.mysql_config.custom_config(config_content)
+        logger.info("Persisting configuration changes to file")
+        old_config = self.mysql_config.get_custom_config(config_content)
         new_config = self._mysql.write_mysqld_config()
-
         changed_config = compare_dictionaries(old_config, new_config)
 
         # Override log rotation

--- a/machines/src/charm.py
+++ b/machines/src/charm.py
@@ -153,7 +153,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         self.framework.observe(self.on[PEER].relation_changed, self._on_peer_relation_changed)
         self.framework.observe(self.on[PEER].relation_departed, self._on_peer_relation_departed)
 
-        self.mysql_config = MySQLConfig(MYSQLD_CUSTOM_CONFIG_FILE)
+        self.mysql_config = MySQLConfig()
         self.database_relation = MySQLProvider(self)
         self.tls = MySQLTLS(self)
         self._grafana_agent = COSAgentProvider(
@@ -254,15 +254,14 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             # the upgrade already restart the daemon
             return
 
-        previous_config = self.mysql_config.custom_config
-        if not previous_config:
-            # empty config means not initialized, skipping
+        config_content = self._mysql.read_file_content(MYSQLD_CUSTOM_CONFIG_FILE)
+        if not config_content:
             return
 
-        # render the new config
-        new_config_dict = self._mysql.write_mysqld_config()
+        old_config = self.mysql_config.custom_config(config_content)
+        new_config = self._mysql.write_mysqld_config()
 
-        changed_config = compare_dictionaries(previous_config, new_config_dict)
+        changed_config = compare_dictionaries(old_config, new_config)
 
         # Override log rotation
         self.log_rotation_setup.setup()
@@ -278,12 +277,10 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             # if only dynamic config changed, apply it
             logger.info("Configuration does not requires restart")
             for config in dynamic_config:
-                if config not in new_config_dict:
+                if config not in new_config:
                     # skip removed configs
                     continue
-                self._mysql.set_dynamic_variable(
-                    config.removeprefix("loose-"), new_config_dict[config]
-                )
+                self._mysql.set_dynamic_variable(config.removeprefix("loose-"), new_config[config])
 
     def _on_start(self, event: StartEvent) -> None:
         """Handle the start event.
@@ -832,7 +829,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             logger.error("Data directory not attached.")
             raise StorageUnavailableError
 
-        if not self.mysql_config.custom_config:
+        if not self._mysql.read_file_content(MYSQLD_CUSTOM_CONFIG_FILE):
             # empty config mean start never ran, skip next checks
             return True
 

--- a/machines/src/config.py
+++ b/machines/src/config.py
@@ -39,7 +39,7 @@ class MySQLConfig:
         return keys - self.static_config
 
     @staticmethod
-    def custom_config(config_content: str) -> dict:
+    def get_custom_config(config_content: str) -> dict:
         """Convert config content to dict."""
         cp = configparser.ConfigParser(interpolation=None)
         cp.read_string(config_content)

--- a/machines/src/config.py
+++ b/machines/src/config.py
@@ -6,7 +6,6 @@
 
 import configparser
 import logging
-import os
 import re
 from typing import ClassVar
 
@@ -31,10 +30,6 @@ class MySQLConfig:
         "admin_address",
     }
 
-    def __init__(self, config_file_path: str):
-        """Initialize config."""
-        self.config_file_path = config_file_path
-
     def keys_requires_restart(self, keys: set) -> bool:
         """Check if keys require restart."""
         return bool(keys & self.static_config)
@@ -43,16 +38,11 @@ class MySQLConfig:
         """Filter static keys."""
         return keys - self.static_config
 
-    @property
-    def custom_config(self) -> dict | None:
-        """Return current custom config dict."""
-        if not os.path.exists(self.config_file_path):
-            return None
-
+    @staticmethod
+    def custom_config(config_content: str) -> dict:
+        """Convert config content to dict."""
         cp = configparser.ConfigParser(interpolation=None)
-
-        with open(self.config_file_path) as config_file:
-            cp.read_file(config_file)
+        cp.read_string(config_content)
 
         return dict(cp["mysqld"])
 

--- a/machines/src/mysql_vm_helpers.py
+++ b/machines/src/mysql_vm_helpers.py
@@ -807,8 +807,8 @@ class MySQL(MySQLBase):
         """
         return [host.names[1] for host in self.charm.hostname_resolution._get_host_details()]
 
-    @staticmethod
     def write_content_to_file(
+        self,
         path: str,
         content: str,
         owner: str = MYSQL_SYSTEM_USER,
@@ -829,6 +829,23 @@ class MySQL(MySQLBase):
 
         shutil.chown(path, owner, group)
         os.chmod(path, mode=permission)
+
+    def read_file_content(self, path: str) -> str | None:
+        """Read file content.
+
+        Args:
+            path: filesystem full path (with filename)
+
+        Returns:
+            file content
+        """
+        if not os.path.exists(path):
+            return None
+
+        with open(path, encoding="utf-8") as fd:
+            content = fd.read()
+
+        return content
 
     @staticmethod
     def fetch_error_log() -> str | None:


### PR DESCRIPTION
**This is the 2nd PR from the refresh V3 implementation efforts**

This PR harmonizes the charm configuration parsing, in order to abstract away file / path related logic, which is one of the main differences between K8s and VM substrates.

---

Depends on:
- https://github.com/canonical/mysql-operators/pull/146
