### PR TITLE
[DPE-9609] Create predefined roles after refresh

### DIFF
--- a/kubernetes/lib/charms/mysql/v0/mysql.py
+++ b/kubernetes/lib/charms/mysql/v0/mysql.py
@@ -1265,8 +1265,9 @@ class MySQLBase(ABC):
             ])
 
             try:
-                logger.debug(f"Configuring Router role for {self.instance_address}")
-                executor.execute_sql(configure_role_commands)
+                with self._read_only_disabled():  # Non-primary cluster members will have SUPER_READ_ONLY mode enabled
+                    logger.debug(f"Configuring Router role for {self.instance_address}")
+                    executor.execute_sql(configure_role_commands)
             except ExecutionError as e:
                 logger.error(f"Failed to configure Router role for {self.instance_address}")
                 raise MySQLConfigureMySQLRolesError() from e
@@ -1296,8 +1297,9 @@ class MySQLBase(ABC):
         executor = self._build_instance_sock_executor()
 
         try:
-            logger.debug(f"Configuring MySQL roles for {self.instance_address}")
-            executor.execute_sql(query)
+            with self._read_only_disabled():  # Non-primary cluster members will have SUPER_READ_ONLY mode enabled
+                logger.debug(f"Configuring MySQL roles for {self.instance_address}")
+                executor.execute_sql(query)
         except ExecutionError as e:
             logger.error(f"Failed to configure roles for {self.instance_address}")
             raise MySQLConfigureMySQLRolesError() from e

--- a/kubernetes/lib/charms/mysql/v0/mysql.py
+++ b/kubernetes/lib/charms/mysql/v0/mysql.py
@@ -1264,9 +1264,8 @@ class MySQLBase(ABC):
             ])
 
             try:
-                with (
-                    self._read_only_disabled()
-                ):  # Non-primary cluster members will have SUPER_READ_ONLY mode enabled
+                # Non-primary cluster members will have SUPER_READ_ONLY mode enabled
+                with self._read_only_disabled():
                     logger.debug(f"Configuring Router role for {self.instance_address}")
                     executor.execute_sql(configure_role_commands)
             except ExecutionError as e:
@@ -1298,9 +1297,8 @@ class MySQLBase(ABC):
         executor = self._build_instance_sock_executor()
 
         try:
-            with (
-                self._read_only_disabled()
-            ):  # Non-primary cluster members will have SUPER_READ_ONLY mode enabled
+            # Non-primary cluster members will have SUPER_READ_ONLY mode enabled
+            with self._read_only_disabled():
                 logger.debug(f"Configuring MySQL roles for {self.instance_address}")
                 executor.execute_sql(query)
         except ExecutionError as e:
@@ -1333,9 +1331,8 @@ class MySQLBase(ABC):
         executor = self._build_instance_sock_executor()
 
         try:
-            with (
-                self._read_only_disabled()
-            ):  # Non-primary cluster members will have SUPER_READ_ONLY mode enabled
+            # Non-primary cluster members will have SUPER_READ_ONLY mode enabled
+            with self._read_only_disabled():
                 logger.debug(f"Configuring MySQL users for {self.instance_address}")
                 executor.execute_sql(configure_commands)
         except ExecutionError as e:

--- a/kubernetes/lib/charms/mysql/v0/mysql.py
+++ b/kubernetes/lib/charms/mysql/v0/mysql.py
@@ -66,7 +66,7 @@ import re
 import sys
 import time
 from abc import ABC, abstractmethod
-from contextlib import contextmanager, nullcontext, suppress
+from contextlib import contextmanager, suppress
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -1089,8 +1089,8 @@ class MySQLBase(ABC):
         """Build a socket executor for the instance operations."""
         return self.executor_class(
             conn_details=ConnectionDetails(
-                username=self.root_user,
-                password=self.root_password,
+                username=self.server_config_user,
+                password=self.server_config_password,
                 socket=self.socket_path,
             ),
             shell_path=self.mysqlsh_path,
@@ -1238,27 +1238,15 @@ class MySQLBase(ABC):
         finally:
             self._instance_client_tcp.set_instance_variable(Scope.GLOBAL, "super_read_only", value)
 
-    def configure_mysql_users_and_roles(self, first_run=False) -> None:
-        """Configure the MySQL users and roles for the instance."""
-        if first_run:
-            # root user still in use
-            executor = self._build_instance_sock_executor()
-        else:
-            executor = self._build_instance_tcp_executor(self.instance_address)
-
-        self._configure_mysql_router_roles(executor)
-        self._configure_mysql_system_roles(executor)
-        with self._read_only_disabled() if not first_run else nullcontext():
-            # Non-primary cluster members will have SUPER_READ_ONLY mode enabled
-            self._configure_mysql_system_users(executor)
-
-    def _configure_mysql_router_roles(self, executor) -> None:
+    def configure_mysql_router_roles(self) -> None:
         """Configure the MySQL Router roles for the instance."""
         try:
             router_roles = self._instance_client_sock.search_instance_roles("%router")
             router_roles = [role.rolename for role in router_roles]
         except ExecutionError as e:
             raise MySQLConfigureMySQLRolesError() from e
+
+        executor = self._build_instance_sock_executor()
 
         for role in (LEGACY_ROLE_ROUTER, MODERN_ROLE_ROUTER):
             if role in router_roles:
@@ -1283,7 +1271,7 @@ class MySQLBase(ABC):
                 logger.error(f"Failed to configure Router role for {self.instance_address}")
                 raise MySQLConfigureMySQLRolesError() from e
 
-    def _configure_mysql_system_roles(self, executor) -> None:
+    def configure_mysql_system_roles(self) -> None:
         """Configure the MySQL system roles for the instance."""
         auth_roles = {
             ROLE_DBA,
@@ -1305,6 +1293,7 @@ class MySQLBase(ABC):
 
         logger.debug("Missing MySQL roles")
         query = self._auth_query_builder.build_instance_auth_roles_query()  # HACK: See above
+        executor = self._build_instance_sock_executor()
 
         try:
             logger.debug(f"Configuring MySQL roles for {self.instance_address}")
@@ -1313,12 +1302,11 @@ class MySQLBase(ABC):
             logger.error(f"Failed to configure roles for {self.instance_address}")
             raise MySQLConfigureMySQLRolesError() from e
 
-    def _configure_mysql_system_users(self, executor) -> None:
+    def configure_mysql_system_users(self) -> None:
         """Configure the MySQL system users for the instance."""
         configure_users_commands = [
             f"UPDATE mysql.user SET authentication_string=null WHERE User='{self.root_user}' and Host='localhost'",  # noqa: S608
             f"ALTER USER '{self.root_user}'@'localhost' IDENTIFIED BY '{self.root_password}'",
-            f"CREATE USER IF NOT EXISTS '{self.server_config_user}'@'%' IDENTIFIED BY '{self.server_config_password}'",
             f"CREATE USER IF NOT EXISTS '{self.monitoring_user}'@'%' IDENTIFIED BY '{self.monitoring_password}' WITH MAX_USER_CONNECTIONS 3",
             f"CREATE USER IF NOT EXISTS '{self.backups_user}'@'%' IDENTIFIED BY '{self.backups_password}'",
         ]
@@ -1326,7 +1314,6 @@ class MySQLBase(ABC):
         # SYSTEM_USER and SUPER privileges to revoke from the root users
         # Reference: https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html#priv_super
         configure_privs_commands = [
-            f"GRANT ALL ON *.* TO '{self.server_config_user}'@'%' WITH GRANT OPTION",
             f"GRANT charmed_stats TO '{self.monitoring_user}'@'%'",
             f"GRANT charmed_backup TO '{self.backups_user}'@'%'",
             f"REVOKE BINLOG_ADMIN, CONNECTION_ADMIN, ENCRYPTION_KEY_ADMIN, GROUP_REPLICATION_ADMIN, REPLICATION_SLAVE_ADMIN, SET_USER_ID, SUPER, SYSTEM_USER, SYSTEM_VARIABLES_ADMIN, VERSION_TOKEN_ADMIN ON *.* FROM '{self.root_user}'@'localhost'",
@@ -1338,9 +1325,12 @@ class MySQLBase(ABC):
             *configure_privs_commands,
         ])
 
+        executor = self._build_instance_sock_executor()
+
         try:
-            logger.debug(f"Configuring MySQL users for {self.instance_address}")
-            executor.execute_sql(configure_commands)
+            with self._read_only_disabled():  # Non-primary cluster members will have SUPER_READ_ONLY mode enabled
+                logger.debug(f"Configuring MySQL users for {self.instance_address}")
+                executor.execute_sql(configure_commands)
         except ExecutionError as e:
             logger.error(f"Failed to configure users for: {self.instance_address}")
             raise MySQLConfigureMySQLUsersError from e

--- a/kubernetes/lib/charms/mysql/v0/mysql.py
+++ b/kubernetes/lib/charms/mysql/v0/mysql.py
@@ -1244,10 +1244,7 @@ class MySQLBase(ABC):
         except ExecutionError as e:
             raise MySQLConfigureMySQLRolesError() from e
 
-        # Try TCP executor first (for upgrades where root has reduced privileges)
-        # Fall back to socket executor (for initial deployment)
-        tcp_executor = self._build_instance_tcp_executor(self.instance_address)
-        sock_executor = self._build_instance_sock_executor()
+        executor = self._build_instance_tcp_executor(self.instance_address)
 
         for role in (LEGACY_ROLE_ROUTER, MODERN_ROLE_ROUTER):
             if role in router_roles:
@@ -1265,19 +1262,12 @@ class MySQLBase(ABC):
                 f"GRANT ALL ON *.* TO {role} WITH GRANT OPTION",
             ])
 
-            # Try TCP first (server_config_user), fall back to socket (root)
-            for executor, executor_name in [(tcp_executor, "TCP"), (sock_executor, "socket")]:
-                try:
-                    logger.debug(f"Configuring Router role via {executor_name} for {self.instance_address}")
-                    executor.execute_sql(configure_role_commands)
-                    break  # Success, exit the loop
-                except ExecutionError as e:
-                    if executor_name == "socket":
-                        # Both failed, raise error
-                        logger.error(f"Failed to configure Router role for {self.instance_address}")
-                        raise MySQLConfigureMySQLRolesError() from e
-                    # TCP failed, will try socket next
-                    logger.debug(f"TCP executor failed, trying socket: {e}")
+            try:
+                logger.debug(f"Configuring Router role for {self.instance_address}")
+                executor.execute_sql(configure_role_commands)
+            except ExecutionError as e:
+                logger.error(f"Failed to configure Router role for {self.instance_address}")
+                raise MySQLConfigureMySQLRolesError() from e
 
     def configure_mysql_system_roles(self) -> None:
         """Configure the MySQL system roles for the instance."""
@@ -1301,25 +1291,14 @@ class MySQLBase(ABC):
 
         logger.debug("Missing MySQL roles")
         query = self._auth_query_builder.build_instance_auth_roles_query()
+        executor = self._build_instance_tcp_executor(self.instance_address)
 
-        # Try TCP executor first (for upgrades where root has reduced privileges)
-        # Fall back to socket executor (for initial deployment)
-        tcp_executor = self._build_instance_tcp_executor(self.instance_address)
-        sock_executor = self._build_instance_sock_executor()
-
-        # Try TCP first (server_config_user), fall back to socket (root)
-        for executor, executor_name in [(tcp_executor, "TCP"), (sock_executor, "socket")]:
-            try:
-                logger.debug(f"Configuring MySQL roles via {executor_name} for {self.instance_address}")
-                executor.execute_sql(query)
-                break  # Success, exit the loop
-            except ExecutionError as e:
-                if executor_name == "socket":
-                    # Both failed, raise error
-                    logger.error(f"Failed to configure roles for {self.instance_address}")
-                    raise MySQLConfigureMySQLRolesError() from e
-                # TCP failed, will try socket next
-                logger.debug(f"TCP executor failed, trying socket: {e}")
+        try:
+            logger.debug(f"Configuring MySQL roles for {self.instance_address}")
+            executor.execute_sql(query)
+        except ExecutionError as e:
+            logger.error(f"Failed to configure roles for {self.instance_address}")
+            raise MySQLConfigureMySQLRolesError() from e
 
     def configure_mysql_system_users(self) -> None:
         """Configure the MySQL system users for the instance."""

