### PR TITLE
8.4 - Fix: Do not decode tls-ca-chain received via S3 relation

### DIFF
--- a/kubernetes/lib/charms/mysql/v0/s3_helpers.py
+++ b/kubernetes/lib/charms/mysql/v0/s3_helpers.py
@@ -88,7 +88,7 @@ def _get_bucket(s3_parameters: dict) -> boto3.resources.base.ServiceResource:
 
     with tempfile.NamedTemporaryFile() if ca_chain else nullcontext() as ca_file:
         if ca_file:
-            ca = "\n".join([base64.b64decode(s).decode() for s in ca_chain])
+            ca = "\n".join(ca_chain)
             ca_file.write(ca.encode())
             ca_file.flush()
 

--- a/machines/lib/charms/mysql/v0/s3_helpers.py
+++ b/machines/lib/charms/mysql/v0/s3_helpers.py
@@ -14,7 +14,6 @@
 
 """S3 helper functions for the MySQL charms."""
 
-import base64
 import logging
 import pathlib
 import tempfile
@@ -88,7 +87,7 @@ def _get_bucket(s3_parameters: dict) -> boto3.resources.base.ServiceResource:
 
     with tempfile.NamedTemporaryFile() if ca_chain else nullcontext() as ca_file:
         if ca_file:
-            ca = "\n".join([base64.b64decode(s).decode() for s in ca_chain])
+            ca = "\n".join(ca_chain)
             ca_file.write(ca.encode())
             ca_file.flush()
 

--- a/machines/tests/unit/test_backups.py
+++ b/machines/tests/unit/test_backups.py
@@ -53,7 +53,7 @@ class TestMySQLBackups(unittest.TestCase):
             "bucket": "test_bucket",
             "access-key": "test-access-key",
             "secret-key": "test-secret-key",
-            "tls-ca-chain": ["Zm9vYmFy"],  # "foobar" in base64
+            "tls-ca-chain": ["foobar"],
         }
         _get_s3_connection_info.return_value = return_value
 
@@ -64,7 +64,6 @@ class TestMySQLBackups(unittest.TestCase):
                 "endpoint": "https://s3.amazonaws.com",
                 "region": None,
                 "path": "",
-                "tls-ca-chain": "foobar",
                 **return_value,
             },
         )


### PR DESCRIPTION
## Issue
Part 1 of the solution to fix https://github.com/canonical/mysql-operators/issues/92.

## Solution
Do not decode tls-ca-chain received via S3 relation since it is already decoded.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
