### PR TITLE
[MISC] 8.4 - Revert juju to 3.6/stable channel

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,7 +59,7 @@ jobs:
 #    secrets: inherit
 
   release:
-    name: Release charm | ${{ matrix.charm.path }}
+    name: Release charm | ${{ matrix.path }}
     needs:
       - build
       - integration-test

--- a/kubernetes/spread.yaml
+++ b/kubernetes/spread.yaml
@@ -107,7 +107,7 @@ path: /root/spread_project
 kill-timeout: 3h
 environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
-  CONCIERGE_JUJU_CHANNEL/juju36: 3.6/candidate
+  CONCIERGE_JUJU_CHANNEL/juju36: 3.6/stable
 prepare: |
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"

--- a/machines/spread.yaml
+++ b/machines/spread.yaml
@@ -110,7 +110,7 @@ path: /root/spread_project
 kill-timeout: 3h
 environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
-  CONCIERGE_JUJU_CHANNEL/juju36: 3.6/candidate
+  CONCIERGE_JUJU_CHANNEL/juju36: 3.6/stable
 prepare: |
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"


### PR DESCRIPTION
This PR partially reverts PR https://github.com/canonical/mysql-operators/pull/143 now that juju `3.6.19` is in the stable channel.