--- a/kubernetes/lib/charms/mysql/v0/mysql.py
+++ b/kubernetes/lib/charms/mysql/v0/mysql.py
@@ -66,7 +66,7 @@ import re
 import sys
 import time
 from abc import ABC, abstractmethod
-from contextlib import contextmanager, suppress
+from contextlib import contextmanager, nullcontext, suppress
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -1040,6 +1040,8 @@ class MySQLBase(ABC):
             role_reader=ROLE_READ,
             role_writer=ROLE_DML,
         )
+        # HACK: I will need idempotent queries
+        self._auth_query_builder.ROLE_CREATION_QUERY = "CREATE ROLE IF NOT EXISTS {rolename}"  # type: ignore
         self._lock_query_builder = CharmLockingQueryBuilder(
             table_schema="mysql",
             table_name="juju_units_operations",
@@ -1236,15 +1238,27 @@ class MySQLBase(ABC):
         finally:
             self._instance_client_tcp.set_instance_variable(Scope.GLOBAL, "super_read_only", value)
 
-    def configure_mysql_router_roles(self) -> None:
+    def configure_mysql_users_and_roles(self, first_run=False) -> None:
+        """Configure the MySQL users and roles for the instance."""
+        if first_run:
+            # root user still in use
+            executor = self._build_instance_sock_executor()
+        else:
+            executor = self._build_instance_tcp_executor(self.instance_address)
+
+        self._configure_mysql_router_roles(executor)
+        self._configure_mysql_system_roles(executor)
+        with self._read_only_disabled() if not first_run else nullcontext():
+            # Non-primary cluster members will have SUPER_READ_ONLY mode enabled
+            self._configure_mysql_system_users(executor)
+
+    def _configure_mysql_router_roles(self, executor) -> None:
         """Configure the MySQL Router roles for the instance."""
         try:
             router_roles = self._instance_client_sock.search_instance_roles("%router")
             router_roles = [role.rolename for role in router_roles]
         except ExecutionError as e:
             raise MySQLConfigureMySQLRolesError() from e
-
-        executor = self._build_instance_tcp_executor(self.instance_address)
 
         for role in (LEGACY_ROLE_ROUTER, MODERN_ROLE_ROUTER):
             if role in router_roles:
@@ -1269,7 +1283,7 @@ class MySQLBase(ABC):
                 logger.error(f"Failed to configure Router role for {self.instance_address}")
                 raise MySQLConfigureMySQLRolesError() from e
 
-    def configure_mysql_system_roles(self) -> None:
+    def _configure_mysql_system_roles(self, executor) -> None:
         """Configure the MySQL system roles for the instance."""
         auth_roles = {
             ROLE_DBA,
@@ -1290,8 +1304,7 @@ class MySQLBase(ABC):
             return
 
         logger.debug("Missing MySQL roles")
-        query = self._auth_query_builder.build_instance_auth_roles_query()
-        executor = self._build_instance_tcp_executor(self.instance_address)
+        query = self._auth_query_builder.build_instance_auth_roles_query()  # HACK: See above
 
         try:
             logger.debug(f"Configuring MySQL roles for {self.instance_address}")
@@ -1300,14 +1313,14 @@ class MySQLBase(ABC):
             logger.error(f"Failed to configure roles for {self.instance_address}")
             raise MySQLConfigureMySQLRolesError() from e
 
-    def configure_mysql_system_users(self) -> None:
+    def _configure_mysql_system_users(self, executor) -> None:
         """Configure the MySQL system users for the instance."""
         configure_users_commands = [
             f"UPDATE mysql.user SET authentication_string=null WHERE User='{self.root_user}' and Host='localhost'",  # noqa: S608
             f"ALTER USER '{self.root_user}'@'localhost' IDENTIFIED BY '{self.root_password}'",
-            f"CREATE USER '{self.server_config_user}'@'%' IDENTIFIED BY '{self.server_config_password}'",
-            f"CREATE USER '{self.monitoring_user}'@'%' IDENTIFIED BY '{self.monitoring_password}' WITH MAX_USER_CONNECTIONS 3",
-            f"CREATE USER '{self.backups_user}'@'%' IDENTIFIED BY '{self.backups_password}'",
+            f"CREATE USER IF NOT EXISTS '{self.server_config_user}'@'%' IDENTIFIED BY '{self.server_config_password}'",
+            f"CREATE USER IF NOT EXISTS '{self.monitoring_user}'@'%' IDENTIFIED BY '{self.monitoring_password}' WITH MAX_USER_CONNECTIONS 3",
+            f"CREATE USER IF NOT EXISTS '{self.backups_user}'@'%' IDENTIFIED BY '{self.backups_password}'",
         ]
 
         # SYSTEM_USER and SUPER privileges to revoke from the root users
@@ -1324,8 +1337,6 @@ class MySQLBase(ABC):
             *configure_users_commands,
             *configure_privs_commands,
         ])
-
-        executor = self._build_instance_sock_executor()
 
         try:
             logger.debug(f"Configuring MySQL users for {self.instance_address}")

--- a/kubernetes/lib/charms/mysql/v0/mysql.py
+++ b/kubernetes/lib/charms/mysql/v0/mysql.py
@@ -1252,7 +1252,7 @@ class MySQLBase(ABC):
 
             logger.debug(f"Missing MySQL role {role}")
             configure_role_commands = ";".join([
-                f"CREATE ROLE {role}",
+                f"CREATE ROLE IF NOT EXISTS {role}",
                 f"GRANT CREATE ON *.* TO {role}",
                 f"GRANT CREATE USER ON *.* TO {role}",
                 # The granting of all privileges to the MySQL Router role

--- a/kubernetes/lib/charms/mysql/v0/mysql.py
+++ b/kubernetes/lib/charms/mysql/v0/mysql.py
@@ -1039,8 +1039,6 @@ class MySQLBase(ABC):
             role_reader=ROLE_READ,
             role_writer=ROLE_DML,
         )
-        # TODO: Remove when mysql-shell-client supports idempotent queries
-        self._auth_query_builder.ROLE_CREATION_QUERY = "CREATE ROLE IF NOT EXISTS {rolename}"  # type: ignore
         self._lock_query_builder = CharmLockingQueryBuilder(
             table_schema="mysql",
             table_name="juju_units_operations",

--- a/kubernetes/lib/charms/mysql/v0/mysql.py
+++ b/kubernetes/lib/charms/mysql/v0/mysql.py
@@ -66,14 +66,13 @@ import re
 import sys
 import time
 from abc import ABC, abstractmethod
+from collections.abc import Generator
 from contextlib import contextmanager, suppress
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
-    Generator,
     Literal,
-    Type,
     get_args,
 )
 
@@ -1005,7 +1004,7 @@ class MySQLBase(ABC):
         backups_user: str,
         backups_password: str,
         mysqlsh_path: str,
-        executor_class: Type[BaseExecutor],
+        executor_class: type[BaseExecutor],
     ):
         """Initialize the MySQL class."""
         self.instance_address = instance_address
@@ -1040,7 +1039,7 @@ class MySQLBase(ABC):
             role_reader=ROLE_READ,
             role_writer=ROLE_DML,
         )
-        # HACK: I will need idempotent queries
+        # TODO: Remove when mysql-shell-client supports idempotent queries
         self._auth_query_builder.ROLE_CREATION_QUERY = "CREATE ROLE IF NOT EXISTS {rolename}"  # type: ignore
         self._lock_query_builder = CharmLockingQueryBuilder(
             table_schema="mysql",
@@ -1265,7 +1264,9 @@ class MySQLBase(ABC):
             ])
 
             try:
-                with self._read_only_disabled():  # Non-primary cluster members will have SUPER_READ_ONLY mode enabled
+                with (
+                    self._read_only_disabled()
+                ):  # Non-primary cluster members will have SUPER_READ_ONLY mode enabled
                     logger.debug(f"Configuring Router role for {self.instance_address}")
                     executor.execute_sql(configure_role_commands)
             except ExecutionError as e:
@@ -1293,11 +1294,13 @@ class MySQLBase(ABC):
             return
 
         logger.debug("Missing MySQL roles")
-        query = self._auth_query_builder.build_instance_auth_roles_query()  # HACK: See above
+        query = self._auth_query_builder.build_instance_auth_roles_query()
         executor = self._build_instance_sock_executor()
 
         try:
-            with self._read_only_disabled():  # Non-primary cluster members will have SUPER_READ_ONLY mode enabled
+            with (
+                self._read_only_disabled()
+            ):  # Non-primary cluster members will have SUPER_READ_ONLY mode enabled
                 logger.debug(f"Configuring MySQL roles for {self.instance_address}")
                 executor.execute_sql(query)
         except ExecutionError as e:
@@ -1330,7 +1333,9 @@ class MySQLBase(ABC):
         executor = self._build_instance_sock_executor()
 
         try:
-            with self._read_only_disabled():  # Non-primary cluster members will have SUPER_READ_ONLY mode enabled
+            with (
+                self._read_only_disabled()
+            ):  # Non-primary cluster members will have SUPER_READ_ONLY mode enabled
                 logger.debug(f"Configuring MySQL users for {self.instance_address}")
                 executor.execute_sql(configure_commands)
         except ExecutionError as e:

--- a/kubernetes/lib/charms/mysql/v0/mysql.py
+++ b/kubernetes/lib/charms/mysql/v0/mysql.py
@@ -1244,7 +1244,10 @@ class MySQLBase(ABC):
         except ExecutionError as e:
             raise MySQLConfigureMySQLRolesError() from e
 
-        executor = self._build_instance_sock_executor()
+        # Try TCP executor first (for upgrades where root has reduced privileges)
+        # Fall back to socket executor (for initial deployment)
+        tcp_executor = self._build_instance_tcp_executor(self.instance_address)
+        sock_executor = self._build_instance_sock_executor()
 
         for role in (LEGACY_ROLE_ROUTER, MODERN_ROLE_ROUTER):
             if role in router_roles:
@@ -1262,12 +1265,19 @@ class MySQLBase(ABC):
                 f"GRANT ALL ON *.* TO {role} WITH GRANT OPTION",
             ])
 
-            try:
-                logger.debug(f"Configuring Router role for {self.instance_address}")
-                executor.execute_sql(configure_role_commands)
-            except ExecutionError as e:
-                logger.error(f"Failed to configure Router role for {self.instance_address}")
-                raise MySQLConfigureMySQLRolesError() from e
+            # Try TCP first (server_config_user), fall back to socket (root)
+            for executor, executor_name in [(tcp_executor, "TCP"), (sock_executor, "socket")]:
+                try:
+                    logger.debug(f"Configuring Router role via {executor_name} for {self.instance_address}")
+                    executor.execute_sql(configure_role_commands)
+                    break  # Success, exit the loop
+                except ExecutionError as e:
+                    if executor_name == "socket":
+                        # Both failed, raise error
+                        logger.error(f"Failed to configure Router role for {self.instance_address}")
+                        raise MySQLConfigureMySQLRolesError() from e
+                    # TCP failed, will try socket next
+                    logger.debug(f"TCP executor failed, trying socket: {e}")
 
     def configure_mysql_system_roles(self) -> None:
         """Configure the MySQL system roles for the instance."""
@@ -1291,14 +1301,25 @@ class MySQLBase(ABC):
 
         logger.debug("Missing MySQL roles")
         query = self._auth_query_builder.build_instance_auth_roles_query()
-        executor = self._build_instance_sock_executor()
 
