### PR TITLE
[DPE-8295] Refresh V3 (IV) - Integration tests

### DIFF
--- a/kubernetes/poetry.lock
+++ b/kubernetes/poetry.lock
@@ -1954,7 +1954,7 @@ version = "2.4.0"
 description = "A lil' TOML parser"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "charm-libs"]
+groups = ["main", "charm-libs", "integration"]
 files = [
     {file = "tomli-2.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b5ef256a3fd497d4973c11bf142e9ed78b150d36f5773f1ca6088c230ffc5867"},
     {file = "tomli-2.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5572e41282d5268eb09a697c89a7bee84fae66511f87533a6f88bd2f7b652da9"},
@@ -2003,6 +2003,18 @@ files = [
     {file = "tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4"},
     {file = "tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a"},
     {file = "tomli-2.4.0.tar.gz", hash = "sha256:aa89c3f6c277dd275d8e243ad24f3b5e701491a860d5121f2cdd399fbb31fc9c"},
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+description = "A lil' TOML writer"
+optional = false
+python-versions = ">=3.9"
+groups = ["integration"]
+files = [
+    {file = "tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90"},
+    {file = "tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021"},
 ]
 
 [[package]]

--- a/kubernetes/pyproject.toml
+++ b/kubernetes/pyproject.toml
@@ -55,6 +55,8 @@ integration = [
     "allure-pytest~=2.13",
     "allure-pytest-default-results~=0.1.2",
     "jubilant~=1.4.0",
+    "tomli~=2.3",
+    "tomli-w~=1.2",
 ]
 build-refresh-version = [
     "charm-refresh-build-version~=0.4.0"

--- a/kubernetes/tests/integration/helpers_ha.py
+++ b/kubernetes/tests/integration/helpers_ha.py
@@ -14,7 +14,6 @@ import yaml
 from jubilant import CLIError, Juju
 from jubilant.statustypes import Status
 from lightkube.core.client import Client
-from lightkube.resources.apps_v1 import StatefulSet
 from lightkube.resources.core_v1 import Endpoints, PersistentVolume, PersistentVolumeClaim, Pod
 from tenacity import (
     Retrying,
@@ -136,18 +135,6 @@ def exec_k8s_container_command(
 
     if response.returncode != 0:
         raise RuntimeError("Failed to execute command")
-
-
-def get_k8s_stateful_set_partitions(juju: Juju, app_name: str) -> int:
-    """Get the number of partitions in a Kubernetes stateful set."""
-    client = Client()
-    stateful_set = client.get(
-        res=StatefulSet,
-        name=app_name,
-        namespace=juju.model,
-    )
-
-    return stateful_set.spec.updateStrategy.rollingUpdate.partition
 
 
 def get_k8s_endpoint_addresses(juju: Juju, endpoint_name: str) -> list[str]:
@@ -304,17 +291,6 @@ def get_unit_address(juju: Juju, app_name: str, unit_name: str) -> str:
     for name, status in app_status.units.items():
         if name == unit_name:
             return status.address
-
-    raise Exception("No application unit found")
-
-
-def get_unit_by_number(juju: Juju, app_name: str, unit_number: int) -> str:
-    """Get unit by number."""
-    model_status = juju.status()
-    app_status = model_status.apps[app_name]
-    for name in app_status.units:
-        if name == f"{app_name}/{unit_number}":
-            return name
 
     raise Exception("No application unit found")
 

--- a/kubernetes/tests/integration/integration/high_availability/test_async_replication_upgrade.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_async_replication_upgrade.py
@@ -5,11 +5,10 @@
 import logging
 import time
 from collections.abc import Generator
-from contextlib import suppress
 
 import jubilant
 import pytest
-from jubilant import Juju, TaskError
+from jubilant import Juju
 
 from ... import architecture
 from ...helpers_ha import (
@@ -17,13 +16,10 @@ from ...helpers_ha import (
     check_mysql_units_writes_increment,
     get_app_leader,
     get_app_units,
-    get_k8s_stateful_set_partitions,
     get_mysql_max_written_value,
     get_mysql_primary_unit,
     get_mysql_variable_value,
-    get_unit_by_number,
     wait_for_apps_status,
-    wait_for_unit_message,
 )
 
 MYSQL_APP_1 = "db1"
@@ -187,18 +183,18 @@ def test_create_replication(first_model: str, second_model: str) -> None:
     )
 
 
-def test_upgrade_from_edge(
+def test_refresh_from_edge(
     first_model: str, second_model: str, charm: str, continuous_writes
 ) -> None:
     """Upgrade the two MySQL clusters."""
     model_1 = Juju(model=first_model)
     model_2 = Juju(model=second_model)
 
-    run_pre_upgrade_checks(model_1, MYSQL_APP_1)
-    run_upgrade_from_edge(model_1, MYSQL_APP_1, charm)
+    run_pre_refresh_checks(model_1, MYSQL_APP_1)
+    run_refresh_from_edge(model_1, MYSQL_APP_1, charm)
 
-    run_pre_upgrade_checks(model_2, MYSQL_APP_2)
-    run_upgrade_from_edge(model_2, MYSQL_APP_2, charm)
+    run_pre_refresh_checks(model_2, MYSQL_APP_2)
+    run_refresh_from_edge(model_2, MYSQL_APP_2, charm)
 
 
 def test_data_replication(first_model: str, second_model: str, continuous_writes) -> None:
@@ -239,13 +235,13 @@ def get_mysql_max_written_values(first_model: str, second_model: str) -> list[in
     return results
 
 
-def run_pre_upgrade_checks(juju: Juju, app_name: str) -> None:
-    """Run the pre-upgrade-check actions."""
+def run_pre_refresh_checks(juju: Juju, app_name: str) -> None:
+    """Run the pre-refresh-check actions."""
     app_leader = get_app_leader(juju, app_name)
     app_units = get_app_units(juju, app_name)
 
-    logging.info("Run pre-upgrade-check action")
-    juju.run(unit=app_leader, action="pre-upgrade-check")
+    logging.info("Run pre-refresh-check action")
+    juju.run(unit=app_leader, action="pre-refresh-check")
 
     logging.info("Assert slow shutdown is enabled")
     for unit_name in app_units:
@@ -256,39 +252,58 @@ def run_pre_upgrade_checks(juju: Juju, app_name: str) -> None:
     mysql_primary = get_mysql_primary_unit(juju, app_name)
     assert mysql_primary == f"{app_name}/0", "Primary unit not set to unit 0"
 
-    logging.info("Assert partition is set to 2")
-    assert get_k8s_stateful_set_partitions(juju, app_name) == 2, "Partition not set to 2"
 
-
-def run_upgrade_from_edge(juju: Juju, app_name: str, charm: str) -> None:
-    """Update the second cluster."""
+def run_refresh_from_edge(juju: Juju, app_name: str, charm: str) -> None:
+    """Refresh the second cluster."""
     logging.info("Ensure continuous writes are incrementing")
     check_mysql_units_writes_increment(juju, app_name)
 
-    logging.info("Refresh the charm")
-    juju.refresh(app=app_name, path=charm)
-
     app_leader = get_app_leader(juju, app_name)
-    upgrade_unit = get_unit_by_number(juju, app_name, 2)
+    app_units = get_app_units(juju, app_name)
+    app_units.sort()
 
-    logging.info("Wait for upgrade to complete on first upgrading unit")
+    logging.info("Refresh the charm")
+    juju.refresh(
+        app=app_name,
+        path=charm,
+        resources={"mysql-image": CHARM_METADATA["resources"]["mysql-image"]["upstream-source"]},
+    )
+
+    logging.info("Wait for refresh to start")
     juju.wait(
-        ready=wait_for_unit_message(app_name, upgrade_unit, "upgrade completed"),
+        ready=wait_for_apps_status(jubilant.any_blocked, app_name),
         timeout=10 * MINUTE_SECS,
     )
 
-    logging.info("Resume upgrade")
-    while get_k8s_stateful_set_partitions(juju, app_name) == 2:
-        # ignore action return error as it is expected when
-        # the leader unit is the next one to be upgraded
-        # due it being immediately rolled when the partition
-        # is patched in the stateful set
-        with suppress(TaskError):
-            juju.run(unit=app_leader, action="resume-upgrade")
+    app_status = juju.status().apps[app_name]
+    upgrade_unit_status = app_status.units[app_units[-1]]
+    upgrade_unit_message = upgrade_unit_status.workload_status.message
 
-    logging.info("Wait for upgrade to complete")
+    if "Refresh incompatible" in upgrade_unit_message:
+        logging.info("Application refresh is blocked due to incompatibility")
+        juju.run(
+            unit=app_units[-1],
+            action="force-refresh-start",
+            params={"check-compatibility": False},
+            wait=5 * MINUTE_SECS,
+        )
+
+    logging.info("Wait for refresh to finish on first unit")
     juju.wait(
-        ready=lambda status: jubilant.all_active(status, app_name),
+        ready=jubilant.all_agents_idle,
+        timeout=5 * MINUTE_SECS,
+    )
+
+    logging.info("Resume refresh")
+    juju.run(
+        unit=app_leader,
+        action="resume-refresh",
+        wait=5 * MINUTE_SECS,
+    )
+
+    logging.info("Wait for refresh to complete")
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, app_name),
         timeout=20 * MINUTE_SECS,
     )
 

--- a/kubernetes/tests/integration/integration/high_availability/test_upgrade.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_upgrade.py
@@ -1,15 +1,15 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import json
 import logging
 import shutil
 import zipfile
-from contextlib import suppress
 from pathlib import Path
 
 import jubilant
-from jubilant import Juju, TaskError
+import tomli
+import tomli_w
+from jubilant import Juju
 
 from ... import architecture
 from ...helpers_ha import (
@@ -17,13 +17,9 @@ from ...helpers_ha import (
     check_mysql_units_writes_increment,
     get_app_leader,
     get_app_units,
-    get_k8s_stateful_set_partitions,
     get_mysql_primary_unit,
     get_mysql_variable_value,
-    get_relation_data,
-    get_unit_by_number,
     wait_for_apps_status,
-    wait_for_unit_message,
     wait_for_unit_status,
 )
 
@@ -69,13 +65,13 @@ def test_deploy_latest(juju: Juju) -> None:
     )
 
 
-def test_pre_upgrade_check(juju: Juju) -> None:
-    """Test that the pre-upgrade-check action runs successfully."""
+def test_pre_refresh_check(juju: Juju) -> None:
+    """Test that the pre-refresh-check action runs successfully."""
     mysql_leader = get_app_leader(juju, MYSQL_APP_NAME)
     mysql_units = get_app_units(juju, MYSQL_APP_NAME)
 
-    logging.info("Run pre-upgrade-check action")
-    juju.run(unit=mysql_leader, action="pre-upgrade-check")
+    logging.info("Run pre-refresh-check action")
+    juju.run(unit=mysql_leader, action="pre-refresh-check")
 
     logging.info("Assert slow shutdown is enabled")
     for unit_name in mysql_units:
@@ -86,14 +82,15 @@ def test_pre_upgrade_check(juju: Juju) -> None:
     mysql_primary = get_mysql_primary_unit(juju, MYSQL_APP_NAME)
     assert mysql_primary == f"{MYSQL_APP_NAME}/0", "Primary unit not set to unit 0"
 
-    logging.info("Assert partition is set to 2")
-    assert get_k8s_stateful_set_partitions(juju, MYSQL_APP_NAME) == 2, "Partition not set to 2"
 
-
-def test_upgrade_from_edge(juju: Juju, charm: str, continuous_writes) -> None:
-    """Update the second cluster."""
+def test_refresh_from_edge(juju: Juju, charm: str, continuous_writes) -> None:
+    """Refresh using the locally built charm."""
     logging.info("Ensure continuous writes are incrementing")
     check_mysql_units_writes_increment(juju, MYSQL_APP_NAME)
+
+    mysql_leader = get_app_leader(juju, MYSQL_APP_NAME)
+    mysql_units = get_app_units(juju, MYSQL_APP_NAME)
+    mysql_units.sort()
 
     logging.info("Refresh the charm")
     juju.refresh(
@@ -102,27 +99,41 @@ def test_upgrade_from_edge(juju: Juju, charm: str, continuous_writes) -> None:
         resources={"mysql-image": CHARM_METADATA["resources"]["mysql-image"]["upstream-source"]},
     )
 
-    mysql_app_leader = get_app_leader(juju, MYSQL_APP_NAME)
-    mysql_upgrade_unit = get_unit_by_number(juju, MYSQL_APP_NAME, 2)
-
-    logging.info("Wait for upgrade to complete on first upgrading unit")
+    logging.info("Wait for refresh to start")
     juju.wait(
-        ready=wait_for_unit_message(MYSQL_APP_NAME, mysql_upgrade_unit, "upgrade completed"),
+        ready=wait_for_apps_status(jubilant.any_blocked, MYSQL_APP_NAME),
         timeout=10 * MINUTE_SECS,
     )
 
-    logging.info("Resume upgrade")
-    while get_k8s_stateful_set_partitions(juju, MYSQL_APP_NAME) == 2:
-        # ignore action return error as it is expected when
-        # the leader unit is the next one to be upgraded
-        # due it being immediately rolled when the partition
-        # is patched in the stateful set
-        with suppress(TaskError):
-            juju.run(unit=mysql_app_leader, action="resume-upgrade")
+    mysql_status = juju.status().apps[MYSQL_APP_NAME]
+    upgrade_unit_status = mysql_status.units[mysql_units[-1]]
+    upgrade_unit_message = upgrade_unit_status.workload_status.message
 
-    logging.info("Wait for upgrade to complete")
+    if "Refresh incompatible" in upgrade_unit_message:
+        logging.info("Application refresh is blocked due to incompatibility")
+        juju.run(
+            unit=mysql_units[-1],
+            action="force-refresh-start",
+            params={"check-compatibility": False},
+            wait=5 * MINUTE_SECS,
+        )
+
+    logging.info("Wait for refresh to finish on first unit")
     juju.wait(
-        ready=lambda status: jubilant.all_active(status, MYSQL_APP_NAME),
+        ready=jubilant.all_agents_idle,
+        timeout=5 * MINUTE_SECS,
+    )
+
+    logging.info("Resume refresh")
+    juju.run(
+        unit=mysql_leader,
+        action="resume-refresh",
+        wait=5 * MINUTE_SECS,
+    )
+
+    logging.info("Wait for refresh to complete")
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, MYSQL_APP_NAME),
         timeout=20 * MINUTE_SECS,
     )
 
@@ -131,13 +142,13 @@ def test_upgrade_from_edge(juju: Juju, charm: str, continuous_writes) -> None:
 
 
 def test_fail_and_rollback(juju: Juju, charm: str, continuous_writes) -> None:
-    """Test an upgrade failure and its rollback."""
-    mysql_app_leader = get_app_leader(juju, MYSQL_APP_NAME)
-    mysql_app_units = get_app_units(juju, MYSQL_APP_NAME)
-    mysql_upgrade_unit = get_unit_by_number(juju, MYSQL_APP_NAME, 2)
+    """Test a refresh failure and its rollback."""
+    mysql_leader = get_app_leader(juju, MYSQL_APP_NAME)
+    mysql_units = get_app_units(juju, MYSQL_APP_NAME)
+    mysql_units.sort()
 
-    logging.info("Run pre-upgrade-check action")
-    juju.run(unit=mysql_app_leader, action="pre-upgrade-check")
+    logging.info("Run pre-refresh-check action")
+    juju.run(unit=mysql_leader, action="pre-refresh-check")
 
     tmp_folder = Path("tmp")
     tmp_folder.mkdir(exist_ok=True)
@@ -146,68 +157,63 @@ def test_fail_and_rollback(juju: Juju, charm: str, continuous_writes) -> None:
     shutil.copy(charm, tmp_folder_charm)
 
     logging.info("Inject dependency fault")
-    inject_dependency_fault(juju, MYSQL_APP_NAME, tmp_folder_charm)
+    inject_dependency_fault(tmp_folder_charm)
 
     logging.info("Refresh the charm")
     juju.refresh(app=MYSQL_APP_NAME, path=tmp_folder_charm)
 
     logging.info("Wait for upgrade to fail on first upgrading unit")
     juju.wait(
-        ready=wait_for_unit_status(MYSQL_APP_NAME, mysql_upgrade_unit, "blocked"),
+        ready=wait_for_unit_status(MYSQL_APP_NAME, mysql_units[-1], "blocked"),
         timeout=10 * MINUTE_SECS,
     )
 
     logging.info("Ensure continuous writes on remaining units")
-    mysql_remaining_units = [unit for unit in mysql_app_units if unit != mysql_upgrade_unit]
-    check_mysql_units_writes_increment(juju, MYSQL_APP_NAME, mysql_remaining_units)
-
-    logging.info("Re-run pre-upgrade-check action")
-    juju.run(unit=mysql_app_leader, action="pre-upgrade-check")
+    check_mysql_units_writes_increment(juju, MYSQL_APP_NAME, mysql_units[0:-1])
 
     logging.info("Re-refresh the charm")
     juju.refresh(app=MYSQL_APP_NAME, path=charm)
 
-    logging.info("Wait for upgrade to complete on first upgrading unit")
+    logging.info("Wait for refresh to start")
     juju.wait(
-        ready=wait_for_unit_message(MYSQL_APP_NAME, mysql_upgrade_unit, "upgrade completed"),
+        ready=wait_for_apps_status(jubilant.any_blocked, MYSQL_APP_NAME),
         timeout=10 * MINUTE_SECS,
     )
 
-    logging.info("Resume upgrade")
-    while get_k8s_stateful_set_partitions(juju, MYSQL_APP_NAME) == 2:
-        # ignore action return error as it is expected when
-        # the leader unit is the next one to be upgraded
-        # due it being immediately rolled when the partition
-        # is patched in the stateful set
-        with suppress(TaskError):
-            juju.run(unit=mysql_app_leader, action="resume-upgrade")
-
-    logging.info("Wait for upgrade to recover")
+    logging.info("Wait for refresh to finish on first unit")
     juju.wait(
-        ready=lambda status: jubilant.all_active(status, MYSQL_APP_NAME),
+        ready=jubilant.all_agents_idle,
+        timeout=5 * MINUTE_SECS,
+    )
+
+    logging.info("Resume refresh")
+    juju.run(
+        unit=mysql_leader,
+        action="resume-refresh",
+        wait=5 * MINUTE_SECS,
+    )
+
+    logging.info("Wait for refresh to complete")
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, MYSQL_APP_NAME),
         timeout=20 * MINUTE_SECS,
     )
 
     logging.info("Ensure continuous writes after rollback procedure")
-    check_mysql_units_writes_increment(juju, MYSQL_APP_NAME, mysql_app_units)
+    check_mysql_units_writes_increment(juju, MYSQL_APP_NAME, mysql_units)
 
     # Remove fault charm file
     tmp_folder_charm.unlink()
 
 
-def inject_dependency_fault(juju: Juju, app_name: str, charm_file: str | Path) -> None:
-    """Inject a dependency fault into the mysql charm."""
-    # Open dependency.json and load current charm version
-    with open("src/dependency.json") as dependency_file:
-        current_charm_version = json.load(dependency_file)["charm"]["version"]
+def inject_dependency_fault(charm_file: str | Path) -> None:
+    """Inject a dependency fault into the MySQL charm."""
+    with Path("refresh_versions.toml").open("rb") as file:
+        versions = tomli.load(file)
 
-    # Query running dependency to overwrite with incompatible version
-    relation_data = get_relation_data(juju, app_name, "upgrade")
+    versions["charm"] = "8.4/0.0.0"
+    versions["workload"] = "8.4"
 
-    loaded_dependency_dict = json.loads(relation_data[0]["application-data"]["dependencies"])
-    loaded_dependency_dict["charm"]["upgrade_supported"] = f">{current_charm_version}"
-    loaded_dependency_dict["charm"]["version"] = "999.999.999"
-
-    # Overwrite dependency.json with incompatible version
+    # Overwrite refresh_versions.toml with incompatible version.
     with zipfile.ZipFile(charm_file, mode="a") as charm_zip:
-        charm_zip.writestr("src/dependency.json", json.dumps(loaded_dependency_dict))
+        charm_zip.writestr("refresh_versions.toml", tomli_w.dumps(versions))

--- a/kubernetes/tests/integration/release/high_availability/test_upgrade_from_stable.py
+++ b/kubernetes/tests/integration/release/high_availability/test_upgrade_from_stable.py
@@ -4,22 +4,20 @@
 import logging
 import os
 from collections.abc import Generator
-from contextlib import contextmanager, suppress
+from contextlib import contextmanager
 
 import jubilant
 import pytest
-from jubilant import Juju, TaskError
+from jubilant import Juju
 
 from ... import architecture, markers
 from ...helpers_ha import (
     CHARM_METADATA,
     check_mysql_units_writes_increment,
     get_app_leader,
-    get_k8s_stateful_set_partitions,
+    get_app_units,
     get_mysql_primary_unit,
-    get_unit_by_number,
     wait_for_apps_status,
-    wait_for_unit_message,
 )
 
 MYSQL_APP_NAME = "mysql-k8s"
@@ -45,7 +43,7 @@ def continuous_writes(juju: Juju) -> Generator:
 
 
 @markers.amd64_only
-def test_upgrade_from_stable_amd(juju: Juju, charm: str):
+def test_refresh_from_stable_amd(juju: Juju, charm: str):
     """Simple test to ensure that all MySQL stable revisions can be upgraded."""
     image = os.getenv("MYSQL_IMAGE")
     revision = os.getenv("CHARM_REVISION_AMD64")
@@ -53,14 +51,14 @@ def test_upgrade_from_stable_amd(juju: Juju, charm: str):
         pytest.skip(f"No revision for {architecture.architecture} architecture")
 
     deploy_stable(juju, int(revision), image)
-    run_upgrade_check(juju)
+    run_refresh_check(juju)
 
     with continuous_writes(juju):
-        upgrade_from_stable(juju, charm)
+        refresh_from_stable(juju, charm)
 
 
 @markers.arm64_only
-def test_upgrade_from_stable_arm(juju: Juju, charm: str):
+def test_refresh_from_stable_arm(juju: Juju, charm: str):
     """Simple test to ensure that all MySQL stable revisions can be upgraded."""
     image = os.getenv("MYSQL_IMAGE")
     revision = os.getenv("CHARM_REVISION_ARM64")
@@ -68,10 +66,10 @@ def test_upgrade_from_stable_arm(juju: Juju, charm: str):
         pytest.skip(f"No revision for {architecture.architecture} architecture")
 
     deploy_stable(juju, int(revision), image)
-    run_upgrade_check(juju)
+    run_refresh_check(juju)
 
     with continuous_writes(juju):
-        upgrade_from_stable(juju, charm)
+        refresh_from_stable(juju, charm)
 
 
 # TODO: add s390x test
@@ -113,25 +111,26 @@ def deploy_stable(juju: Juju, revision: int, image: str) -> None:
     )
 
 
