### PR TITLE
[DPE-8295] Refresh V3 (III.2): Fix automatic tagging

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,13 +19,13 @@ this operator.
   the `8.4/edge` branch. This also avoids merge commits and creates a linear Git commit history.
 
 ## Develop
-Install `yq`, `tox`, `poetry`, and `charmcraftcache`
+Install `yq`, `tox`, `poetry`, and `charmcraftlocal`
 
 ```shell
 pipx install yq
 pipx install tox
 pipx install poetry
-pipx install charmcraftcache
+pipx install charmcraftlocal
 ```
 
 You can create an environment for development:
@@ -54,8 +54,8 @@ You can create an environment for development:
 Build the charm in this git repository using:
 
 ```shell
-(cd kubernetes && charmcraftcache pack)
-(cd machines && charmcraftcache pack)
+(cd kubernetes && charmcraftlocal pack)
+(cd machines && charmcraftlocal pack)
 ```
 
 ### Deploy

--- a/common/common/__init__.py
+++ b/common/common/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.

--- a/kubernetes/poetry.lock
+++ b/kubernetes/poetry.lock
@@ -2190,4 +2190,4 @@ test = ["big-O", "importlib-resources ; python_version < \"3.9\"", "jaraco.funct
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "ed4a5d96300ccf6959235947c427c9a5285c92c00e5cede1199789cfaa17e6f7"
+content-hash = "75a830a0f29d69556c816dedd4310373e5c7d6b00bb7f7b6d52cca83b2a34d43"

--- a/kubernetes/pyproject.toml
+++ b/kubernetes/pyproject.toml
@@ -66,6 +66,9 @@ requires-poetry = ">=2.2.0"
 
 [tool.poetry.dependencies]
 python = "^3.12"
+# This is mandatory to make charmcraftlocal trigger the tagging behavior.
+# https://github.com/canonical/charmcraftlocal/blob/v0.3.4/charmcraftlocal/_main.py#L259
+common = {path = "../common", develop = true}
 
 [tool.poetry.group.format]
 optional = true

--- a/machines/poetry.lock
+++ b/machines/poetry.lock
@@ -2171,4 +2171,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "ed4a5d96300ccf6959235947c427c9a5285c92c00e5cede1199789cfaa17e6f7"
+content-hash = "75a830a0f29d69556c816dedd4310373e5c7d6b00bb7f7b6d52cca83b2a34d43"

--- a/machines/pyproject.toml
+++ b/machines/pyproject.toml
@@ -64,6 +64,9 @@ requires-poetry = ">=2.2.0"
 
 [tool.poetry.dependencies]
 python = "^3.12"
+# This is mandatory to make charmcraftlocal trigger the tagging behavior.
+# https://github.com/canonical/charmcraftlocal/blob/v0.3.4/charmcraftlocal/_main.py#L259
+common = {path = "../common", develop = true}
 
 [tool.poetry.group.format]
 optional = true


### PR DESCRIPTION
This PR is a hot-fix over the previous [PR](https://github.com/canonical/mysql-operators/pull/148) (the one introducing the whole refresh V3 functionality), so that the automatic tagging is triggered before the building process starts.

### Disclaimer

Depending on `charmcraftlocal` goes against the general guideline of using charmcraft wrappers, but there is not way to introduce refresh V3 vanilla implementation into a mono-repo setup otherwise. We **need** to do the tagging before actually starting the packing process, as vanilla charmcraft does not have access to the `.git` folder in the parent directory.