-        try:
-            logger.debug(f"Configuring MySQL roles for {self.instance_address}")
-            executor.execute_sql(query)
-        except ExecutionError as e:
-            logger.error(f"Failed to configure roles for {self.instance_address}")
-            raise MySQLConfigureMySQLRolesError() from e
+        # Try TCP executor first (for upgrades where root has reduced privileges)
+        # Fall back to socket executor (for initial deployment)
+        tcp_executor = self._build_instance_tcp_executor(self.instance_address)
+        sock_executor = self._build_instance_sock_executor()
+
+        # Try TCP first (server_config_user), fall back to socket (root)
+        for executor, executor_name in [(tcp_executor, "TCP"), (sock_executor, "socket")]:
+            try:
+                logger.debug(f"Configuring MySQL roles via {executor_name} for {self.instance_address}")
+                executor.execute_sql(query)
+                break  # Success, exit the loop
+            except ExecutionError as e:
+                if executor_name == "socket":
+                    # Both failed, raise error
+                    logger.error(f"Failed to configure roles for {self.instance_address}")
+                    raise MySQLConfigureMySQLRolesError() from e
+                # TCP failed, will try socket next
+                logger.debug(f"TCP executor failed, trying socket: {e}")
 
     def configure_mysql_system_users(self) -> None:
         """Configure the MySQL system users for the instance."""