-def run_upgrade_check(juju: Juju) -> None:
-    """Test that the pre-upgrade-check action runs successfully."""
+def run_refresh_check(juju: Juju) -> None:
+    """Test that the pre-refresh-check action runs successfully."""
     mysql_leader = get_app_leader(juju, MYSQL_APP_NAME)
 
-    logging.info("Run pre-upgrade-check action")
-    juju.run(unit=mysql_leader, action="pre-upgrade-check")
+    logging.info("Run pre-refresh-check action")
+    juju.run(unit=mysql_leader, action="pre-refresh-check")
 
     logging.info("Assert primary is set to leader")
     mysql_primary = get_mysql_primary_unit(juju, MYSQL_APP_NAME)
     assert mysql_primary == f"{MYSQL_APP_NAME}/0", "Primary unit not set to unit 0"
 
-    logging.info("Assert partition is set to 2")
-    assert get_k8s_stateful_set_partitions(juju, MYSQL_APP_NAME) == 2, "Partition not set to 2"
 
-
-def upgrade_from_stable(juju: Juju, charm: str) -> None:
-    """Update the second cluster."""
+def refresh_from_stable(juju: Juju, charm: str) -> None:
+    """Refresh the cluster."""
     logging.info("Ensure continuous writes are incrementing")
     check_mysql_units_writes_increment(juju, MYSQL_APP_NAME)
