### PR TITLE
[MISC] 8.4 - Cleanup K8s legacy permissions fix

### DIFF
--- a/kubernetes/metadata.yaml
+++ b/kubernetes/metadata.yaml
@@ -31,7 +31,7 @@ resources:
   mysql-image:
     type: oci-image
     description: Ubuntu LTS Docker image for MySQL
-    upstream-source: ghcr.io/canonical/charmed-mysql@sha256:5e3ab326cb01f31a9e096ada50cb87ebd27671a990ad5e4f565ca5d1e5c48a3b
+    upstream-source: ghcr.io/canonical/charmed-mysql@sha256:143b30eaade9e55b5756d38d4bedac29d41adb5e6f30c21f7eec596ab1138564
 
 peers:
   database-peers:

--- a/kubernetes/src/charm.py
+++ b/kubernetes/src/charm.py
@@ -711,7 +711,6 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         # bootstrap the data directory and users
         logger.info("Initializing mysqld")
         try:
-            self._mysql.fix_data_dir(container)
             self._mysql.initialise_mysqld()
 
             # Add the pebble layer

--- a/kubernetes/src/mysql_k8s_helpers.py
+++ b/kubernetes/src/mysql_k8s_helpers.py
@@ -173,32 +173,6 @@ class MySQL(MySQLBase):
         executor.set_container(self.container)
         return executor
 
-    def fix_data_dir(self, container: Container) -> None:
-        """Ensure the data directory for mysql is writable for the "mysql" user.
-
-        Until the ability to set fsGroup and fsGroupChangePolicy via Pod securityContext
-        is available we fix permissions incorrectly with chown.
-        """
-        if not container.exists(MYSQL_DATA_DIR):
-            container.make_dir(MYSQL_DATA_DIR, user=MYSQL_SYSTEM_USER, group=MYSQL_SYSTEM_GROUP)
-            return
-
-        paths = container.list_files(MYSQL_DATA_DIR, itself=True)
-        logger.debug(f"Data directory ownership: {paths[0].user}:{paths[0].group}")
-        if paths[0].user != MYSQL_SYSTEM_USER or paths[0].group != MYSQL_SYSTEM_GROUP:
-            logger.debug(f"Changing ownership to {MYSQL_SYSTEM_USER}:{MYSQL_SYSTEM_GROUP}")
-            try:
-                process = container.exec([
-                    "chown",
-                    "-R",
-                    f"{MYSQL_SYSTEM_USER}:{MYSQL_SYSTEM_GROUP}",
-                    MYSQL_DATA_DIR,
-                ])
-                process.wait()
-            except ExecError as e:
-                logger.error(f"Exited with code {e.exit_code}. Stderr:\n{e.stderr}")
-                raise MySQLInitialiseMySQLDError(e.stderr or "") from None
-
     @retry(reraise=True, stop=stop_after_delay(30), wait=wait_fixed(5))
     def initialise_mysqld(self) -> None:
         """Execute instance first run.

--- a/kubernetes/tests/unit/test_charm.py
+++ b/kubernetes/tests/unit/test_charm.py
@@ -161,7 +161,6 @@ class TestCharm(unittest.TestCase):
     @patch("mysql_k8s_helpers.MySQL.configure_instance")
     @patch("mysql_k8s_helpers.MySQL.create_cluster")
     @patch("mysql_k8s_helpers.MySQL.initialise_mysqld")
-    @patch("mysql_k8s_helpers.MySQL.fix_data_dir")
     @patch("mysql_k8s_helpers.MySQL.is_instance_in_cluster")
     @patch("mysql_k8s_helpers.MySQL.get_member_state", return_value="ONLINE")
     @patch("mysql_k8s_helpers.MySQL.get_member_role", return_value="PRIMARY")
@@ -182,7 +181,6 @@ class TestCharm(unittest.TestCase):
         _get_member_state,
         _is_instance_in_cluster,
         _initialise_mysqld,
-        _fix_data_dir,
         _create_cluster,
         _configure_instance,
         _configure_mysql_router_roles,


### PR DESCRIPTION
This PR removes an old MySQL data directory permissions fix, reverting this [old PR](https://github.com/canonical/mysql-k8s-operator/pull/238).

As far as I understand, we are already setting the permissions in the charmed MySQL rock (see [code](https://github.com/canonical/charmed-mysql-rock/blob/2f85574565129ac3dc44768de53875182b65bed5/rockcraft.yaml#L61)), but the `/var/lib/mysql` folder does not exist yet. To that end, I am proposing to explicitly create such folder before the ownership change takes place (see [PR](https://github.com/canonical/charmed-mysql-rock/pull/70)). This will need to be updated, pointing at the new image SHA.

---

Required for MySQL K8s charm in root-less mode.