--- a/kubernetes/poetry.lock
+++ b/kubernetes/poetry.lock
@@ -1024,14 +1024,14 @@ telemetry = ["opentelemetry-api (==1.18.0)", "opentelemetry-exporter-otlp-proto-
 
 [[package]]
 name = "mysql-shell-client"
-version = "0.7.1"
+version = "0.8.0"
 description = "Python client for MySQL Shell"
 optional = false
 python-versions = ">=3.10"
 groups = ["charm-libs"]
 files = [
-    {file = "mysql_shell_client-0.7.1-py3-none-any.whl", hash = "sha256:0223fde0ad97a132d1ad0c4ba91cb15c1ef1041272c2b74d764a5441f3092562"},
-    {file = "mysql_shell_client-0.7.1.tar.gz", hash = "sha256:e5595cd6ec76b2c0d887dccc32c4feb18031afd7f22b5b7222596308052efa44"},
+    {file = "mysql_shell_client-0.8.0-py3-none-any.whl", hash = "sha256:2ec1cd6461ea1e9ec234d678083836cf5408f75708696af3d61de62a551df579"},
+    {file = "mysql_shell_client-0.8.0.tar.gz", hash = "sha256:a8a19c2b341c130548be869bc96bdec97c22bbd7b82610dba442ab7954f4cf1b"},
 ]
 
 [package.extras]

--- a/kubernetes/pyproject.toml
+++ b/kubernetes/pyproject.toml
@@ -20,7 +20,7 @@ charm-libs = [
     # tempo_coordinator_k8s/v0/charm_tracing.py requires pydantic
     "pydantic~=1.10",
     # mysql/v0/*.py"
-    "mysql_shell_client~=0.7",
+    "mysql_shell_client~=0.8",
     # tls_certificates_interface/v1/tls_certificates.py
     # tls_certificates lib uses a feature only available in cryptography >=42.0.5
     "cryptography>=42.0.5",

--- a/kubernetes/src/charm.py
+++ b/kubernetes/src/charm.py
@@ -718,9 +718,9 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
 
             logger.info("Configuring initialized mysqld")
             # Configure all base users and revoke privileges from the root users
+            self._mysql.configure_mysql_system_users()
             self._mysql.configure_mysql_router_roles()
             self._mysql.configure_mysql_system_roles()
-            self._mysql.configure_mysql_system_users()
 
             if self.config.plugin_audit_enabled:
                 # Enable the audit plugin

--- a/kubernetes/src/charm.py
+++ b/kubernetes/src/charm.py
@@ -713,12 +713,14 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             logger.info("Waiting for instance to be ready")
             self._mysql.wait_until_mysql_connection(check_port=False)
 
-            logger.info("Resetting root password and starting mysqld")
-            self._mysql.reset_root_password_and_start_mysqld()
+            logger.info("Set operator user and restart mysqld")
+            self._mysql.set_operator_user_and_start_mysqld()
 
             logger.info("Configuring initialized mysqld")
             # Configure all base users and revoke privileges from the root users
-            self._mysql.configure_mysql_users_and_roles(first_run=True)
+            self._mysql.configure_mysql_router_roles()
+            self._mysql.configure_mysql_system_roles()
+            self._mysql.configure_mysql_system_users()
 
             if self.config.plugin_audit_enabled:
                 # Enable the audit plugin

--- a/kubernetes/src/charm.py
+++ b/kubernetes/src/charm.py
@@ -718,9 +718,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
 
             logger.info("Configuring initialized mysqld")
             # Configure all base users and revoke privileges from the root users
-            self._mysql.configure_mysql_system_users()
-            self._mysql.configure_mysql_router_roles()
-            self._mysql.configure_mysql_system_roles()
+            self._mysql.configure_mysql_users_and_roles(first_run=True)
 
             if self.config.plugin_audit_enabled:
                 # Enable the audit plugin

--- a/kubernetes/src/mysql_k8s_helpers.py
+++ b/kubernetes/src/mysql_k8s_helpers.py
@@ -249,17 +249,19 @@ class MySQL(MySQLBase):
             self.reset_data_dir()
             raise MySQLInitialiseMySQLDError from None
 
-    def reset_root_password_and_start_mysqld(self) -> None:
-        """Reset the root user password and start mysqld."""
-        logger.debug("Resetting root user password and starting mysqld")
-        alter_user_queries = [
-            f"ALTER USER 'root'@'localhost' IDENTIFIED BY '{self.root_password}';",
+    def set_operator_user_and_start_mysqld(self) -> None:
+        """Set the operator user and start mysqld."""
+        create_user_queries = [
+            f"CREATE USER '{self.server_config_user}'@'%' IDENTIFIED BY '{self.server_config_password}';",
+            f"GRANT ALL ON *.* TO '{self.server_config_user}'@'%' WITH GRANT OPTION;",
             "FLUSH PRIVILEGES;",
         ]
 
+        file_path = "/create-operator-user.sql"
+
         self.container.push(
-            "/alter-root-user.sql",
-            "\n".join(alter_user_queries),
+            file_path,
+            "\n".join(create_user_queries),
             encoding="utf-8",
             permissions=0o600,
             user=MYSQL_SYSTEM_USER,
@@ -269,14 +271,14 @@ class MySQL(MySQLBase):
         try:
             self.container.push(
                 MYSQLD_INIT_CONFIG_FILE,
-                "[mysqld]\ninit_file = /alter-root-user.sql",
+                f"[mysqld]\ninit_file = {file_path}",
                 encoding="utf-8",
                 permissions=0o600,
                 user=MYSQL_SYSTEM_USER,
                 group=MYSQL_SYSTEM_GROUP,
             )
         except PathError:
-            self.container.remove_path("/alter-root-user.sql")
+            self.container.remove_path(file_path)
 
             logger.exception("Failed to write the custom config file for init-file")
             raise
@@ -288,7 +290,7 @@ class MySQL(MySQLBase):
             logger.exception("Failed to run init-file and wait for connection")
             raise
         finally:
-            self.container.remove_path("/alter-root-user.sql")
+            self.container.remove_path(file_path)
             self.container.remove_path(MYSQLD_INIT_CONFIG_FILE)
 
     @retry(reraise=True, stop=stop_after_delay(120), wait=wait_fixed(2))

--- a/kubernetes/src/upgrade.py
+++ b/kubernetes/src/upgrade.py
@@ -220,6 +220,11 @@ class MySQLK8sUpgrade(DataUpgrade):
             self.charm._reconcile_pebble_layer(container)
             self.charm.unit.status = MaintenanceStatus("recovering unit after upgrade")
             self.charm.recover_unit_after_restart()
+
+            logger.info("Ensuring predefined roles exist")
+            self.charm._mysql.configure_mysql_router_roles()
+            self.charm._mysql.configure_mysql_system_roles()
+
             if self.charm.config.plugin_audit_enabled:
                 self.charm._mysql.install_plugins(["audit_log"])
             self.charm._mysql.install_plugins(["binlog_utils_udf"])

--- a/kubernetes/src/upgrade.py
+++ b/kubernetes/src/upgrade.py
@@ -221,7 +221,7 @@ class MySQLK8sUpgrade(DataUpgrade):
             self.charm.unit.status = MaintenanceStatus("recovering unit after upgrade")
             self.charm.recover_unit_after_restart()
 
-            logger.info("Ensuring predefined roles exist")
+            logger.info("Reconciling predefined roles exist")
             self.charm._mysql.configure_mysql_users_and_roles()
 
             if self.charm.config.plugin_audit_enabled:

--- a/kubernetes/src/upgrade.py
+++ b/kubernetes/src/upgrade.py
@@ -222,7 +222,9 @@ class MySQLK8sUpgrade(DataUpgrade):
             self.charm.recover_unit_after_restart()
 
             logger.info("Reconciling predefined roles exist")
-            self.charm._mysql.configure_mysql_users_and_roles()
+            self.charm._mysql.configure_mysql_router_roles()
+            self.charm._mysql.configure_mysql_system_roles()
+            self.charm._mysql.configure_mysql_system_users()
 
             if self.charm.config.plugin_audit_enabled:
                 self.charm._mysql.install_plugins(["audit_log"])

--- a/kubernetes/src/upgrade.py
+++ b/kubernetes/src/upgrade.py
@@ -221,7 +221,7 @@ class MySQLK8sUpgrade(DataUpgrade):
             self.charm.unit.status = MaintenanceStatus("recovering unit after upgrade")
             self.charm.recover_unit_after_restart()
 
-            logger.info("Reconciling predefined roles exist")
+            logger.info("Reconciling predefined roles")
             self.charm._mysql.configure_mysql_router_roles()
             self.charm._mysql.configure_mysql_system_roles()
             self.charm._mysql.configure_mysql_system_users()

--- a/kubernetes/src/upgrade.py
+++ b/kubernetes/src/upgrade.py
@@ -222,8 +222,7 @@ class MySQLK8sUpgrade(DataUpgrade):
             self.charm.recover_unit_after_restart()
 
             logger.info("Ensuring predefined roles exist")
-            self.charm._mysql.configure_mysql_router_roles()
-            self.charm._mysql.configure_mysql_system_roles()
+            self.charm._mysql.configure_mysql_users_and_roles()
 
             if self.charm.config.plugin_audit_enabled:
                 self.charm._mysql.install_plugins(["audit_log"])

--- a/kubernetes/tests/integration/integration/roles/test_predefined_roles_refresh.py
+++ b/kubernetes/tests/integration/integration/roles/test_predefined_roles_refresh.py
@@ -1,21 +1,24 @@
 #!/usr/bin/env python3
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
-
 import logging
+from contextlib import suppress
 
 import jubilant_backports
-from jubilant_backports import Juju
+from jubilant_backports import Juju, TaskError
 
 from ...helpers_ha import (
     CHARM_METADATA,
     MINUTE_SECS,
     execute_queries_on_unit,
     get_app_leader,
+    get_k8s_stateful_set_partitions,
     get_mysql_primary_unit,
     get_mysql_server_credentials,
     get_unit_address,
+    get_unit_by_number,
     wait_for_apps_status,
+    wait_for_unit_message,
 )
 
 DATABASE_APP_NAME = "mysql-k8s"
@@ -37,7 +40,7 @@ def test_build_and_deploy(juju: Juju) -> None:
         channel="8.0/stable",
         revision=OLD_MYSQL_REVISION,
         config={"profile": "testing"},
-        num_units=1,
+        num_units=3,
         trust=True,
     )
     juju.wait(
@@ -85,6 +88,7 @@ def test_verify_no_predefined_roles_in_old_revision(juju: Juju):
 def test_verify_predefined_roles_present_after_refresh(juju: Juju, charm):
     """Verify that predefined roles are present after refresh."""
     mysql_leader = get_app_leader(juju, DATABASE_APP_NAME)
+    mysql_upgrade_unit = get_unit_by_number(juju, DATABASE_APP_NAME, 2)
 
     logging.info("Running pre-upgrade-check action")
     juju.run(unit=mysql_leader, action="pre-upgrade-check")
@@ -96,10 +100,25 @@ def test_verify_predefined_roles_present_after_refresh(juju: Juju, charm):
         resources={"mysql-image": CHARM_METADATA["resources"]["mysql-image"]["upstream-source"]},
     )
 
-    logging.info("Wait for refresh to complete")
+    logging.info("Wait for upgrade to complete on first upgrading unit")
     juju.wait(
-        ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
+        ready=wait_for_unit_message(DATABASE_APP_NAME, mysql_upgrade_unit, "upgrade completed"),
         timeout=TIMEOUT,
+    )
+
+    logging.info("Resume upgrade")
+    while get_k8s_stateful_set_partitions(juju, DATABASE_APP_NAME) == 2:
+        # ignore action return error as it is expected when
+        # the leader unit is the next one to be upgraded
+        # due it being immediately rolled when the partition
+        # is patched in the stateful set
+        with suppress(TaskError):
+            juju.run(unit=mysql_leader, action="resume-upgrade")
+
+    logging.info("Wait for upgrade to recover")
+    juju.wait(
+        ready=lambda status: jubilant_backports.all_active(status, DATABASE_APP_NAME),
+        timeout=20 * MINUTE_SECS,
     )
 
     primary_unit_name = get_mysql_primary_unit(juju, DATABASE_APP_NAME)

--- a/kubernetes/tests/integration/integration/roles/test_predefined_roles_refresh.py
+++ b/kubernetes/tests/integration/integration/roles/test_predefined_roles_refresh.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
+
 import logging
 from contextlib import suppress
+from time import sleep
 
 import jubilant_backports
 from jubilant_backports import Juju, TaskError
@@ -43,6 +45,10 @@ def test_build_and_deploy(juju: Juju) -> None:
         num_units=3,
         trust=True,
     )
+    # Allow some time between deploy and status call. Avoids:
+    # ERROR getting details for storage database/0: filesystem for storage instance "database/0" not found
+    sleep(30)
+
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
         timeout=TIMEOUT,

--- a/kubernetes/tests/integration/integration/roles/test_predefined_roles_refresh.py
+++ b/kubernetes/tests/integration/integration/roles/test_predefined_roles_refresh.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+
+import jubilant_backports
+from jubilant_backports import Juju
+
+from ...helpers_ha import (
+    CHARM_METADATA,
+    MINUTE_SECS,
+    execute_queries_on_unit,
+    get_app_leader,
+    get_mysql_primary_unit,
+    get_mysql_server_credentials,
+    get_unit_address,
+    wait_for_apps_status,
+)
+
+DATABASE_APP_NAME = "mysql-k8s"
+MYSQL_ROUTER_APP_NAME = "mysql-router-k8s"
+MYSQL_TEST_APP_NAME = "mysql-test-app"
+
+OLD_MYSQL_REVISION = 255
+
+TIMEOUT = 10 * MINUTE_SECS
+
+
+def test_build_and_deploy(juju: Juju) -> None:
+    """Deploy an old MySQL revision without predefined roles support."""
+    logging.info(f"Deploying MySQL cluster revision {OLD_MYSQL_REVISION}")
+    juju.deploy(
+        charm=DATABASE_APP_NAME,
+        app=DATABASE_APP_NAME,
+        base="ubuntu@22.04",
+        channel="8.0/stable",
+        revision=OLD_MYSQL_REVISION,
+        config={"profile": "testing"},
+        num_units=1,
+        trust=True,
+    )
+    juju.wait(
+        ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
+        timeout=TIMEOUT,
+    )
+
+
+def test_verify_no_predefined_roles_in_old_revision(juju: Juju):
+    """Verify that predefined roles don't exist in the old revision."""
+    primary_unit_name = get_mysql_primary_unit(juju, DATABASE_APP_NAME)
+    primary_unit_address = get_unit_address(juju, DATABASE_APP_NAME, primary_unit_name)
+    server_config_credentials = get_mysql_server_credentials(juju, primary_unit_name)
+
+    logging.info("Checking that predefined roles don't exist in old revision")
+    rows = execute_queries_on_unit(
+        primary_unit_address,
+        server_config_credentials["username"],
+        server_config_credentials["password"],
+        [
+            "SELECT user AS role_name FROM mysql.user "
+            "WHERE account_locked='Y' AND password_expired='Y' AND authentication_string='' "
+            "AND user IN ('mysqlrouter', 'charmed_router', 'charmed_read', 'charmed_dml', "
+            "'charmed_ddl', 'charmed_dba', 'charmed_backup', 'charmed_stats')"
+        ],
+        commit=False,
+    )
+
+    predefined_roles = {
+        "charmed_backup",
+        "charmed_dba",
+        "charmed_ddl",
+        "charmed_dml",
+        "charmed_read",
+        "charmed_router",
+        "charmed_stats",
+        "mysqlrouter",
+    }
+
+    assert set(rows).isdisjoint(predefined_roles), (
+        f"Expected no predefined roles in revision {OLD_MYSQL_REVISION}, but found: {rows}"
+    )
+
+
+def test_verify_predefined_roles_present_after_refresh(juju: Juju, charm):
+    """Verify that predefined roles are present after refresh."""
+    mysql_leader = get_app_leader(juju, DATABASE_APP_NAME)
+
+    logging.info("Running pre-upgrade-check action")
+    juju.run(unit=mysql_leader, action="pre-upgrade-check")
+
+    logging.info("Refreshing MySQL to new charm with predefined roles support")
+    juju.refresh(
+        app=DATABASE_APP_NAME,
+        path=charm,
+        resources={"mysql-image": CHARM_METADATA["resources"]["mysql-image"]["upstream-source"]},
+    )
+
+    logging.info("Wait for refresh to complete")
+    juju.wait(
+        ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
+        timeout=TIMEOUT,
+    )
+
+    primary_unit_name = get_mysql_primary_unit(juju, DATABASE_APP_NAME)
+    primary_unit_address = get_unit_address(juju, DATABASE_APP_NAME, primary_unit_name)
+    server_config_credentials = get_mysql_server_credentials(juju, primary_unit_name)
+
+    logging.info("Checking if predefined roles exist after refresh")
+    rows = execute_queries_on_unit(
+        primary_unit_address,
+        server_config_credentials["username"],
+        server_config_credentials["password"],
+        ["SELECT user AS role_name FROM mysql.user"],
+        commit=False,
+    )
+
+    expected_roles = {
+        "charmed_backup",
+        "charmed_dba",
+        "charmed_ddl",
+        "charmed_dml",
+        "charmed_read",
+        "charmed_router",
+        "charmed_stats",
+        "mysqlrouter",
+    }
+
+    existing_roles = set(rows)
+    assert expected_roles <= set(existing_roles), (
+        f"Expected roles {expected_roles} to be a subset of existing roles {existing_roles}"
+    )
+
+
+def test_integrate_mysql_router_and_test_app(juju: Juju):
+    """Integrate MySQL Router with MySQL and verify they work."""
+    logging.info("Deploying MySQL Router")
+    juju.deploy(
+        charm=MYSQL_ROUTER_APP_NAME,
+        app=MYSQL_ROUTER_APP_NAME,
+        base="ubuntu@22.04",
+        channel="8.0/stable",
+        num_units=1,
+        trust=True,
+    )
+
+    logging.info("Deploying MySQL test application")
+    juju.deploy(
+        charm=MYSQL_TEST_APP_NAME,
+        app=MYSQL_TEST_APP_NAME,
+        base="ubuntu@22.04",
+        channel="latest/edge",
+        num_units=1,
+        config={"database_name": "test"},
+    )
+
+    logging.info("Waiting for applications to be ready")
+    juju.wait(
+        ready=lambda status: all((
+            jubilant_backports.all_agents_idle(status, MYSQL_ROUTER_APP_NAME),
+            jubilant_backports.all_agents_idle(status, MYSQL_TEST_APP_NAME),
+        )),
+        timeout=TIMEOUT,
+    )
+
+    logging.info("Integrating mysql-router with mysql-test-app")
+    juju.integrate(
+        f"{MYSQL_ROUTER_APP_NAME}:database",
+        f"{MYSQL_TEST_APP_NAME}:database",
+    )
+
+    logging.info("Integrating mysql-router with mysql")
+    juju.integrate(
+        f"{MYSQL_ROUTER_APP_NAME}:backend-database",
+        f"{DATABASE_APP_NAME}:database",
+    )
+
+    logging.info("Waiting for all apps to become active")
+    juju.wait(
+        ready=wait_for_apps_status(
+            jubilant_backports.all_active,
+            DATABASE_APP_NAME,
+            MYSQL_ROUTER_APP_NAME,
+            MYSQL_TEST_APP_NAME,
+        ),
+        timeout=TIMEOUT,
+    )

--- a/kubernetes/tests/spread/integration/test_predefined_roles_refresh.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_predefined_roles_refresh.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_predefined_roles_refresh.py
+environment:
+  TEST_MODULE: roles/test_predefined_roles_refresh.py
+execute: |
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/kubernetes/tests/unit/test_charm.py
+++ b/kubernetes/tests/unit/test_charm.py
@@ -155,7 +155,9 @@ class TestCharm(unittest.TestCase):
     @patch("mysql_k8s_helpers.MySQL.initialize_juju_units_operations_table")
     @patch("mysql_k8s_helpers.MySQL.get_mysql_version", return_value="8.0.0")
     @patch("mysql_k8s_helpers.MySQL.wait_until_mysql_connection")
-    @patch("mysql_k8s_helpers.MySQL.configure_mysql_users_and_roles")
+    @patch("mysql_k8s_helpers.MySQL.configure_mysql_router_roles")
+    @patch("mysql_k8s_helpers.MySQL.configure_mysql_system_roles")
+    @patch("mysql_k8s_helpers.MySQL.configure_mysql_system_users")
     @patch("mysql_k8s_helpers.MySQL.configure_instance")
     @patch("mysql_k8s_helpers.MySQL.create_cluster")
     @patch("mysql_k8s_helpers.MySQL.initialise_mysqld")
@@ -169,7 +171,7 @@ class TestCharm(unittest.TestCase):
     )
     @patch("mysql_k8s_helpers.MySQL.get_max_connections", return_value=120)
     @patch("mysql_k8s_helpers.MySQL.setup_logrotate_config")
-    @patch("mysql_k8s_helpers.MySQL.reset_root_password_and_start_mysqld")
+    @patch("mysql_k8s_helpers.MySQL.set_operator_user_and_start_mysqld")
     def test_mysql_pebble_ready(
         self,
         _,
@@ -183,7 +185,9 @@ class TestCharm(unittest.TestCase):
         _fix_data_dir,
         _create_cluster,
         _configure_instance,
-        _configure_mysql_users_and_roles,
+        _configure_mysql_router_roles,
+        _configure_mysql_system_roles,
+        _configure_mysql_system_users,
         _wait_until_mysql_connection,
         _get_mysql_version,
         _initialize_juju_units_operations_table,

--- a/kubernetes/tests/unit/test_charm.py
+++ b/kubernetes/tests/unit/test_charm.py
@@ -155,9 +155,7 @@ class TestCharm(unittest.TestCase):
     @patch("mysql_k8s_helpers.MySQL.initialize_juju_units_operations_table")
     @patch("mysql_k8s_helpers.MySQL.get_mysql_version", return_value="8.0.0")
     @patch("mysql_k8s_helpers.MySQL.wait_until_mysql_connection")
-    @patch("mysql_k8s_helpers.MySQL.configure_mysql_router_roles")
-    @patch("mysql_k8s_helpers.MySQL.configure_mysql_system_roles")
-    @patch("mysql_k8s_helpers.MySQL.configure_mysql_system_users")
+    @patch("mysql_k8s_helpers.MySQL.configure_mysql_users_and_roles")
     @patch("mysql_k8s_helpers.MySQL.configure_instance")
     @patch("mysql_k8s_helpers.MySQL.create_cluster")
     @patch("mysql_k8s_helpers.MySQL.initialise_mysqld")
@@ -185,9 +183,7 @@ class TestCharm(unittest.TestCase):
         _fix_data_dir,
         _create_cluster,
         _configure_instance,
-        _configure_mysql_router_roles,
-        _configure_mysql_system_roles,
-        _configure_mysql_system_users,
+        _configure_mysql_users_and_roles,
         _wait_until_mysql_connection,
         _get_mysql_version,
         _initialize_juju_units_operations_table,

--- a/kubernetes/tests/unit/test_mysql_k8s_helpers.py
+++ b/kubernetes/tests/unit/test_mysql_k8s_helpers.py
@@ -292,15 +292,15 @@ class TestMySQL(unittest.TestCase):
 
     @patch("ops.model.Container")
     @patch("mysql_k8s_helpers.MySQL.wait_until_mysql_connection")
-    def test_reset_root_password_and_start_mysqld(self, _wait_until_mysql_connection, _container):
-        """Test for reset_root_password_and_start_mysqld()."""
+    def test_set_operator_user_and_start_mysqld(self, _wait_until_mysql_connection, _container):
+        """Test for set_operator_user_and_start_mysqld()."""
         self.mysql.container = _container
-        self.mysql.reset_root_password_and_start_mysqld()
+        self.mysql.set_operator_user_and_start_mysqld()
 
         self.mysql.container.push.assert_has_calls([
             call(
-                "/alter-root-user.sql",
-                "ALTER USER 'root'@'localhost' IDENTIFIED BY 'password';\nFLUSH PRIVILEGES;",
+                "/create-operator-user.sql",
+                "CREATE USER 'serverconfig'@'%' IDENTIFIED BY 'serverconfigpassword';\nGRANT ALL ON *.* TO 'serverconfig'@'%' WITH GRANT OPTION;\nFLUSH PRIVILEGES;",
                 encoding="utf-8",
                 permissions=384,
                 user="mysql",
@@ -308,7 +308,7 @@ class TestMySQL(unittest.TestCase):
             ),
             call(
                 "/etc/mysql/mysql.conf.d/z-custom-init-file.cnf",
-                "[mysqld]\ninit_file = /alter-root-user.sql",
+                "[mysqld]\ninit_file = /create-operator-user.sql",
                 encoding="utf-8",
                 permissions=384,
                 user="mysql",
@@ -318,16 +318,16 @@ class TestMySQL(unittest.TestCase):
         self.mysql.container.restart.assert_called_once_with("mysqld")
         _wait_until_mysql_connection.assert_called_once_with(check_port=False)
         self.mysql.container.remove_path.assert_has_calls([
-            call("/alter-root-user.sql"),
+            call("/create-operator-user.sql"),
             call("/etc/mysql/mysql.conf.d/z-custom-init-file.cnf"),
         ])
 
     @patch("ops.model.Container")
     @patch("mysql_k8s_helpers.MySQL.wait_until_mysql_connection")
-    def test_reset_root_password_and_start_mysqld_error(
+    def test_set_operator_user_and_start_mysqld_error(
         self, _wait_until_mysql_connection, _container
     ):
-        """Test exceptions in reset_root_password_and_start_mysqld()."""
+        """Test exceptions in set_operator_user_and_start_mysqld()."""
         self.mysql.container = _container
         _container.push.side_effect = [
             None,
@@ -335,19 +335,19 @@ class TestMySQL(unittest.TestCase):
         ]
 
         with self.assertRaises(PathError):
-            self.mysql.reset_root_password_and_start_mysqld()
+            self.mysql.set_operator_user_and_start_mysqld()
 
         self.mysql.container.push.assert_has_calls([
             call(
-                "/alter-root-user.sql",
-                "ALTER USER 'root'@'localhost' IDENTIFIED BY 'password';\nFLUSH PRIVILEGES;",
+                "/create-operator-user.sql",
+                "CREATE USER 'serverconfig'@'%' IDENTIFIED BY 'serverconfigpassword';\nGRANT ALL ON *.* TO 'serverconfig'@'%' WITH GRANT OPTION;\nFLUSH PRIVILEGES;",
                 encoding="utf-8",
                 permissions=384,
                 user="mysql",
                 group="mysql",
             ),
         ])
-        self.mysql.container.remove_path.assert_called_once_with("/alter-root-user.sql")
+        self.mysql.container.remove_path.assert_called_once_with("/create-operator-user.sql")
         _wait_until_mysql_connection.assert_not_called()
 
         _container.push.side_effect = [None, None]
@@ -359,12 +359,12 @@ class TestMySQL(unittest.TestCase):
         ]
 
         with self.assertRaises(MySQLServiceNotRunningError):
-            self.mysql.reset_root_password_and_start_mysqld()
+            self.mysql.set_operator_user_and_start_mysqld()
 
         self.mysql.container.push.assert_has_calls([
             call(
-                "/alter-root-user.sql",
-                "ALTER USER 'root'@'localhost' IDENTIFIED BY 'password';\nFLUSH PRIVILEGES;",
+                "/create-operator-user.sql",
+                "CREATE USER 'serverconfig'@'%' IDENTIFIED BY 'serverconfigpassword';\nGRANT ALL ON *.* TO 'serverconfig'@'%' WITH GRANT OPTION;\nFLUSH PRIVILEGES;",
                 encoding="utf-8",
                 permissions=384,
                 user="mysql",
@@ -372,7 +372,7 @@ class TestMySQL(unittest.TestCase):
             ),
             call(
                 "/etc/mysql/mysql.conf.d/z-custom-init-file.cnf",
-                "[mysqld]\ninit_file = /alter-root-user.sql",
+                "[mysqld]\ninit_file = /create-operator-user.sql",
                 encoding="utf-8",
                 permissions=384,
                 user="mysql",
@@ -381,6 +381,6 @@ class TestMySQL(unittest.TestCase):
         ])
         self.mysql.container.restart.assert_called_once_with("mysqld")
         self.mysql.container.remove_path.assert_has_calls([
-            call("/alter-root-user.sql"),
+            call("/create-operator-user.sql"),
             call("/etc/mysql/mysql.conf.d/z-custom-init-file.cnf"),
         ])

--- a/kubernetes/tests/unit/test_upgrade.py
+++ b/kubernetes/tests/unit/test_upgrade.py
@@ -173,8 +173,7 @@ class TestUpgrade(unittest.TestCase):
 
     @patch("charm.MySQLOperatorCharm.get_unit_address", return_value="mysql-k8s.somedomain")
     @patch("charm.MySQLOperatorCharm.recover_unit_after_restart")
-    @patch("mysql_k8s_helpers.MySQL.configure_mysql_system_roles")
-    @patch("mysql_k8s_helpers.MySQL.configure_mysql_router_roles")
+    @patch("mysql_k8s_helpers.MySQL.configure_mysql_users_and_roles")
     @patch("mysql_k8s_helpers.MySQL.install_plugins")
     @patch("mysql_k8s_helpers.MySQL.cluster_metadata_exists", return_value=True)
     @patch("mysql_k8s_helpers.MySQL.setup_logrotate_config")
@@ -191,8 +190,7 @@ class TestUpgrade(unittest.TestCase):
         mock_setup_logrotate_config,
         mock_cluster_metadata_exists,
         mock_install_plugins,
-        mock_configure_mysql_router_roles,
-        mock_configure_mysql_system_roles,
+        mock_configure_mysql_users_and_roles,
         mock_recover_unit_after_restart,
         mock_get_unit_address,
     ):
@@ -218,9 +216,8 @@ class TestUpgrade(unittest.TestCase):
             "idle",  # change to `completed` - behavior not yet set in the lib
         )
 
-        # Verify role configuration methods were called during upgrade
-        mock_configure_mysql_router_roles.assert_called_once()
-        mock_configure_mysql_system_roles.assert_called_once()
+        # Verify user and role configuration method was called during upgrade
+        mock_configure_mysql_users_and_roles.assert_called_once()
 
         self.harness.update_relation_data(
             self.upgrade_relation_id, "mysql-k8s/0", {"state": "upgrading"}

--- a/kubernetes/tests/unit/test_upgrade.py
+++ b/kubernetes/tests/unit/test_upgrade.py
@@ -173,7 +173,9 @@ class TestUpgrade(unittest.TestCase):
 
     @patch("charm.MySQLOperatorCharm.get_unit_address", return_value="mysql-k8s.somedomain")
     @patch("charm.MySQLOperatorCharm.recover_unit_after_restart")
-    @patch("mysql_k8s_helpers.MySQL.configure_mysql_users_and_roles")
+    @patch("mysql_k8s_helpers.MySQL.configure_mysql_router_roles")
+    @patch("mysql_k8s_helpers.MySQL.configure_mysql_system_roles")
+    @patch("mysql_k8s_helpers.MySQL.configure_mysql_system_users")
     @patch("mysql_k8s_helpers.MySQL.install_plugins")
     @patch("mysql_k8s_helpers.MySQL.cluster_metadata_exists", return_value=True)
     @patch("mysql_k8s_helpers.MySQL.setup_logrotate_config")
@@ -190,7 +192,9 @@ class TestUpgrade(unittest.TestCase):
         mock_setup_logrotate_config,
         mock_cluster_metadata_exists,
         mock_install_plugins,
-        mock_configure_mysql_users_and_roles,
+        mock_configure_mysql_system_users,
+        mock_configure_mysql_system_roles,
+        mock_configure_mysql_router_roles,
         mock_recover_unit_after_restart,
         mock_get_unit_address,
     ):
@@ -215,9 +219,6 @@ class TestUpgrade(unittest.TestCase):
             self.harness.get_relation_data(self.upgrade_relation_id, "mysql-k8s/1")["state"],
             "idle",  # change to `completed` - behavior not yet set in the lib
         )
-
-        # Verify user and role configuration method was called during upgrade
-        mock_configure_mysql_users_and_roles.assert_called_once()
 
         self.harness.update_relation_data(
             self.upgrade_relation_id, "mysql-k8s/0", {"state": "upgrading"}

--- a/kubernetes/tests/unit/test_upgrade.py
+++ b/kubernetes/tests/unit/test_upgrade.py
@@ -173,6 +173,8 @@ class TestUpgrade(unittest.TestCase):
 
     @patch("charm.MySQLOperatorCharm.get_unit_address", return_value="mysql-k8s.somedomain")
     @patch("charm.MySQLOperatorCharm.recover_unit_after_restart")
+    @patch("mysql_k8s_helpers.MySQL.configure_mysql_system_roles")
+    @patch("mysql_k8s_helpers.MySQL.configure_mysql_router_roles")
     @patch("mysql_k8s_helpers.MySQL.install_plugins")
     @patch("mysql_k8s_helpers.MySQL.cluster_metadata_exists", return_value=True)
     @patch("mysql_k8s_helpers.MySQL.setup_logrotate_config")
@@ -189,6 +191,8 @@ class TestUpgrade(unittest.TestCase):
         mock_setup_logrotate_config,
         mock_cluster_metadata_exists,
         mock_install_plugins,
+        mock_configure_mysql_router_roles,
+        mock_configure_mysql_system_roles,
         mock_recover_unit_after_restart,
         mock_get_unit_address,
     ):
@@ -213,6 +217,10 @@ class TestUpgrade(unittest.TestCase):
             self.harness.get_relation_data(self.upgrade_relation_id, "mysql-k8s/1")["state"],
             "idle",  # change to `completed` - behavior not yet set in the lib
         )
+
+        # Verify role configuration methods were called during upgrade
+        mock_configure_mysql_router_roles.assert_called_once()
+        mock_configure_mysql_system_roles.assert_called_once()
 
         self.harness.update_relation_data(
             self.upgrade_relation_id, "mysql-k8s/0", {"state": "upgrading"}

--- a/machines/lib/charms/mysql/v0/mysql.py
+++ b/machines/lib/charms/mysql/v0/mysql.py
@@ -66,14 +66,13 @@ import re
 import sys
 import time
 from abc import ABC, abstractmethod
+from collections.abc import Generator
 from contextlib import contextmanager, suppress
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
-    Generator,
     Literal,
-    Type,
     get_args,
 )
 
@@ -1005,7 +1004,7 @@ class MySQLBase(ABC):
         backups_user: str,
         backups_password: str,
         mysqlsh_path: str,
-        executor_class: Type[BaseExecutor],
+        executor_class: type[BaseExecutor],
     ):
         """Initialize the MySQL class."""
         self.instance_address = instance_address

--- a/machines/lib/charms/mysql/v0/mysql.py
+++ b/machines/lib/charms/mysql/v0/mysql.py
@@ -1264,9 +1264,8 @@ class MySQLBase(ABC):
             ])
 
             try:
-                with (
-                    self._read_only_disabled()
-                ):  # Non-primary cluster members will have SUPER_READ_ONLY mode enabled
+                # Non-primary cluster members will have SUPER_READ_ONLY mode enabled
+                with self._read_only_disabled():
                     logger.debug(f"Configuring Router role for {self.instance_address}")
                     executor.execute_sql(configure_role_commands)
             except ExecutionError as e:
@@ -1298,9 +1297,8 @@ class MySQLBase(ABC):
         executor = self._build_instance_sock_executor()
 
         try:
-            with (
-                self._read_only_disabled()
-            ):  # Non-primary cluster members will have SUPER_READ_ONLY mode enabled
+            # Non-primary cluster members will have SUPER_READ_ONLY mode enabled
+            with self._read_only_disabled():
                 logger.debug(f"Configuring MySQL roles for {self.instance_address}")
                 executor.execute_sql(query)
         except ExecutionError as e:
@@ -1333,9 +1331,8 @@ class MySQLBase(ABC):
         executor = self._build_instance_sock_executor()
 
         try:
-            with (
-                self._read_only_disabled()
-            ):  # Non-primary cluster members will have SUPER_READ_ONLY mode enabled
+            # Non-primary cluster members will have SUPER_READ_ONLY mode enabled
+            with self._read_only_disabled():
                 logger.debug(f"Configuring MySQL users for {self.instance_address}")
                 executor.execute_sql(configure_commands)
         except ExecutionError as e:

--- a/machines/lib/charms/mysql/v0/mysql.py
+++ b/machines/lib/charms/mysql/v0/mysql.py
@@ -1040,6 +1040,8 @@ class MySQLBase(ABC):
             role_reader=ROLE_READ,
             role_writer=ROLE_DML,
         )
+        # TODO: Remove when mysql-shell-client supports idempotent queries
+        self._auth_query_builder.ROLE_CREATION_QUERY = "CREATE ROLE IF NOT EXISTS {rolename}"  # type: ignore
         self._lock_query_builder = CharmLockingQueryBuilder(
             table_schema="mysql",
             table_name="juju_units_operations",
@@ -1087,8 +1089,8 @@ class MySQLBase(ABC):
         """Build a socket executor for the instance operations."""
         return self.executor_class(
             conn_details=ConnectionDetails(
-                username=self.root_user,
-                password=self.root_password,
+                username=self.server_config_user,
+                password=self.server_config_password,
                 socket=self.socket_path,
             ),
             shell_path=self.mysqlsh_path,
@@ -1244,7 +1246,7 @@ class MySQLBase(ABC):
         except ExecutionError as e:
             raise MySQLConfigureMySQLRolesError() from e
 
-        executor = self._build_instance_tcp_executor(self.instance_address)
+        executor = self._build_instance_sock_executor()
 
         for role in (LEGACY_ROLE_ROUTER, MODERN_ROLE_ROUTER):
             if role in router_roles:
@@ -1263,8 +1265,11 @@ class MySQLBase(ABC):
             ])
 
             try:
-                logger.debug(f"Configuring Router role for {self.instance_address}")
-                executor.execute_sql(configure_role_commands)
+                with (
+                    self._read_only_disabled()
+                ):  # Non-primary cluster members will have SUPER_READ_ONLY mode enabled
+                    logger.debug(f"Configuring Router role for {self.instance_address}")
+                    executor.execute_sql(configure_role_commands)
             except ExecutionError as e:
                 logger.error(f"Failed to configure Router role for {self.instance_address}")
                 raise MySQLConfigureMySQLRolesError() from e
@@ -1291,11 +1296,14 @@ class MySQLBase(ABC):
 
         logger.debug("Missing MySQL roles")
         query = self._auth_query_builder.build_instance_auth_roles_query()
-        executor = self._build_instance_tcp_executor(self.instance_address)
+        executor = self._build_instance_sock_executor()
 
         try:
-            logger.debug(f"Configuring MySQL roles for {self.instance_address}")
-            executor.execute_sql(query)
+            with (
+                self._read_only_disabled()
+            ):  # Non-primary cluster members will have SUPER_READ_ONLY mode enabled
+                logger.debug(f"Configuring MySQL roles for {self.instance_address}")
+                executor.execute_sql(query)
         except ExecutionError as e:
             logger.error(f"Failed to configure roles for {self.instance_address}")
             raise MySQLConfigureMySQLRolesError() from e