+
+    mysql_leader = get_app_leader(juju, MYSQL_APP_NAME)
+    mysql_units = get_app_units(juju, MYSQL_APP_NAME)
+    mysql_units.sort()
 
     logging.info("Refresh the charm")
     juju.refresh(
@@ -140,27 +139,41 @@ def upgrade_from_stable(juju: Juju, charm: str) -> None:
         resources={"mysql-image": CHARM_METADATA["resources"]["mysql-image"]["upstream-source"]},
     )
 
-    mysql_app_leader = get_app_leader(juju, MYSQL_APP_NAME)
-    mysql_upgrade_unit = get_unit_by_number(juju, MYSQL_APP_NAME, 2)
-
-    logging.info("Wait for upgrade to complete on first upgrading unit")
+    logging.info("Wait for refresh to start")
     juju.wait(
-        ready=wait_for_unit_message(MYSQL_APP_NAME, mysql_upgrade_unit, "upgrade completed"),
+        ready=wait_for_apps_status(jubilant.any_blocked, MYSQL_APP_NAME),
         timeout=10 * MINUTE_SECS,
     )
 
-    logging.info("Resume upgrade")
-    while get_k8s_stateful_set_partitions(juju, MYSQL_APP_NAME) == 2:
-        # ignore action return error as it is expected when
-        # the leader unit is the next one to be upgraded
-        # due it being immediately rolled when the partition
-        # is patched in the stateful set
-        with suppress(TaskError):
-            juju.run(unit=mysql_app_leader, action="resume-upgrade")
+    mysql_status = juju.status().apps[MYSQL_APP_NAME]
+    upgrade_unit_status = mysql_status.units[mysql_units[-1]]
+    upgrade_unit_message = upgrade_unit_status.workload_status.message
 
