### PR TITLE
[DPE-9469] 8.0 - Fix relation-broken services

### DIFF
--- a/kubernetes/src/relations/mysql_provider.py
+++ b/kubernetes/src/relations/mysql_provider.py
@@ -267,8 +267,7 @@ class MySQLProvider(Object):
             # https://bugs.launchpad.net/juju/+bug/1979811
             return
 
-        if len(self.model.relations[DB_RELATION_NAME]) == 1:
-            # remove kubernetes service when last relation is removed
+        if len(self.model.relations[DB_RELATION_NAME]) == 0:
             self.charm.k8s_helpers.delete_endpoint_services(["primary", "replicas"])
 
         relation_id = event.relation.id

--- a/kubernetes/tests/integration/integration/relations/test_database.py
+++ b/kubernetes/tests/integration/integration/relations/test_database.py
@@ -119,3 +119,57 @@ def test_relation_broken(juju: Juju):
         timeout=15 * MINUTE_SECS,
         delay=2,
     )
+
+    juju.remove_application(APPLICATION_APP_NAME, destroy_storage=True, force=True)
+
+
+def test_relation_broken_connectivity(juju: Juju):
+    """Remove one out of multiple relation and check expected connectivity."""
+    test_app_1 = f"{APPLICATION_APP_NAME}1"
+    test_app_2 = f"{APPLICATION_APP_NAME}2"
+
+    logging.info("Deploying applications...")
+    juju.deploy(
+        APPLICATION_APP_NAME,
+        test_app_1,
+        num_units=1,
+        channel="latest/edge",
+        config={"database_name": "test_database_1"},
+        base="ubuntu@22.04",
+    )
+
+    juju.deploy(
+        APPLICATION_APP_NAME,
+        test_app_2,
+        num_units=1,
+        channel="latest/edge",
+        config={"database_name": "test_database_2"},
+        base="ubuntu@22.04",
+    )
+
+    logging.info("Creating relations...")
+    juju.integrate(
+        f"{test_app_1}:{APPLICATION_ENDPOINT}",
+        f"{DATABASE_APP_NAME}:{DATABASE_ENDPOINT}",
+    )
+    juju.integrate(
+        f"{test_app_2}:{APPLICATION_ENDPOINT}",
+        f"{DATABASE_APP_NAME}:{DATABASE_ENDPOINT}",
+    )
+
+    logging.info("Waiting for application app to be active...")
+    juju.wait(
+        ready=wait_for_apps_status(jubilant_backports.all_active, test_app_1, test_app_2),
+        error=jubilant_backports.any_blocked,
+        timeout=5 * MINUTE_SECS,
+        delay=2,
+    )
+
+    logging.info("Removing relation...")
+    juju.remove_relation(
+        f"{test_app_2}:{APPLICATION_ENDPOINT}",
+        f"{DATABASE_APP_NAME}:{DATABASE_ENDPOINT}",
+    )
+
+    juju.run(f"{test_app_1}/0", "clear-continuous-writes")
+    juju.run(f"{test_app_1}/0", "start-continuous-writes")


### PR DESCRIPTION
This PR addresses issue https://github.com/canonical/mysql-operators/issues/93 by removing the K8s services only when the number of apps under the same relation is 0.