@@ -1305,15 +1313,13 @@ class MySQLBase(ABC):
         configure_users_commands = [
             f"UPDATE mysql.user SET authentication_string=null WHERE User='{self.root_user}' and Host='localhost'",  # noqa: S608
             f"ALTER USER '{self.root_user}'@'localhost' IDENTIFIED BY '{self.root_password}'",
-            f"CREATE USER '{self.server_config_user}'@'%' IDENTIFIED BY '{self.server_config_password}'",
-            f"CREATE USER '{self.monitoring_user}'@'%' IDENTIFIED BY '{self.monitoring_password}' WITH MAX_USER_CONNECTIONS 3",
-            f"CREATE USER '{self.backups_user}'@'%' IDENTIFIED BY '{self.backups_password}'",
+            f"CREATE USER IF NOT EXISTS '{self.monitoring_user}'@'%' IDENTIFIED BY '{self.monitoring_password}' WITH MAX_USER_CONNECTIONS 3",
+            f"CREATE USER IF NOT EXISTS '{self.backups_user}'@'%' IDENTIFIED BY '{self.backups_password}'",
         ]
 
         # SYSTEM_USER and SUPER privileges to revoke from the root users
         # Reference: https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html#priv_super
         configure_privs_commands = [
-            f"GRANT ALL ON *.* TO '{self.server_config_user}'@'%' WITH GRANT OPTION",
             f"GRANT charmed_stats TO '{self.monitoring_user}'@'%'",
             f"GRANT charmed_backup TO '{self.backups_user}'@'%'",
             f"REVOKE BINLOG_ADMIN, CONNECTION_ADMIN, ENCRYPTION_KEY_ADMIN, GROUP_REPLICATION_ADMIN, REPLICATION_SLAVE_ADMIN, SET_USER_ID, SUPER, SYSTEM_USER, SYSTEM_VARIABLES_ADMIN, VERSION_TOKEN_ADMIN ON *.* FROM '{self.root_user}'@'localhost'",
@@ -1328,8 +1334,11 @@ class MySQLBase(ABC):
         executor = self._build_instance_sock_executor()
 
         try:
-            logger.debug(f"Configuring MySQL users for {self.instance_address}")
-            executor.execute_sql(configure_commands)
+            with (
+                self._read_only_disabled()
+            ):  # Non-primary cluster members will have SUPER_READ_ONLY mode enabled
+                logger.debug(f"Configuring MySQL users for {self.instance_address}")
+                executor.execute_sql(configure_commands)
         except ExecutionError as e:
             logger.error(f"Failed to configure users for: {self.instance_address}")
             raise MySQLConfigureMySQLUsersError from e

--- a/machines/lib/charms/mysql/v0/mysql.py
+++ b/machines/lib/charms/mysql/v0/mysql.py
@@ -1244,7 +1244,7 @@ class MySQLBase(ABC):
         except ExecutionError as e:
             raise MySQLConfigureMySQLRolesError() from e
 
-        executor = self._build_instance_sock_executor()
+        executor = self._build_instance_tcp_executor(self.instance_address)
 
         for role in (LEGACY_ROLE_ROUTER, MODERN_ROLE_ROUTER):
             if role in router_roles:
@@ -1291,7 +1291,7 @@ class MySQLBase(ABC):
 
         logger.debug("Missing MySQL roles")
         query = self._auth_query_builder.build_instance_auth_roles_query()
-        executor = self._build_instance_sock_executor()
+        executor = self._build_instance_tcp_executor(self.instance_address)
 
         try:
             logger.debug(f"Configuring MySQL roles for {self.instance_address}")

--- a/machines/lib/charms/mysql/v0/mysql.py
+++ b/machines/lib/charms/mysql/v0/mysql.py
@@ -1252,7 +1252,7 @@ class MySQLBase(ABC):
 
             logger.debug(f"Missing MySQL role {role}")
             configure_role_commands = ";".join([
-                f"CREATE ROLE {role}",
+                f"CREATE ROLE IF NOT EXISTS {role}",
                 f"GRANT CREATE ON *.* TO {role}",
                 f"GRANT CREATE USER ON *.* TO {role}",
                 # The granting of all privileges to the MySQL Router role

--- a/machines/lib/charms/mysql/v0/mysql.py
+++ b/machines/lib/charms/mysql/v0/mysql.py
@@ -1039,8 +1039,6 @@ class MySQLBase(ABC):
             role_reader=ROLE_READ,
             role_writer=ROLE_DML,
         )
-        # TODO: Remove when mysql-shell-client supports idempotent queries
-        self._auth_query_builder.ROLE_CREATION_QUERY = "CREATE ROLE IF NOT EXISTS {rolename}"  # type: ignore
         self._lock_query_builder = CharmLockingQueryBuilder(
             table_schema="mysql",
             table_name="juju_units_operations",

--- a/machines/lib/pyproject.toml
+++ b/machines/lib/pyproject.toml
@@ -5,7 +5,7 @@
 [tool.ruff]
 # preview and explicit preview are enabled for CPY001
 preview = true
-target-version = "py38"
+target-version = "py310"
 src = [".."]
 line-length = 99
 

--- a/machines/poetry.lock
+++ b/machines/poetry.lock
@@ -1030,14 +1030,14 @@ telemetry = ["opentelemetry-api (==1.18.0)", "opentelemetry-exporter-otlp-proto-
 
 [[package]]
 name = "mysql-shell-client"
-version = "0.7.1"
+version = "0.8.0"
 description = "Python client for MySQL Shell"
 optional = false
 python-versions = ">=3.10"
 groups = ["charm-libs"]
 files = [
-    {file = "mysql_shell_client-0.7.1-py3-none-any.whl", hash = "sha256:0223fde0ad97a132d1ad0c4ba91cb15c1ef1041272c2b74d764a5441f3092562"},
-    {file = "mysql_shell_client-0.7.1.tar.gz", hash = "sha256:e5595cd6ec76b2c0d887dccc32c4feb18031afd7f22b5b7222596308052efa44"},
+    {file = "mysql_shell_client-0.8.0-py3-none-any.whl", hash = "sha256:2ec1cd6461ea1e9ec234d678083836cf5408f75708696af3d61de62a551df579"},
+    {file = "mysql_shell_client-0.8.0.tar.gz", hash = "sha256:a8a19c2b341c130548be869bc96bdec97c22bbd7b82610dba442ab7954f4cf1b"},
 ]
 
 [package.extras]

--- a/machines/pyproject.toml
+++ b/machines/pyproject.toml
@@ -23,7 +23,7 @@ charm-libs = [
     # grafana_agent/v0/cos_agent.py
     "cosl>=0.0.50",
     # mysql/v0/*.py"
-    "mysql_shell_client~=0.7",
+    "mysql_shell_client~=0.8",
     # tls_certificates_interface/v2/tls_certificates.py
     "cryptography>=42.0.5",
     "jsonschema",

--- a/machines/src/charm.py
+++ b/machines/src/charm.py
@@ -780,10 +780,10 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
 
         self._mysql.write_mysqld_config()
         self.log_rotation_setup.setup()
-        self._mysql.reset_root_password_and_start_mysqld()
-        self._mysql.configure_mysql_system_users()
+        self._mysql.set_operator_user_and_start_mysqld()
         self._mysql.configure_mysql_router_roles()
         self._mysql.configure_mysql_system_roles()
+        self._mysql.configure_mysql_system_users()
 
         if self.config.plugin_audit_enabled:
             self._mysql.install_plugins(["audit_log"])

--- a/machines/src/charm.py
+++ b/machines/src/charm.py
@@ -781,9 +781,9 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         self._mysql.write_mysqld_config()
         self.log_rotation_setup.setup()
         self._mysql.reset_root_password_and_start_mysqld()
+        self._mysql.configure_mysql_system_users()
         self._mysql.configure_mysql_router_roles()
         self._mysql.configure_mysql_system_roles()
-        self._mysql.configure_mysql_system_users()
 
         if self.config.plugin_audit_enabled:
             self._mysql.install_plugins(["audit_log"])

--- a/machines/src/mysql_vm_helpers.py
+++ b/machines/src/mysql_vm_helpers.py
@@ -336,9 +336,9 @@ class MySQL(MySQLBase):
         cron_content = f"* 1-23 * * * root {script_path}\n1-59 0 * * * root {script_path}\n"
         self.write_content_to_file(cron_path, cron_content, owner="root")
 
-    def reset_root_password_and_start_mysqld(self) -> None:
+    def set_operator_user_and_start_mysqld(self) -> None:
         """Reset the root user password and start mysqld."""
-        logger.debug("Resetting root user password and starting mysqld")
+        logger.info("Set operator user and restart mysqld")
         with (
             tempfile.NamedTemporaryFile(
                 dir=MYSQLD_CONFIG_DIRECTORY,
@@ -349,7 +349,7 @@ class MySQL(MySQLBase):
             ) as _custom_config_file,
             tempfile.NamedTemporaryFile(
                 dir=CHARMED_MYSQL_COMMON_DIRECTORY,
-                prefix="alter-root-user.",
+                prefix="create-operator-user.",
                 suffix=".sql",
                 mode="w",
                 encoding="utf-8",
@@ -369,7 +369,8 @@ class MySQL(MySQLBase):
                 ) from e
 
             _sql_file.write(
-                f"ALTER USER 'root'@'localhost' IDENTIFIED BY '{self.root_password}';\n"
+                f"CREATE USER '{self.server_config_user}'@'%' IDENTIFIED BY '{self.server_config_password}';"
+                f"GRANT ALL ON *.* TO '{self.server_config_user}'@'%' WITH GRANT OPTION;"
                 "FLUSH PRIVILEGES;"
             )
             _sql_file.flush()

--- a/machines/src/upgrade.py
+++ b/machines/src/upgrade.py
@@ -232,7 +232,7 @@ class MySQLVMUpgrade(DataUpgrade):
         try:
             self.charm.recover_unit_after_restart()
 
-            logger.info("Ensuring predefined roles exist")
+            logger.info("Reconciling predefined roles exist")
             self.charm._mysql.configure_mysql_router_roles()
             self.charm._mysql.configure_mysql_system_roles()
 

--- a/machines/src/upgrade.py
+++ b/machines/src/upgrade.py
@@ -182,7 +182,7 @@ class MySQLVMUpgrade(DataUpgrade):
                 return
 
             # override config, avoid restart
-            self.charm._on_config_changed(None)
+            self.charm._mysql.write_mysqld_config()
             self.charm.unit.status = MaintenanceStatus("starting services...")
             # stop cron daemon to be able to query `error.log`
             set_cron_daemon("stop")

--- a/machines/src/upgrade.py
+++ b/machines/src/upgrade.py
@@ -232,7 +232,7 @@ class MySQLVMUpgrade(DataUpgrade):
         try:
             self.charm.recover_unit_after_restart()
 
-            logger.info("Reconciling predefined roles exist")
+            logger.info("Reconciling predefined roles")
             self.charm._mysql.configure_mysql_router_roles()
             self.charm._mysql.configure_mysql_system_roles()
             self.charm._mysql.configure_mysql_system_users()

--- a/machines/src/upgrade.py
+++ b/machines/src/upgrade.py
@@ -235,6 +235,7 @@ class MySQLVMUpgrade(DataUpgrade):
             logger.info("Reconciling predefined roles exist")
             self.charm._mysql.configure_mysql_router_roles()
             self.charm._mysql.configure_mysql_system_roles()
+            self.charm._mysql.configure_mysql_system_users()
 
             logger.debug("Upgraded unit is healthy. Set upgrade state to `completed`")
             self.set_unit_completed()

--- a/machines/src/upgrade.py
+++ b/machines/src/upgrade.py
@@ -232,6 +232,10 @@ class MySQLVMUpgrade(DataUpgrade):
         try:
             self.charm.recover_unit_after_restart()
 
+            logger.info("Ensuring predefined roles exist")
+            self.charm._mysql.configure_mysql_router_roles()
+            self.charm._mysql.configure_mysql_system_roles()
+
             logger.debug("Upgraded unit is healthy. Set upgrade state to `completed`")
             self.set_unit_completed()
             # ensures leader gets it's own relation-changed when it upgrades

--- a/machines/tests/integration/integration/roles/test_predefined_roles_refresh.py
+++ b/machines/tests/integration/integration/roles/test_predefined_roles_refresh.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+import logging
+
+import jubilant_backports
+from jubilant_backports import Juju
+
+from ...helpers import execute_queries_on_unit
+from ...helpers_ha import (
+    MINUTE_SECS,
+    get_app_leader,
+    get_mysql_primary_unit,
+    get_mysql_server_credentials,
+    get_unit_ip,
+    wait_for_apps_status,
+)
+
+DATABASE_APP_NAME = "mysql"
+MYSQL_ROUTER_APP_NAME = "mysql-router"
+MYSQL_TEST_APP_NAME = "mysql-test-app"
+
+OLD_MYSQL_REVISION = 366
+
+TIMEOUT = 10 * MINUTE_SECS
+
+
+def test_build_and_deploy(juju: Juju) -> None:
+    """Deploy an old MySQL revision without predefined roles support."""
+    logging.info(f"Deploying MySQL cluster revision {OLD_MYSQL_REVISION}")
+    juju.deploy(
+        charm=DATABASE_APP_NAME,
+        app=DATABASE_APP_NAME,
+        base="ubuntu@22.04",
+        channel="8.0/stable",
+        revision=OLD_MYSQL_REVISION,
+        config={"profile": "testing"},
+        num_units=1,
+    )
+    juju.wait(
+        ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
+        timeout=TIMEOUT,
+    )
+
+
+def test_verify_no_predefined_roles_in_old_revision(juju: Juju):
+    """Verify that predefined roles don't exist in the old revision."""
+    primary_unit_name = get_mysql_primary_unit(juju, DATABASE_APP_NAME)
+    primary_unit_address = get_unit_ip(juju, DATABASE_APP_NAME, primary_unit_name)
+    server_config_credentials = get_mysql_server_credentials(juju, primary_unit_name)
+
+    logging.info("Checking that predefined roles don't exist in old revision")
+    rows = execute_queries_on_unit(
+        primary_unit_address,
+        server_config_credentials["username"],
+        server_config_credentials["password"],
+        [
+            "SELECT user AS role_name FROM mysql.user "
+            "WHERE account_locked='Y' AND password_expired='Y' AND authentication_string='' "
+            "AND user IN ('mysqlrouter', 'charmed_router', 'charmed_read', 'charmed_dml', "
+            "'charmed_ddl', 'charmed_dba', 'charmed_backup', 'charmed_stats')"
+        ],
+        commit=False,
+    )
+
+    predefined_roles = {
+        "charmed_backup",
+        "charmed_dba",
+        "charmed_ddl",
+        "charmed_dml",
+        "charmed_read",
+        "charmed_router",
+        "charmed_stats",
+        "mysqlrouter",
+    }
+
+    assert set(rows).isdisjoint(predefined_roles), (
+        f"Expected no predefined roles in revision {OLD_MYSQL_REVISION}, but found: {rows}"
+    )
+
+
+def test_verify_predefined_roles_present_after_refresh(juju: Juju, charm):
+    """Verify that predefined roles are present after refresh."""
+    mysql_leader = get_app_leader(juju, DATABASE_APP_NAME)
+
+    logging.info("Running pre-upgrade-check action")
+    juju.run(unit=mysql_leader, action="pre-upgrade-check")
+
+    logging.info("Refreshing MySQL to new charm with predefined roles support")
+    juju.refresh(
+        app=DATABASE_APP_NAME,
+        path=charm,
+    )
+
+    logging.info("Wait for refresh to complete")
+    juju.wait(
+        ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
+        timeout=TIMEOUT,
+    )
+
+    primary_unit_name = get_mysql_primary_unit(juju, DATABASE_APP_NAME)
+    primary_unit_address = get_unit_ip(juju, DATABASE_APP_NAME, primary_unit_name)
+    server_config_credentials = get_mysql_server_credentials(juju, primary_unit_name)
+
+    logging.info("Checking if predefined roles exist after refresh")
+    rows = execute_queries_on_unit(
+        primary_unit_address,
+        server_config_credentials["username"],
+        server_config_credentials["password"],
+        ["SELECT user AS role_name FROM mysql.user"],
+        commit=False,
+    )
+
+    expected_roles = {
+        "charmed_backup",
+        "charmed_dba",
+        "charmed_ddl",
+        "charmed_dml",
+        "charmed_read",
+        "charmed_router",
+        "charmed_stats",
+        "mysqlrouter",
+    }
+
+    existing_roles = set(rows)
+    assert expected_roles <= set(existing_roles), (
+        f"Expected roles {expected_roles} to be a subset of existing roles {existing_roles}"
+    )
+
+
+def test_integrate_mysql_router_and_test_app(juju: Juju):
+    """Integrate MySQL Router with MySQL and verify they work."""
+    logging.info("Deploying MySQL Router")
+    juju.deploy(
+        charm=MYSQL_ROUTER_APP_NAME,
+        app=MYSQL_ROUTER_APP_NAME,
+        base="ubuntu@22.04",
+        channel="dpe/edge",
+        num_units=1,
+        trust=True,
+    )
+
+    logging.info("Deploying MySQL test application")
+    juju.deploy(
+        charm=MYSQL_TEST_APP_NAME,
+        app=MYSQL_TEST_APP_NAME,
+        base="ubuntu@22.04",
+        channel="latest/edge",
+        num_units=1,
+        config={"database_name": "test"},
+    )
+
+    logging.info("Waiting for applications to be ready")
+    juju.wait(
+        ready=lambda status: all((
+            jubilant_backports.all_agents_idle(status, MYSQL_ROUTER_APP_NAME),
+            jubilant_backports.all_agents_idle(status, MYSQL_TEST_APP_NAME),
+        )),
+        timeout=TIMEOUT,
+    )
+
+    logging.info("Integrating mysql-router with mysql-test-app")
+    juju.integrate(
+        f"{MYSQL_ROUTER_APP_NAME}:database",
+        f"{MYSQL_TEST_APP_NAME}:database",
+    )
+
+    logging.info("Integrating mysql-router with mysql")
+    juju.integrate(
+        f"{MYSQL_ROUTER_APP_NAME}:backend-database",
+        f"{DATABASE_APP_NAME}:database",
+    )
+
+    logging.info("Waiting for all apps to become active")
+    juju.wait(
+        ready=wait_for_apps_status(
+            jubilant_backports.all_active,
+            DATABASE_APP_NAME,
+            MYSQL_ROUTER_APP_NAME,
+            MYSQL_TEST_APP_NAME,
+        ),
+        timeout=TIMEOUT,
+    )

--- a/machines/tests/integration/integration/roles/test_predefined_roles_refresh.py
+++ b/machines/tests/integration/integration/roles/test_predefined_roles_refresh.py
@@ -2,6 +2,7 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 import logging
+from time import sleep
 
 import jubilant_backports
 from jubilant_backports import Juju
@@ -37,6 +38,10 @@ def test_build_and_deploy(juju: Juju) -> None:
         config={"profile": "testing"},
         num_units=3,
     )
+    # Allow some time between deploy and status call. Avoids:
+    # ERROR getting details for storage database/0: filesystem for storage instance "database/0" not found
+    sleep(30)
+
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
         timeout=TIMEOUT,

--- a/machines/tests/integration/integration/roles/test_predefined_roles_refresh.py
+++ b/machines/tests/integration/integration/roles/test_predefined_roles_refresh.py
@@ -6,9 +6,9 @@ import logging
 import jubilant_backports
 from jubilant_backports import Juju
 
-from ...helpers import execute_queries_on_unit
 from ...helpers_ha import (
     MINUTE_SECS,
+    execute_queries_on_unit,
     get_app_leader,
     get_mysql_primary_unit,
     get_mysql_server_credentials,
@@ -35,7 +35,7 @@ def test_build_and_deploy(juju: Juju) -> None:
         channel="8.0/stable",
         revision=OLD_MYSQL_REVISION,
         config={"profile": "testing"},
-        num_units=1,
+        num_units=3,
     )
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
@@ -92,10 +92,16 @@ def test_verify_predefined_roles_present_after_refresh(juju: Juju, charm):
         path=charm,
     )
 
-    logging.info("Wait for refresh to complete")
+    logging.info("Wait for upgrade to start")
     juju.wait(
-        ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
-        timeout=TIMEOUT,
+        ready=lambda status: jubilant_backports.any_maintenance(status, DATABASE_APP_NAME),
+        timeout=10 * MINUTE_SECS,
+    )
+
+    logging.info("Wait for upgrade to complete")
+    juju.wait(
+        ready=lambda status: jubilant_backports.all_active(status, DATABASE_APP_NAME),
+        timeout=20 * MINUTE_SECS,
     )
 
     primary_unit_name = get_mysql_primary_unit(juju, DATABASE_APP_NAME)

--- a/machines/tests/spread/integration/test_predefined_roles_refresh.py/task.yaml
+++ b/machines/tests/spread/integration/test_predefined_roles_refresh.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_predefined_roles_refresh.py
+environment:
+  TEST_MODULE: roles/test_predefined_roles_refresh.py
+execute: |
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/machines/tests/unit/test_mysql.py
+++ b/machines/tests/unit/test_mysql.py
@@ -152,7 +152,7 @@ class TestMySQLBase(unittest.TestCase):
             "WHERE user LIKE '{role}' AND authentication_string=''"
         )
         create_query = ";".join((
-            "CREATE ROLE {role}",
+            "CREATE ROLE IF NOT EXISTS {role}",
             "GRANT CREATE ON *.* TO {role}",
             "GRANT CREATE USER ON *.* TO {role}",
             "GRANT ALL ON *.* TO {role} WITH GRANT OPTION",

--- a/machines/tests/unit/test_mysql.py
+++ b/machines/tests/unit/test_mysql.py
@@ -192,8 +192,6 @@ class TestMySQLBase(unittest.TestCase):
             role_reader=ROLE_READ,
             role_writer=ROLE_DML,
         )
-        # TODO: Remove when mysql-shell-client supports idempotent queries
-        builder.ROLE_CREATION_QUERY = "CREATE ROLE IF NOT EXISTS {rolename}"  # type: ignore
         create_query = builder.build_instance_auth_roles_query()
 
         self.mysql.configure_mysql_system_roles()

--- a/machines/tests/unit/test_mysql.py
+++ b/machines/tests/unit/test_mysql.py
@@ -142,7 +142,8 @@ class TestMySQLBase(unittest.TestCase):
             self.mock_executor_cls,
         )  # pyright: ignore
 
-    def test_configure_mysql_router_roles(self):
+    @patch("charms.mysql.v0.mysql.MySQLBase._read_only_disabled")
+    def test_configure_mysql_router_roles(self, _read_only_disabled):
         """Test successful configuration of MySQL router role."""
         self.mock_executor.execute_sql.return_value = []
 
@@ -172,7 +173,8 @@ class TestMySQLBase(unittest.TestCase):
         with self.assertRaises(MySQLConfigureMySQLRolesError):
             self.mysql.configure_mysql_router_roles()
 
-    def test_configure_mysql_system_roles(self):
+    @patch("charms.mysql.v0.mysql.MySQLBase._read_only_disabled")
+    def test_configure_mysql_system_roles(self, _read_only_disabled):
         """Test successful configuration of MySQL system roles."""
         self.mock_executor.execute_sql.return_value = []
 
@@ -190,6 +192,8 @@ class TestMySQLBase(unittest.TestCase):
             role_reader=ROLE_READ,
             role_writer=ROLE_DML,
         )
+        # TODO: Remove when mysql-shell-client supports idempotent queries
+        builder.ROLE_CREATION_QUERY = "CREATE ROLE IF NOT EXISTS {rolename}"  # type: ignore
         create_query = builder.build_instance_auth_roles_query()
 
         self.mysql.configure_mysql_system_roles()
@@ -205,17 +209,16 @@ class TestMySQLBase(unittest.TestCase):
         with self.assertRaises(MySQLConfigureMySQLRolesError):
             self.mysql.configure_mysql_system_roles()
 
-    def test_configure_mysql_system_users(self):
+    @patch("charms.mysql.v0.mysql.MySQLBase._read_only_disabled")
+    def test_configure_mysql_system_users(self, _read_only_disabled):
         """Test successful configuration of MySQL system users."""
         self.mock_executor.execute_sql.return_value = []
 
         queries = ";".join([
             "UPDATE mysql.user SET authentication_string=null WHERE User='root' and Host='localhost'",
             "ALTER USER 'root'@'localhost' IDENTIFIED BY 'password'",
-            "CREATE USER 'serverconfig'@'%' IDENTIFIED BY 'serverconfigpassword'",
-            "CREATE USER 'monitoring'@'%' IDENTIFIED BY 'monitoringpassword' WITH MAX_USER_CONNECTIONS 3",
-            "CREATE USER 'backups'@'%' IDENTIFIED BY 'backupspassword'",
-            "GRANT ALL ON *.* TO 'serverconfig'@'%' WITH GRANT OPTION",
+            "CREATE USER IF NOT EXISTS 'monitoring'@'%' IDENTIFIED BY 'monitoringpassword' WITH MAX_USER_CONNECTIONS 3",
+            "CREATE USER IF NOT EXISTS 'backups'@'%' IDENTIFIED BY 'backupspassword'",
             "GRANT charmed_stats TO 'monitoring'@'%'",
             "GRANT charmed_backup TO 'backups'@'%'",
             "REVOKE BINLOG_ADMIN, CONNECTION_ADMIN, ENCRYPTION_KEY_ADMIN, GROUP_REPLICATION_ADMIN, REPLICATION_SLAVE_ADMIN, SET_USER_ID, SUPER, SYSTEM_USER, SYSTEM_VARIABLES_ADMIN, VERSION_TOKEN_ADMIN ON *.* FROM 'root'@'localhost'",
@@ -307,7 +310,7 @@ class TestMySQLBase(unittest.TestCase):
         granting_query = ";".join([
             "GRANT SELECT ON `test_database`.* TO `charmed_read`",
             "GRANT SELECT, INSERT, DELETE, UPDATE ON `test_database`.* TO `charmed_dml`",
-            "CREATE ROLE `test_database_00`",
+            "CREATE ROLE IF NOT EXISTS `test_database_00`",
             "GRANT SELECT, INSERT, DELETE, UPDATE, EXECUTE, ALTER, ALTER ROUTINE, CREATE, CREATE ROUTINE, CREATE VIEW, DROP, INDEX, LOCK TABLES, REFERENCES, TRIGGER ON `test_database`.* TO `test_database_00`",
         ])
 

--- a/machines/tests/unit/test_mysqlsh_helpers.py
+++ b/machines/tests/unit/test_mysqlsh_helpers.py
@@ -79,15 +79,15 @@ class TestMySQL(unittest.TestCase):
     @patch("subprocess.check_output")
     @patch("mysql_vm_helpers.snap_service_operation")
     @patch("mysql_vm_helpers.MySQL.wait_until_mysql_connection")
-    def test_reset_root_password_and_start_mysqld(
+    def test_set_operator_user_and_start_mysqld(
         self,
         _wait_until_mysql_connection,
         _snap_service_operation,
         _check_output,
         _named_temporary_file,
     ):
-        """Test a successful execution of reset_root_password_and_start_mysqld."""
-        self.mysql.reset_root_password_and_start_mysqld()
+        """Test a successful execution of set_operator_user_and_start_mysqld."""
+        self.mysql.set_operator_user_and_start_mysqld()
 
         self.assertEqual(2, _named_temporary_file.call_count)
         self.assertEqual(2, _check_output.call_count)
@@ -98,18 +98,18 @@ class TestMySQL(unittest.TestCase):
     @patch("subprocess.check_output")
     @patch("mysql_vm_helpers.snap_service_operation")
     @patch("mysql_vm_helpers.MySQL.wait_until_mysql_connection")
-    def test_reset_root_password_and_start_mysqld_exception(
+    def test_set_operator_user_and_start_mysqld_exception(
         self,
         _wait_until_mysql_connection,
         _snap_service_operation,
         _check_output,
         _named_temporary_file,
     ):
-        """Test a failed execution of reset_root_password_and_start_mysqld."""
+        """Test a failed execution of set_operator_user_and_start_mysqld."""
         _check_output.side_effect = subprocess.CalledProcessError(cmd="", returncode=-1)
 
         with self.assertRaises(MySQLResetRootPasswordAndStartMySQLDError):
-            self.mysql.reset_root_password_and_start_mysqld()
+            self.mysql.set_operator_user_and_start_mysqld()
 
         self.assertEqual(2, _named_temporary_file.call_count)
         self.assertEqual(1, _check_output.call_count)
@@ -125,7 +125,7 @@ class TestMySQL(unittest.TestCase):
         _snap_service_operation.side_effect = SnapServiceOperationError()
 
         with self.assertRaises(MySQLResetRootPasswordAndStartMySQLDError):
-            self.mysql.reset_root_password_and_start_mysqld()
+            self.mysql.set_operator_user_and_start_mysqld()
 
         self.assertEqual(2, _named_temporary_file.call_count)
         self.assertEqual(2, _check_output.call_count)
@@ -142,7 +142,7 @@ class TestMySQL(unittest.TestCase):
         _wait_until_mysql_connection.side_effect = MySQLServiceNotRunningError()
 
         with self.assertRaises(MySQLResetRootPasswordAndStartMySQLDError):
-            self.mysql.reset_root_password_and_start_mysqld()
+            self.mysql.set_operator_user_and_start_mysqld()
 
         self.assertEqual(2, _named_temporary_file.call_count)
         self.assertEqual(2, _check_output.call_count)

--- a/machines/tests/unit/test_upgrade.py
+++ b/machines/tests/unit/test_upgrade.py
@@ -154,10 +154,10 @@ class TestUpgrade(unittest.TestCase):
     @patch("mysql_vm_helpers.MySQL.stop_mysqld")
     @patch("mysql_vm_helpers.MySQL.start_mysqld")
     @patch("mysql_vm_helpers.MySQL.is_instance_in_cluster", return_value=True)
-    @patch("charm.MySQLOperatorCharm._on_config_changed")
+    @patch("mysql_vm_helpers.MySQL.write_mysqld_config")
     def test_upgrade_granted(
         self,
-        mock_config_change,
+        mock_write_mysqld_config,
         mock_is_instance_in_cluster,
         mock_start_mysqld,
         mock_stop_mysqld,
@@ -186,7 +186,7 @@ class TestUpgrade(unittest.TestCase):
         mock_stop_mysqld.assert_called_once()
         mock_install_workload.assert_called_once()
         mock_get_mysql_version.assert_called_once()
-        mock_config_change.assert_called()
+        mock_write_mysqld_config.assert_called()
 
         self.harness.update_relation_data(
             self.upgrade_relation_id, "mysql/0", {"state": "upgrading"}


### PR DESCRIPTION
## Issue

Fix #151.

- This borrows #122 approach of creating the operator user (in the case of the 8.0/edge branch, still using `serverconfig`) and use that for both the socket and TCP executors.
- It also makes user creation idempotent. One of mysql-shell-client classes are patched, if this approach is blessed I can send a PR to the library so that the patch isn't needed.
- In addition, I wrapped the user and role config functions in `self._read_only_disabled()`, as it's done with `install_plugin`. This is because otherwise refreshing clusters doesn't work, as non-primary instances are put in SUPER_READ_ONLY mode.
- I retained the commit history to show the different approaches I tried, so it's not very meaningful. If it helps, I can squash it.

## Solution

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