-    logging.info("Wait for upgrade to complete")
+    if "Refresh incompatible" in upgrade_unit_message:
+        logging.info("Application refresh is blocked due to incompatibility")
+        juju.run(
+            unit=mysql_units[-1],
+            action="force-refresh-start",
+            params={"check-compatibility": False},
+            wait=5 * MINUTE_SECS,
+        )
+
+    logging.info("Wait for refresh to finish on first unit")
     juju.wait(
-        ready=lambda status: jubilant.all_active(status, MYSQL_APP_NAME),
+        ready=jubilant.all_agents_idle,
+        timeout=5 * MINUTE_SECS,
+    )
+
+    logging.info("Resume refresh")
+    juju.run(
+        unit=mysql_leader,
+        action="resume-refresh",
+        wait=5 * MINUTE_SECS,
+    )
+
+    logging.info("Wait for refresh to complete")
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, MYSQL_APP_NAME),
         timeout=20 * MINUTE_SECS,
     )
 

--- a/kubernetes/tests/spread/integration/test_async_replication_upgrade.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_async_replication_upgrade.py/task.yaml
@@ -2,8 +2,6 @@ summary: test_async_replication_upgrade.py
 environment:
   TEST_MODULE: high_availability/test_async_replication_upgrade.py
 execute: |
