### PR TITLE
[MISC] 8.0 - Revert juju to 3.6/stable channel

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,7 @@ jobs:
     secrets: inherit
 
   release:
-    name: Release charm | ${{ matrix.charm.path }}
+    name: Release charm | ${{ matrix.path }}
     needs:
       - build
       - integration-test

--- a/kubernetes/spread.yaml
+++ b/kubernetes/spread.yaml
@@ -109,7 +109,7 @@ path: /root/spread_project
 kill-timeout: 3h
 environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
-  CONCIERGE_JUJU_CHANNEL/juju36: 3.6/candidate
+  CONCIERGE_JUJU_CHANNEL/juju36: 3.6/stable
   CONCIERGE_JUJU_CHANNEL/juju29: 2.9/stable
 prepare: |
   snap refresh --hold

--- a/machines/spread.yaml
+++ b/machines/spread.yaml
@@ -112,7 +112,7 @@ path: /root/spread_project
 kill-timeout: 3h
 environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
-  CONCIERGE_JUJU_CHANNEL/juju36: 3.6/candidate
+  CONCIERGE_JUJU_CHANNEL/juju36: 3.6/stable
   CONCIERGE_JUJU_CHANNEL/juju29: 2.9/stable
 prepare: |
   snap refresh --hold


### PR DESCRIPTION
This PR partially reverts PR https://github.com/canonical/mysql-operators/pull/144 now that juju `3.6.19` is in the stable channel.
