### PR TITLE
[DPE-9612] 8.4 - Rootless K8s container

### DIFF
--- a/kubernetes/metadata.yaml
+++ b/kubernetes/metadata.yaml
@@ -19,9 +19,12 @@ website:
   - https://github.com/canonical/mysql-operators
 maintainers:
   - Canonical Data Platform <data-platform@lists.launchpad.net>
+charm-user: non-root
 
 containers:
   mysql:
+    uid: 584788
+    gig: 584788
     resource: mysql-image
     mounts:
       - storage: database

--- a/kubernetes/src/constants.py
+++ b/kubernetes/src/constants.py
@@ -54,7 +54,6 @@ GR_MAX_MEMBERS = 9
 COS_AGENT_RELATION_NAME = "metrics-endpoint"
 COS_LOGGING_RELATION_NAME = "logging"
 LOG_ROTATE_CONFIG_FILE = "/etc/logrotate.d/flush_mysql_logs"
-ROOT_SYSTEM_USER = "root"
 SECRET_KEY_FALLBACKS = {
     "root-password": "root_password",
     "server-config-password": "server_config_password",

--- a/kubernetes/src/mysql_k8s_helpers.py
+++ b/kubernetes/src/mysql_k8s_helpers.py
@@ -207,7 +207,7 @@ class MySQL(MySQLBase):
             "FLUSH PRIVILEGES;",
         ]
 