-  # TODO: Un-comment when we release a refresh V3 based charm to 8.4/edge
-  # tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
-  exit 0
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_upgrade.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_upgrade.py/task.yaml
@@ -2,8 +2,6 @@ summary: test_upgrade.py
 environment:
   TEST_MODULE: high_availability/test_upgrade.py
 execute: |
-  # TODO: Un-comment when we release a refresh V3 based charm to 8.4/edge
-  # tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
-  exit 0
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/poetry.lock
+++ b/machines/poetry.lock
@@ -1931,7 +1931,7 @@ version = "2.4.0"
 description = "A lil' TOML parser"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "charm-libs"]
+groups = ["main", "charm-libs", "integration"]
 files = [
     {file = "tomli-2.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b5ef256a3fd497d4973c11bf142e9ed78b150d36f5773f1ca6088c230ffc5867"},
     {file = "tomli-2.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5572e41282d5268eb09a697c89a7bee84fae66511f87533a6f88bd2f7b652da9"},
@@ -1980,6 +1980,18 @@ files = [
     {file = "tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4"},
     {file = "tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a"},
     {file = "tomli-2.4.0.tar.gz", hash = "sha256:aa89c3f6c277dd275d8e243ad24f3b5e701491a860d5121f2cdd399fbb31fc9c"},
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+description = "A lil' TOML writer"
+optional = false
+python-versions = ">=3.9"
+groups = ["integration"]
+files = [
+    {file = "tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90"},
+    {file = "tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021"},
 ]
 
 [[package]]

--- a/machines/pyproject.toml
+++ b/machines/pyproject.toml
@@ -53,6 +53,8 @@ integration = [
     "allure-pytest~=2.13",
     "allure-pytest-default-results~=0.1.2",
     "jubilant~=1.4.0",
+    "tomli~=2.3",
+    "tomli-w~=1.2",
 ]
 build-refresh-version = [
     "charm-refresh-build-version~=0.4.0"

--- a/machines/tests/integration/helpers_ha.py
+++ b/machines/tests/integration/helpers_ha.py
@@ -216,33 +216,6 @@ def get_unit_status_log(juju: Juju, unit_name: str, log_lines: int = 0) -> list[
     return json.loads(output)
 
 
-def get_relation_data(juju: Juju, app_name: str, rel_name: str) -> list[dict]:
-    """Returns a list that contains the relation-data.
-
-    Args:
-        juju: The juju instance to use.
-        app_name: The name of the application
-        rel_name: name of the relation to get connection data from
-
-    Returns:
-        A list that contains the relation-data
-    """
-    app_leader = get_app_leader(juju, app_name)
-    app_leader_info = get_unit_info(juju, app_leader)
-    if not app_leader_info:
-        raise ValueError(f"No unit info could be grabbed for unit {app_leader}")
-
-    relation_data = [
-        value
-        for value in app_leader_info[app_leader]["relation-info"]
-        if value["endpoint"] == rel_name
-    ]
-    if not relation_data:
-        raise ValueError(f"No relation data could be grabbed for relation {rel_name}")
-
-    return relation_data
-
-
 @retry(stop=stop_after_attempt(30), wait=wait_fixed(5), reraise=True)
 def get_mysql_cluster_status(juju: Juju, unit: str, cluster_set: bool = False) -> dict:
     """Get the cluster status by running the get-cluster-status action.

--- a/machines/tests/integration/integration/high_availability/test_async_replication_upgrade.py
+++ b/machines/tests/integration/integration/high_availability/test_async_replication_upgrade.py
@@ -175,18 +175,18 @@ def test_create_replication(first_model: str, second_model: str) -> None:
     )
 
 
-def test_upgrade_from_edge(
+def test_refresh_from_edge(
     first_model: str, second_model: str, charm: str, continuous_writes
 ) -> None:
-    """Upgrade the two MySQL clusters."""
+    """Refresh the two MySQL clusters."""
     model_1 = Juju(model=first_model)
     model_2 = Juju(model=second_model)
 
-    run_pre_upgrade_checks(model_1, MYSQL_APP_1)
-    run_upgrade_from_edge(model_1, MYSQL_APP_1, charm)
+    run_pre_refresh_checks(model_1, MYSQL_APP_1)
+    run_refresh_from_edge(model_1, MYSQL_APP_1, charm)
 
-    run_pre_upgrade_checks(model_2, MYSQL_APP_2)
-    run_upgrade_from_edge(model_2, MYSQL_APP_2, charm)
+    run_pre_refresh_checks(model_2, MYSQL_APP_2)
+    run_refresh_from_edge(model_2, MYSQL_APP_2, charm)
 
 
 def test_data_replication(first_model: str, second_model: str, continuous_writes) -> None:
@@ -227,13 +227,13 @@ def get_mysql_max_written_values(first_model: str, second_model: str) -> list[in
     return results
 
 
-def run_pre_upgrade_checks(juju: Juju, app_name: str) -> None:
-    """Run the pre-upgrade-check actions."""
+def run_pre_refresh_checks(juju: Juju, app_name: str) -> None:
+    """Run the pre-refresh-check actions."""
     app_leader = get_app_leader(juju, app_name)
     app_units = get_app_units(juju, app_name)
 
-    logging.info("Run pre-upgrade-check action")
-    juju.run(unit=app_leader, action="pre-upgrade-check")
+    logging.info("Run pre-refresh-check action")
+    juju.run(unit=app_leader, action="pre-refresh-check")
 
     logging.info("Assert slow shutdown is enabled")
     for unit_name in app_units:
@@ -245,23 +245,51 @@ def run_pre_upgrade_checks(juju: Juju, app_name: str) -> None:
     assert mysql_primary == app_leader, "Primary unit not set to leader"
 
 
-def run_upgrade_from_edge(juju: Juju, app_name: str, charm: str) -> None:
-    """Update the second cluster."""
+def run_refresh_from_edge(juju: Juju, app_name: str, charm: str) -> None:
+    """Refresh the second cluster."""
     logging.info("Ensure continuous writes are incrementing")
     check_mysql_units_writes_increment(juju, app_name)
+
+    app_units = get_app_units(juju, app_name)
+    app_units.sort()
 
     logging.info("Refresh the charm")
     juju.refresh(app=app_name, path=charm)
 
-    logging.info("Wait for upgrade to start")
-    juju.wait(
-        ready=lambda status: jubilant.any_maintenance(status, app_name),
-        timeout=10 * MINUTE_SECS,
-    )
+    try:
+        logging.info("Wait for refresh to start")
+        juju.wait(
+            ready=wait_for_apps_status(jubilant.all_blocked, app_name),
+            timeout=5 * MINUTE_SECS,
+        )
 
-    logging.info("Wait for upgrade to complete")
+        if "Refresh incompatible" in juju.status().apps[app_name].app_status.message:
+            logging.info("Application refresh is blocked due to incompatibility")
+            juju.run(
+                unit=app_units[-1],
+                action="force-refresh-start",
+                params={"check-compatibility": False},
+                wait=5 * MINUTE_SECS,
+            )
+    except TimeoutError:
+        logging.info("Refresh completed without snap refresh (Python code only)")
+    else:
+        logging.info("Wait for refresh to finish on first unit")
+        juju.wait(
+            ready=jubilant.all_agents_idle,
+            timeout=5 * MINUTE_SECS,
+        )
+
+        logging.info("Resume refresh")
+        juju.run(
+            unit=app_units[-2],
+            action="resume-refresh",
+            wait=5 * MINUTE_SECS,
+        )
+
+    logging.info("Wait for refresh to complete")
     juju.wait(
-        ready=lambda status: jubilant.all_active(status, app_name),
+        ready=wait_for_apps_status(jubilant.all_active, app_name),
         timeout=20 * MINUTE_SECS,
     )
 

--- a/machines/tests/integration/integration/high_availability/test_upgrade.py
+++ b/machines/tests/integration/integration/high_availability/test_upgrade.py
@@ -1,13 +1,15 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import json
 import logging
+import platform
 import shutil
 import zipfile
 from pathlib import Path
 
 import jubilant
+import tomli
+import tomli_w
 from jubilant import Juju
 
 from ...helpers_ha import (
@@ -16,7 +18,6 @@ from ...helpers_ha import (
     get_app_units,
     get_mysql_primary_unit,
     get_mysql_variable_value,
-    get_relation_data,
     wait_for_apps_status,
 )
 
@@ -58,13 +59,13 @@ def test_deploy_latest(juju: Juju) -> None:
     )
 
 
-def test_pre_upgrade_check(juju: Juju) -> None:
-    """Test that the pre-upgrade-check action runs successfully."""
+def test_pre_refresh_check(juju: Juju) -> None:
+    """Test that the pre-refresh-check action runs successfully."""
     mysql_leader = get_app_leader(juju, MYSQL_APP_NAME)
     mysql_units = get_app_units(juju, MYSQL_APP_NAME)
 
-    logging.info("Run pre-upgrade-check action")
-    juju.run(unit=mysql_leader, action="pre-upgrade-check")
+    logging.info("Run pre-refresh-check action")
+    juju.run(unit=mysql_leader, action="pre-refresh-check")
 
     logging.info("Assert slow shutdown is enabled")
     for unit_name in mysql_units:
@@ -76,23 +77,51 @@ def test_pre_upgrade_check(juju: Juju) -> None:
     assert mysql_primary == mysql_leader, "Primary unit not set to leader"
 
 
-def test_upgrade_from_edge(juju: Juju, charm: str, continuous_writes) -> None:
-    """Update the second cluster."""
+def test_refresh_from_edge(juju: Juju, charm: str, continuous_writes) -> None:
+    """Refresh using the locally built charm."""
     logging.info("Ensure continuous writes are incrementing")
     check_mysql_units_writes_increment(juju, MYSQL_APP_NAME)
+
+    mysql_units = get_app_units(juju, MYSQL_APP_NAME)
+    mysql_units.sort()
 
     logging.info("Refresh the charm")
     juju.refresh(app=MYSQL_APP_NAME, path=charm)
 
-    logging.info("Wait for upgrade to start")
-    juju.wait(
-        ready=lambda status: jubilant.any_maintenance(status, MYSQL_APP_NAME),
-        timeout=10 * MINUTE_SECS,
-    )
+    try:
+        logging.info("Wait for refresh to start")
+        juju.wait(
+            ready=wait_for_apps_status(jubilant.all_blocked, MYSQL_APP_NAME),
+            timeout=5 * MINUTE_SECS,
+        )
 
-    logging.info("Wait for upgrade to complete")
+        if "Refresh incompatible" in juju.status().apps[MYSQL_APP_NAME].app_status.message:
+            logging.info("Application refresh is blocked due to incompatibility")
+            juju.run(
+                unit=mysql_units[-1],
+                action="force-refresh-start",
+                params={"check-compatibility": False},
+                wait=5 * MINUTE_SECS,
+            )
+    except TimeoutError:
+        logging.info("Refresh completed without snap refresh (Python code only)")
+    else:
+        logging.info("Wait for refresh to finish on first unit")
+        juju.wait(
+            ready=jubilant.all_agents_idle,
+            timeout=5 * MINUTE_SECS,
+        )
+
+        logging.info("Resume refresh")
+        juju.run(
+            unit=mysql_units[-2],
+            action="resume-refresh",
+            wait=5 * MINUTE_SECS,
+        )
+
+    logging.info("Wait for refresh to complete")
     juju.wait(
-        ready=lambda status: jubilant.all_active(status, MYSQL_APP_NAME),
+        ready=wait_for_apps_status(jubilant.all_active, MYSQL_APP_NAME),
         timeout=20 * MINUTE_SECS,
     )
 
@@ -101,12 +130,12 @@ def test_upgrade_from_edge(juju: Juju, charm: str, continuous_writes) -> None:
 
 
 def test_fail_and_rollback(juju: Juju, charm: str, continuous_writes) -> None:
-    """Test an upgrade failure and its rollback."""
+    """Test a refresh failure and its rollback."""
     mysql_app_leader = get_app_leader(juju, MYSQL_APP_NAME)
     mysql_app_units = get_app_units(juju, MYSQL_APP_NAME)
 
-    logging.info("Run pre-upgrade-check action")
-    juju.run(unit=mysql_app_leader, action="pre-upgrade-check")
+    logging.info("Run pre-refresh-check action")
+    juju.run(unit=mysql_app_leader, action="pre-refresh-check")
 
     tmp_folder = Path("tmp")
     tmp_folder.mkdir(exist_ok=True)
@@ -115,12 +144,12 @@ def test_fail_and_rollback(juju: Juju, charm: str, continuous_writes) -> None:
     shutil.copy(charm, tmp_folder_charm)
 
     logging.info("Inject dependency fault")
-    inject_dependency_fault(juju, MYSQL_APP_NAME, tmp_folder_charm)
+    inject_dependency_fault(tmp_folder_charm)
 
     logging.info("Refresh the charm")
     juju.refresh(app=MYSQL_APP_NAME, path=tmp_folder_charm)
 
-    logging.info("Wait for upgrade to fail on leader")
+    logging.info("Wait for refresh to fail on leader")
     juju.wait(
         ready=wait_for_apps_status(jubilant.any_blocked, MYSQL_APP_NAME),
         timeout=10 * MINUTE_SECS,
@@ -129,21 +158,12 @@ def test_fail_and_rollback(juju: Juju, charm: str, continuous_writes) -> None:
     logging.info("Ensure continuous writes on all units")
     check_mysql_units_writes_increment(juju, MYSQL_APP_NAME, mysql_app_units)
 
-    logging.info("Re-run pre-upgrade-check action")
-    juju.run(unit=mysql_app_leader, action="pre-upgrade-check")
-
     logging.info("Re-refresh the charm")
     juju.refresh(app=MYSQL_APP_NAME, path=charm)
 
-    logging.info("Wait for upgrade to start")
+    logging.info("Wait for refresh to complete")
     juju.wait(
-        ready=lambda status: jubilant.any_maintenance(status, MYSQL_APP_NAME),
-        timeout=10 * MINUTE_SECS,
-    )
-
-    logging.info("Wait for upgrade to complete")
-    juju.wait(
-        ready=lambda status: jubilant.all_active(status, MYSQL_APP_NAME),
+        ready=wait_for_apps_status(jubilant.all_active, MYSQL_APP_NAME),
         timeout=20 * MINUTE_SECS,
     )
 
@@ -154,19 +174,14 @@ def test_fail_and_rollback(juju: Juju, charm: str, continuous_writes) -> None:
     tmp_folder_charm.unlink()
 
 
-def inject_dependency_fault(juju: Juju, app_name: str, charm_file: str | Path) -> None:
+def inject_dependency_fault(charm_file: str | Path) -> None:
     """Inject a dependency fault into the mysql charm."""
-    # Open dependency.json and load current charm version
-    with open("src/dependency.json") as dependency_file:
-        current_charm_version = json.load(dependency_file)["charm"]["version"]
+    with Path("refresh_versions.toml").open("rb") as file:
+        versions = tomli.load(file)
 
-    # Query running dependency to overwrite with incompatible version
-    relation_data = get_relation_data(juju, app_name, "upgrade")
+    versions["charm"] = "8.4/0.0.0"
+    versions["snap"]["revisions"][platform.machine()] = "1"
 
-    loaded_dependency_dict = json.loads(relation_data[0]["application-data"]["dependencies"])
-    loaded_dependency_dict["charm"]["upgrade_supported"] = f">{current_charm_version}"
-    loaded_dependency_dict["charm"]["version"] = f"{int(current_charm_version) + 1}"
-
-    # Overwrite dependency.json with incompatible version
+    # Overwrite refresh_versions.toml with incompatible version.
     with zipfile.ZipFile(charm_file, mode="a") as charm_zip:
-        charm_zip.writestr("src/dependency.json", json.dumps(loaded_dependency_dict))
+        charm_zip.writestr("refresh_versions.toml", tomli_w.dumps(versions))

--- a/machines/tests/integration/integration/relations/test_database.py
+++ b/machines/tests/integration/integration/relations/test_database.py
@@ -14,10 +14,11 @@ from utils import generate_random_password
 from ...helpers import execute_queries_on_unit
 from ...helpers_ha import (
     MINUTE_SECS,
+    get_app_leader,
     get_app_units,
     get_mysql_primary_unit,
     get_mysql_server_credentials,
-    get_relation_data,
+    get_unit_info,
     get_unit_ip,
     remove_leader_unit,
     rotate_mysql_server_credentials,
@@ -205,7 +206,7 @@ def check_read_only_endpoints(juju: Juju, app_name: str, relation_name: str) -> 
         app_name: The name of the application
         relation_name: The name of the relation
     """
-    relation_data = get_relation_data(juju=juju, app_name=app_name, rel_name=relation_name)
+    relation_data = get_relation_data(juju=juju, app_name=app_name, relation_name=relation_name)
     read_only_endpoint_ips = get_read_only_endpoint_ips(relation_data)
     # check that the number of read-only-endpoints is correct
     if len(get_app_units(juju, app_name)) - 1 != len(read_only_endpoint_ips):
@@ -263,3 +264,30 @@ def get_read_only_endpoint_ips(relation_data: list) -> list[str]:
             raise ValueError("Malformed endpoint")
 
     return read_only_endpoint_hostnames
+
+
+def get_relation_data(juju: Juju, app_name: str, relation_name: str) -> list[dict]:
+    """Returns a list that contains the relation-data.
+
+    Args:
+        juju: The juju instance to use.
+        app_name: The name of the application
+        relation_name: name of the relation to get connection data from
+
+    Returns:
+        A list that contains the relation-data
+    """
+    app_leader = get_app_leader(juju, app_name)
+    app_leader_info = get_unit_info(juju, app_leader)
+    if not app_leader_info:
+        raise ValueError(f"No unit info could be grabbed for unit {app_leader}")
+
+    relation_data = [
+        value
+        for value in app_leader_info[app_leader]["relation-info"]
+        if value["endpoint"] == relation_name
+    ]
+    if not relation_data:
+        raise ValueError(f"No relation data could be grabbed for relation {relation_name}")
+
+    return relation_data

--- a/machines/tests/integration/release/high_availability/test_upgrade_from_stable.py
+++ b/machines/tests/integration/release/high_availability/test_upgrade_from_stable.py
@@ -14,6 +14,7 @@ from ... import architecture, markers
 from ...helpers_ha import (
     check_mysql_units_writes_increment,
     get_app_leader,
+    get_app_units,
     get_mysql_primary_unit,
     wait_for_apps_status,
 )
@@ -41,31 +42,31 @@ def continuous_writes(juju: Juju) -> Generator:
 
 
 @markers.amd64_only
-def test_upgrade_from_stable_amd(juju: Juju, charm: str):
+def test_refresh_from_stable_amd(juju: Juju, charm: str):
     """Simple test to ensure that all MySQL stable revisions can be upgraded."""
     revision = os.getenv("CHARM_REVISION_AMD64")
     if revision is None:
         pytest.skip(f"No revision for {architecture.architecture} architecture")
 
     deploy_stable(juju, int(revision))
-    run_upgrade_check(juju)
+    run_refresh_check(juju)
 
     with continuous_writes(juju):
-        upgrade_from_stable(juju, charm)
+        refresh_from_stable(juju, charm)
 
 
 @markers.arm64_only
-def test_upgrade_from_stable_arm(juju: Juju, charm: str):
+def test_refresh_from_stable_arm(juju: Juju, charm: str):
     """Simple test to ensure that all MySQL stable revisions can be upgraded."""
     revision = os.getenv("CHARM_REVISION_ARM64")
     if revision is None:
         pytest.skip(f"No revision for {architecture.architecture} architecture")
 
     deploy_stable(juju, int(revision))
-    run_upgrade_check(juju)
+    run_refresh_check(juju)
 
     with continuous_writes(juju):
-        upgrade_from_stable(juju, charm)
+        refresh_from_stable(juju, charm)
 
 
 # TODO: add s390x test
@@ -104,37 +105,65 @@ def deploy_stable(juju: Juju, revision: int) -> None:
     )
 
 
-async def run_upgrade_check(juju: Juju) -> None:
-    """Run the pre-upgrade-check action runs successfully."""
+def run_refresh_check(juju: Juju) -> None:
+    """Run the pre-refresh-check action runs successfully."""
     mysql_leader = get_app_leader(juju, MYSQL_APP_NAME)
 
-    logging.info("Run pre-upgrade-check action")
-    juju.run(unit=mysql_leader, action="pre-upgrade-check")
+    logging.info("Run pre-refresh-check action")
+    juju.run(unit=mysql_leader, action="pre-refresh-check")
 
     logging.info("Assert primary is set to leader")
     mysql_primary = get_mysql_primary_unit(juju, MYSQL_APP_NAME)
     assert mysql_primary == mysql_leader, "Primary unit not set to leader"
 
 
-async def upgrade_from_stable(juju: Juju, charm: str) -> None:
-    """Update the cluster."""
+def refresh_from_stable(juju: Juju, charm: str) -> None:
+    """Refresh the cluster."""
     logging.info("Ensure continuous writes are incrementing")
-    await check_mysql_units_writes_increment(juju, MYSQL_APP_NAME)
+    check_mysql_units_writes_increment(juju, MYSQL_APP_NAME)
+
+    mysql_units = get_app_units(juju, MYSQL_APP_NAME)
+    mysql_units.sort()
 
     logging.info("Refresh the charm")
     juju.refresh(app=MYSQL_APP_NAME, path=charm)
 
-    logging.info("Wait for upgrade to start")
-    juju.wait(
-        ready=lambda status: jubilant.any_maintenance(status, MYSQL_APP_NAME),
-        timeout=10 * MINUTE_SECS,
-    )
+    try:
+        logging.info("Wait for refresh to start")
+        juju.wait(
+            ready=wait_for_apps_status(jubilant.all_blocked, MYSQL_APP_NAME),
+            timeout=5 * MINUTE_SECS,
+        )
 
-    logging.info("Wait for upgrade to complete")
+        if "Refresh incompatible" in juju.status().apps[MYSQL_APP_NAME].app_status.message:
+            logging.info("Application refresh is blocked due to incompatibility")
+            juju.run(
+                unit=mysql_units[-1],
+                action="force-refresh-start",
+                params={"check-compatibility": False},
+                wait=5 * MINUTE_SECS,
+            )
+    except TimeoutError:
+        logging.info("Refresh completed without snap refresh (Python code only)")
+    else:
+        logging.info("Wait for refresh to finish on first unit")
+        juju.wait(
+            ready=jubilant.all_agents_idle,
+            timeout=5 * MINUTE_SECS,
+        )
+
+        logging.info("Resume refresh")
+        juju.run(
+            unit=mysql_units[-2],
+            action="resume-refresh",
+            wait=5 * MINUTE_SECS,
+        )
+
+    logging.info("Wait for refresh to complete")
     juju.wait(
-        ready=lambda status: jubilant.all_active(status, MYSQL_APP_NAME),
+        ready=wait_for_apps_status(jubilant.all_active, MYSQL_APP_NAME),
         timeout=20 * MINUTE_SECS,
     )
 
     logging.info("Ensure continuous writes are incrementing")
-    await check_mysql_units_writes_increment(juju, MYSQL_APP_NAME)
+    check_mysql_units_writes_increment(juju, MYSQL_APP_NAME)

--- a/machines/tests/spread/integration/test_async_replication_upgrade.py/task.yaml
+++ b/machines/tests/spread/integration/test_async_replication_upgrade.py/task.yaml
@@ -2,8 +2,6 @@ summary: test_async_replication_upgrade.py
 environment:
   TEST_MODULE: high_availability/test_async_replication_upgrade.py
 execute: |
-  # TODO: Un-comment when we release a refresh V3 based charm to 8.4/edge
-  # tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
-  exit 0
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_upgrade.py/task.yaml
+++ b/machines/tests/spread/integration/test_upgrade.py/task.yaml
@@ -2,8 +2,6 @@ summary: test_upgrade.py
 environment:
   TEST_MODULE: high_availability/test_upgrade.py
 execute: |
-  # TODO: Un-comment when we release a refresh V3 based charm to 8.4/edge
-  # tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
-  exit 0
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results


### PR DESCRIPTION
**This is the 4th PR from the refresh V3 implementation efforts**

This PR updates the integration tests to make them compatible with the upcoming refresh V3 K8s and VM charms. By the time this PR is merged, we should already have a refresh V3 charm in the `8.4/edge` channels.

---

Depends on:
- https://github.com/canonical/mysql-operators/pull/146
- https://github.com/canonical/mysql-operators/pull/147
- https://github.com/canonical/mysql-operators/pull/148