### PR TITLE
Remove substrate folders in automatic doc checks

### DIFF
--- a/.github/workflows/automatic_doc_checks.yaml
+++ b/.github/workflows/automatic_doc_checks.yaml
@@ -18,12 +18,7 @@ concurrency:
 
 jobs:
   documentation-checks:
-    strategy:
-      matrix:
-        path:
-          - kubernetes
-          - machines
     uses: canonical/documentation-workflows/.github/workflows/documentation-checks.yaml@main
     with:
-      working-directory: ${{ matrix.path }}/docs
+      working-directory: "docs"
       fetch-depth: 0


### PR DESCRIPTION
## Issue
Automatic doc checks were attempting to run on `kubernetes/` and `machines/` folder.

They should only run on the `docs/` folder.

## Solution
Removed matrix strategy for documentation checks

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