-        file_path = "/create-operator-user.sql"
+        file_path = f"/home/{MYSQL_SYSTEM_USER}/create-operator-user.sql"
 
         self.container.push(
             file_path,

--- a/kubernetes/src/mysql_k8s_helpers.py
+++ b/kubernetes/src/mysql_k8s_helpers.py
@@ -48,7 +48,6 @@ from constants import (
     MYSQLD_SOCK_FILE,
     MYSQLSH_LOCATION,
     PEER,
-    ROOT_SYSTEM_USER,
     XTRABACKUP_PLUGIN_DIR,
 )
 from k8s_helpers import KubernetesClientError, KubernetesHelpers
@@ -289,8 +288,8 @@ class MySQL(MySQLBase):
         self.write_content_to_file(
             LOG_ROTATE_CONFIG_FILE,
             rendered,
-            owner=ROOT_SYSTEM_USER,
-            group=ROOT_SYSTEM_USER,
+            owner=MYSQL_SYSTEM_USER,
+            group=MYSQL_SYSTEM_GROUP,
         )
 
     def execute_backup_commands(

--- a/kubernetes/src/mysql_k8s_helpers.py
+++ b/kubernetes/src/mysql_k8s_helpers.py
@@ -465,8 +465,8 @@ class MySQL(MySQLBase):
         self,
         commands: list[str],
         bash: bool = False,
-        user: str | None = None,
-        group: str | None = None,
+        user: str | None = MYSQL_SYSTEM_USER,
+        group: str | None = MYSQL_SYSTEM_GROUP,
         env_extra: dict | None = None,
         timeout: float | None = None,
         stream_output: str | None = None,
@@ -505,7 +505,7 @@ class MySQL(MySQLBase):
         path: str,
         content: str,
         owner: str = MYSQL_SYSTEM_USER,
-        group: str = MYSQL_SYSTEM_USER,
+        group: str = MYSQL_SYSTEM_GROUP,
         permission: int = 0o640,
     ) -> None:
         """Write content to file.

--- a/kubernetes/src/rotate_mysql_logs.py
+++ b/kubernetes/src/rotate_mysql_logs.py
@@ -11,7 +11,11 @@ from mysql_shell import LogType
 from ops.charm import CharmEvents
 from ops.framework import EventBase, EventSource, Object
 
-from constants import LOG_ROTATE_CONFIG_FILE
+from constants import (
+    LOG_ROTATE_CONFIG_FILE,
+    MYSQL_SYSTEM_GROUP,
+    MYSQL_SYSTEM_USER,
+)
 
 if typing.TYPE_CHECKING:
     from charm import MySQLOperatorCharm
@@ -60,7 +64,11 @@ class RotateMySQLLogs(Object):
             return
 
         try:
-            self.charm._mysql._execute_commands(["logrotate", "-f", LOG_ROTATE_CONFIG_FILE])
+            self.charm._mysql._execute_commands(
+                ["logrotate", "-f", LOG_ROTATE_CONFIG_FILE],
+                user=MYSQL_SYSTEM_USER,
+                group=MYSQL_SYSTEM_GROUP,
+            )
         except MySQLExecError:
             logger.warning("Failed to rotate MySQL logs")
             return

--- a/kubernetes/src/rotate_mysql_logs.py
+++ b/kubernetes/src/rotate_mysql_logs.py
@@ -11,11 +11,7 @@ from mysql_shell import LogType
 from ops.charm import CharmEvents
 from ops.framework import EventBase, EventSource, Object
 
-from constants import (
-    LOG_ROTATE_CONFIG_FILE,
-    MYSQL_SYSTEM_GROUP,
-    MYSQL_SYSTEM_USER,
-)
+from constants import LOG_ROTATE_CONFIG_FILE
 
 if typing.TYPE_CHECKING:
     from charm import MySQLOperatorCharm
@@ -64,11 +60,7 @@ class RotateMySQLLogs(Object):
             return
 
         try:
-            self.charm._mysql._execute_commands(
-                ["logrotate", "-f", LOG_ROTATE_CONFIG_FILE],
-                user=MYSQL_SYSTEM_USER,
-                group=MYSQL_SYSTEM_GROUP,
-            )
+            self.charm._mysql._execute_commands(["logrotate", "-f", LOG_ROTATE_CONFIG_FILE])
         except MySQLExecError:
             logger.warning("Failed to rotate MySQL logs")
             return

--- a/kubernetes/templates/logrotate.j2
+++ b/kubernetes/templates/logrotate.j2
@@ -1,6 +1,3 @@
-# Use system user
-su {{ system_user }} {{ system_group }}
-
 # Create dedicated subdirectory for rotated files
 createolddir 770 {{ system_user }} {{ system_group }}
 
@@ -32,4 +29,3 @@ nocopytruncate
     olddir archive_{{ log }}
 }
 {% endfor %}
-

--- a/kubernetes/tests/unit/test_mysql_k8s_helpers.py
+++ b/kubernetes/tests/unit/test_mysql_k8s_helpers.py
@@ -128,15 +128,35 @@ class TestMySQL(unittest.TestCase):
     def test_log_rotate_config(self, _container):
         """Test log_rotate_config."""
         rendered_logrotate_config = (
-            "# Use system user\nsu mysql mysql\n\n# Create dedicated subdirectory for rotated "
-            "files\ncreateolddir 770 mysql mysql\n\n# Frequency of logs rotation\nhourly\nmaxa"
-            "ge 1\nrotate 1440\n\n# Compression settings\n\nnocompress\n\n\n# Naming of rotate"
-            "d files should be in the format:\ndateext\ndateformat -%Y%m%d_%H%M\n\n# Settings "
-            "to prevent misconfigurations and unwanted behaviours\nifempty\nmissingok\nnomail\n"
-            "nosharedscripts\nnocopytruncate\n\n\n/var/log/mysql/error.log {\n    olddir archi"
-            "ve_error\n}\n\n/var/log/mysql/general.log {\n    olddir archive_general\n}\n\n/va"
-            "r/log/mysql/slowquery.log {\n    olddir archive_slowquery\n}\n\n/var/log/mysql/au"
-            "dit.log {\n    olddir archive_audit\n}\n\n"
+            "# Create dedicated subdirectory for rotated files\n"
+            "createolddir 770 mysql mysql\n\n"
+            "# Frequency of logs rotation\n"
+            "hourly\n"
+            "maxage 1\n"
+            "rotate 1440\n\n"
+            "# Compression settings\n\n"
+            "nocompress\n\n\n"
+            "# Naming of rotated files should be in the format:\n"
+            "dateext\n"
+            "dateformat -%Y%m%d_%H%M\n\n"
+            "# Settings to prevent misconfigurations and unwanted behaviours\n"
+            "ifempty\n"
+            "missingok\n"
+            "nomail\n"
+            "nosharedscripts\n"
+            "nocopytruncate\n\n\n"
+            "/var/log/mysql/error.log {\n"
+            "    olddir archive_error\n"
+            "}\n\n"
+            "/var/log/mysql/general.log {\n"
+            "    olddir archive_general\n"
+            "}\n\n"
+            "/var/log/mysql/slowquery.log {\n"
+            "    olddir archive_slowquery\n"
+            "}\n\n"
+            "/var/log/mysql/audit.log {\n"
+            "    olddir archive_audit\n"
+            "}\n"
         )
 
         self.mysql.container = _container
@@ -146,8 +166,8 @@ class TestMySQL(unittest.TestCase):
             "/etc/logrotate.d/flush_mysql_logs",
             rendered_logrotate_config,
             permissions=416,
-            user="root",
-            group="root",
+            user="mysql",
+            group="mysql",
         )
 
     def test_update_endpoints(self):

--- a/kubernetes/tests/unit/test_mysql_k8s_helpers.py
+++ b/kubernetes/tests/unit/test_mysql_k8s_helpers.py
@@ -207,7 +207,7 @@ class TestMySQL(unittest.TestCase):
 
         self.mysql.container.push.assert_has_calls([
             call(
-                "/create-operator-user.sql",
+                "/home/mysql/create-operator-user.sql",
                 (
                     "CREATE USER 'charmed-operator'@'%' IDENTIFIED BY 'charmed-operatorpassword';\n"
                     "GRANT ALL ON *.* TO 'charmed-operator'@'%' WITH GRANT OPTION;\n"
@@ -220,7 +220,7 @@ class TestMySQL(unittest.TestCase):
             ),
             call(
                 "/etc/mysql/mysql.conf.d/z-custom-init-file.cnf",
-                "[mysqld]\ninit_file = /create-operator-user.sql",
+                "[mysqld]\ninit_file = /home/mysql/create-operator-user.sql",
                 encoding="utf-8",
                 permissions=384,
                 user="mysql",
@@ -230,7 +230,7 @@ class TestMySQL(unittest.TestCase):
         self.mysql.container.restart.assert_called_once_with("mysqld")
         _wait_until_mysql_connection.assert_called_once_with(check_port=False)
         self.mysql.container.remove_path.assert_has_calls([
-            call("/create-operator-user.sql"),
+            call("/home/mysql/create-operator-user.sql"),
             call("/etc/mysql/mysql.conf.d/z-custom-init-file.cnf"),
         ])
 
@@ -251,7 +251,7 @@ class TestMySQL(unittest.TestCase):
 
         self.mysql.container.push.assert_has_calls([
             call(
-                "/create-operator-user.sql",
+                "/home/mysql/create-operator-user.sql",
                 (
                     "CREATE USER 'charmed-operator'@'%' IDENTIFIED BY 'charmed-operatorpassword';\n"
                     "GRANT ALL ON *.* TO 'charmed-operator'@'%' WITH GRANT OPTION;\n"
@@ -263,7 +263,9 @@ class TestMySQL(unittest.TestCase):
                 group="mysql",
             ),
         ])
-        self.mysql.container.remove_path.assert_called_once_with("/create-operator-user.sql")
+        self.mysql.container.remove_path.assert_called_once_with(
+            "/home/mysql/create-operator-user.sql"
+        )
         _wait_until_mysql_connection.assert_not_called()
 
         _container.push.side_effect = [None, None]
@@ -279,7 +281,7 @@ class TestMySQL(unittest.TestCase):
 
         self.mysql.container.push.assert_has_calls([
             call(
-                "/create-operator-user.sql",
+                "/home/mysql/create-operator-user.sql",
                 (
                     "CREATE USER 'charmed-operator'@'%' IDENTIFIED BY 'charmed-operatorpassword';\n"
                     "GRANT ALL ON *.* TO 'charmed-operator'@'%' WITH GRANT OPTION;\n"
@@ -292,7 +294,7 @@ class TestMySQL(unittest.TestCase):
             ),
             call(
                 "/etc/mysql/mysql.conf.d/z-custom-init-file.cnf",
-                "[mysqld]\ninit_file = /create-operator-user.sql",
+                "[mysqld]\ninit_file = /home/mysql/create-operator-user.sql",
                 encoding="utf-8",
                 permissions=384,
                 user="mysql",
@@ -301,6 +303,6 @@ class TestMySQL(unittest.TestCase):
         ])
         self.mysql.container.restart.assert_called_once_with("mysqld")
         self.mysql.container.remove_path.assert_has_calls([
-            call("/create-operator-user.sql"),
+            call("/home/mysql/create-operator-user.sql"),
             call("/etc/mysql/mysql.conf.d/z-custom-init-file.cnf"),
         ])


### PR DESCRIPTION
This PR updates the MySQL K8s charm to make the workload container a root-less one.

---

Depends on:
- https://github.com/canonical/charmed-mysql-rock/pull/70
- https://github.com/canonical/mysql-operators/pull/167 