### PR TITLE
Upgrade deprecated actions

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -83,7 +83,7 @@ jobs:
         # Default test results in case the integration tests time out or runner set up fails
         # (So that Allure report will show "unknown"/"failed" test result, instead of omitting the test)
         if: ${{ github.event_name == 'schedule' && github.run_attempt == '1' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: allure-default-results-integration-test-${{ inputs.path-to-charm-directory }}
           path: ${{ inputs.path-to-charm-directory }}/allure-default-results/
@@ -122,7 +122,7 @@ jobs:
           go install github.com/canonical/spread/cmd/spread@latest
       - name: Download packed charm(s)
         timeout-minutes: 5
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           pattern: ${{ inputs.artifact-prefix }}-*
           merge-multiple: true
@@ -145,7 +145,7 @@ jobs:
         # Allure can only process one result per pytest test ID. If parameterization is done via
         # spread instead of pytest, there will be overlapping pytest test IDs.
         if: ${{ (success() || (failure() && steps.spread.outcome == 'failure')) && startsWith(matrix.job.spread_job, 'github-ci:ubuntu-24.04:') && endsWith(matrix.job.spread_job, ':juju36') && github.event_name == 'schedule' && github.run_attempt == '1' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: allure-results-integration-test-${{ inputs.path-to-charm-directory }}-${{ matrix.job.name_in_artifact }}
           path: ${{ inputs.path-to-charm-directory }}/artifacts/${{ matrix.job.spread_job }}/allure-results/
@@ -186,7 +186,7 @@ jobs:
       - name: Upload logs
         timeout-minutes: 5
         if: ${{ !contains(matrix.job.spread_job, 'juju29') && (success() || (failure() && steps.spread.outcome == 'failure')) }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: logs-integration-test-${{ inputs.path-to-charm-directory }}-${{ matrix.job.name_in_artifact }}
           path: ~/logs/

--- a/.github/workflows/release_test.yaml
+++ b/.github/workflows/release_test.yaml
@@ -83,7 +83,7 @@ jobs:
         # Default test results in case the integration tests time out or runner set up fails
         # (So that Allure report will show "unknown"/"failed" test result, instead of omitting the test)
         if: ${{ github.event_name == 'schedule' && github.run_attempt == '1' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: allure-default-results-release-test-${{ inputs.path-to-charm-directory }}
           path: ${{ inputs.path-to-charm-directory }}/allure-default-results/
@@ -122,7 +122,7 @@ jobs:
           go install github.com/canonical/spread/cmd/spread@latest
       - name: Download packed charm(s)
         timeout-minutes: 5
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           pattern: ${{ inputs.artifact-prefix }}-*
           merge-multiple: true
@@ -145,7 +145,7 @@ jobs:
         # Allure can only process one result per pytest test ID. If parameterization is done via
         # spread instead of pytest, there will be overlapping pytest test IDs.
         if: ${{ (success() || (failure() && steps.spread.outcome == 'failure')) && startsWith(matrix.job.spread_job, 'github-ci:ubuntu-24.04:') && endsWith(matrix.job.spread_job, ':juju36') && github.event_name == 'schedule' && github.run_attempt == '1' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: allure-results-release-test-${{ inputs.path-to-charm-directory }}-${{ matrix.job.name_in_artifact }}
           path: ${{ inputs.path-to-charm-directory }}/artifacts/${{ matrix.job.spread_job }}/allure-results/
@@ -186,7 +186,7 @@ jobs:
       - name: Upload logs
         timeout-minutes: 5
         if: ${{ !contains(matrix.job.spread_job, 'juju29') && (success() || (failure() && steps.spread.outcome == 'failure')) }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: logs-release-test-${{ inputs.path-to-charm-directory }}-${{ matrix.job.name_in_artifact }}
           path: ~/logs/

--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -92,12 +92,12 @@ jobs:
       - name: Download default test results
         # Default test results in case the integration tests time out or runner set up fails
         # (So that Allure report will show "unknown"/"failed" test result, instead of omitting the test)
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           path: allure-default-results/
           name: allure-default-results-integration-test
       - name: Download test results
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           path: allure-results/
           pattern: allure-results-integration-test-*


### PR DESCRIPTION
## Issue

Addressing "Warning: Node.js 20 actions are deprecated.", see for example https://github.com/canonical/mysql-operators/actions/runs/23433535188

<img width="1740" height="400" alt="image" src="https://github.com/user-attachments/assets/34a94542-23a9-4872-98c4-2fb743fb9d8e" />

## Solution

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
