### PR TITLE
Fix revision choice according to architecture

### DIFF
--- a/kubernetes/tests/integration/integration/roles/test_predefined_roles_refresh.py
+++ b/kubernetes/tests/integration/integration/roles/test_predefined_roles_refresh.py
@@ -9,6 +9,7 @@ from time import sleep
 import jubilant_backports
 from jubilant_backports import Juju, TaskError
 
+from ... import architecture
 from ...helpers_ha import (
     CHARM_METADATA,
     MINUTE_SECS,
@@ -27,7 +28,11 @@ DATABASE_APP_NAME = "mysql-k8s"
 MYSQL_ROUTER_APP_NAME = "mysql-router-k8s"
 MYSQL_TEST_APP_NAME = "mysql-test-app"
 
-OLD_MYSQL_REVISION = 255
+OLD_MYSQL_REVISIONS = {
+    "amd64": 255,
+    "arm64": 254,
+}
+OLD_MYSQL_REVISION = OLD_MYSQL_REVISIONS[architecture.architecture]
 
 TIMEOUT = 10 * MINUTE_SECS
 

--- a/machines/tests/integration/integration/roles/test_predefined_roles_refresh.py
+++ b/machines/tests/integration/integration/roles/test_predefined_roles_refresh.py
@@ -7,6 +7,7 @@ from time import sleep
 import jubilant_backports
 from jubilant_backports import Juju
 
+from ... import architecture
 from ...helpers_ha import (
     MINUTE_SECS,
     execute_queries_on_unit,
@@ -21,7 +22,11 @@ DATABASE_APP_NAME = "mysql"
 MYSQL_ROUTER_APP_NAME = "mysql-router"
 MYSQL_TEST_APP_NAME = "mysql-test-app"
 
-OLD_MYSQL_REVISION = 366
+OLD_MYSQL_REVISIONS = {
+    "amd64": 366,
+    "arm64": 367,
+}
+OLD_MYSQL_REVISION = OLD_MYSQL_REVISIONS[architecture.architecture]
 
 TIMEOUT = 10 * MINUTE_SECS
 


### PR DESCRIPTION
## Issue

I merged https://github.com/canonical/mysql-operators/pull/163 with some tests failing but those timeouts were legitimate. The real reason was hiding in `juju debug-log`:

https://github.com/canonical/mysql-operators/actions/runs/23478123339/job/68337612310#step:12:96

This fixes the issue.

## Solution

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
