### PR TITLE
[MISC] 8.0 - Cleanup charmcraft.yaml

### DIFF
--- a/kubernetes/charmcraft.yaml
+++ b/kubernetes/charmcraft.yaml
@@ -19,24 +19,10 @@ parts:
   # https://github.com/canonical/craft-parts/pull/901
   poetry-deps:
     plugin: nil
-    build-packages:
-      - curl
     override-build: |
-      # Use environment variable instead of `--break-system-packages` to avoid failing on older
-      # versions of pip that do not recognize `--break-system-packages`
-      # `--user` needed (in addition to `--break-system-packages`) for Ubuntu >=24.04
       PIP_BREAK_SYSTEM_PACKAGES=true python3 -m pip install --user --upgrade pip==25.3  # renovate: charmcraft-pip-latest
-
-      # Use uv to install poetry so that a newer version of Python can be installed if needed by poetry
-      curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.9.5/uv-installer.sh | sh  # renovate: charmcraft-uv-latest
-      # poetry 2.0.0 requires Python >=3.9
-      if ! "$HOME/.local/bin/uv" python find '>=3.9'
-      then
-        # Use first Python version that is >=3.9 and available in an Ubuntu LTS
-        # (to reduce the number of Python versions we use)
-        "$HOME/.local/bin/uv" python install 3.10.12  # renovate: charmcraft-python-ubuntu-22.04
-      fi
-      "$HOME/.local/bin/uv" tool install --no-python-downloads --python '>=3.9' poetry==2.2.1 --with poetry-plugin-export==1.9.0  # renovate: charmcraft-poetry-latest
+      PIP_BREAK_SYSTEM_PACKAGES=true python3 -m pip install --user poetry==2.2.1        # renovate: charmcraft-poetry-latest
+      PIP_BREAK_SYSTEM_PACKAGES=true python3 -m pip install --user poetry-plugin-export==1.9.0
 
       ln -sf "$HOME/.local/bin/poetry" /usr/local/bin/poetry
   # "charm-poetry" part name is arbitrary; use for consistency
@@ -60,12 +46,7 @@ parts:
     override-build: |
       # Workaround for https://github.com/canonical/charmcraft/issues/2068
       # rustup used to install rustc and cargo, which are needed to build Python dependencies with Rust from source
-      if [[ "$CRAFT_PLATFORM" == ubuntu@20.04:* || "$CRAFT_PLATFORM" == ubuntu@22.04:* ]]
-      then
-        snap install rustup --classic
-      else
-        apt-get install rustup -y
-      fi
+      snap install rustup --classic
 
       # If Ubuntu version < 24.04, rustup was installed from snap instead of from the Ubuntu
       # archive—which means the rustup version could be updated at any time. Print rustup version
@@ -78,6 +59,7 @@ parts:
       rustup default 1.90.0  # renovate: charmcraft-rust-latest
 
       craftctl default
+  
       # Include requirements.txt in *.charm artifact for easier debugging
       cp requirements.txt "$CRAFT_PART_INSTALL/requirements.txt"
   # "files" part name is arbitrary; use for consistency

--- a/machines/charmcraft.yaml
+++ b/machines/charmcraft.yaml
@@ -19,24 +19,10 @@ parts:
   # https://github.com/canonical/craft-parts/pull/901
   poetry-deps:
     plugin: nil
-    build-packages:
-      - curl
     override-build: |
-      # Use environment variable instead of `--break-system-packages` to avoid failing on older
-      # versions of pip that do not recognize `--break-system-packages`
-      # `--user` needed (in addition to `--break-system-packages`) for Ubuntu >=24.04
       PIP_BREAK_SYSTEM_PACKAGES=true python3 -m pip install --user --upgrade pip==25.3  # renovate: charmcraft-pip-latest
-
-      # Use uv to install poetry so that a newer version of Python can be installed if needed by poetry
-      curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.9.5/uv-installer.sh | sh  # renovate: charmcraft-uv-latest
-      # poetry 2.0.0 requires Python >=3.9
-      if ! "$HOME/.local/bin/uv" python find '>=3.9'
-      then
-        # Use first Python version that is >=3.9 and available in an Ubuntu LTS
-        # (to reduce the number of Python versions we use)
-        "$HOME/.local/bin/uv" python install 3.10.12  # renovate: charmcraft-python-ubuntu-22.04
-      fi
-      "$HOME/.local/bin/uv" tool install --no-python-downloads --python '>=3.9' poetry==2.2.1 --with poetry-plugin-export==1.9.0  # renovate: charmcraft-poetry-latest
+      PIP_BREAK_SYSTEM_PACKAGES=true python3 -m pip install --user poetry==2.2.1        # renovate: charmcraft-poetry-latest
+      PIP_BREAK_SYSTEM_PACKAGES=true python3 -m pip install --user poetry-plugin-export==1.9.0
 
       ln -sf "$HOME/.local/bin/poetry" /usr/local/bin/poetry
   # "charm-poetry" part name is arbitrary; use for consistency
@@ -60,12 +46,7 @@ parts:
     override-build: |
       # Workaround for https://github.com/canonical/charmcraft/issues/2068
       # rustup used to install rustc and cargo, which are needed to build Python dependencies with Rust from source
-      if [[ "$CRAFT_PLATFORM" == ubuntu@20.04:* || "$CRAFT_PLATFORM" == ubuntu@22.04:* ]]
-      then
-        snap install rustup --classic
-      else
-        apt-get install rustup -y
-      fi
+      snap install rustup --classic
 
       # If Ubuntu version < 24.04, rustup was installed from snap instead of from the Ubuntu
       # archive—which means the rustup version could be updated at any time. Print rustup version
@@ -78,6 +59,7 @@ parts:
       rustup default 1.90.0  # renovate: charmcraft-rust-latest
 
       craftctl default
+
       # Include requirements.txt in *.charm artifact for easier debugging
       cp requirements.txt "$CRAFT_PART_INSTALL/requirements.txt"
   # "files" part name is arbitrary; use for consistency


### PR DESCRIPTION
This PR cleans-up the `charmcraft.yaml` file after having branches out MySQL 8.0 (Jammy) and 8.4 (Noble) codebases.

Complements PR https://github.com/canonical/mysql-operators/pull/59.