### PR TITLE
Fix 8.4 docs build

### DIFF
--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -69,7 +69,7 @@ The snap "charmed-mysql" also ships list of tools used by charm:
 * `charmed-mysql.xtrabackup` - a tool to backup/restore MySQL DB.
 
 The `mysql` and `mysqlsh` are well known and popular tools to manage MySQL.
-The `xtrabackup (xbcloud+xbstream)` used for [MySQL Backups](/how-to/back-up-and-restore/create-a-backup) only to store backups on S3 compatible storage.
+The `xtrabackup (xbcloud+xbstream)` used for {ref}`MySQL Backups <create-a-backup>` only to store backups on S3 compatible storage.
 
 ### Kubernetes charm
 
@@ -97,9 +97,9 @@ The Charmed MySQL K8s (`workload` container) based on the `mysql-image` resource
 
 [Charmcraft](https://juju.is/docs/sdk/install-charmcraft) uploads an image as a [charm resource](https://charmhub.io/mysql-k8s/resources/mysql-image) to [Charmhub](https://charmhub.io/mysql-k8s) during the [publishing](https://github.com/canonical/mysql-k8s-operator/blob/main/.github/workflows/release.yaml#L40-L53), as described in the [Juju SDK How-to guides](https://juju.is/docs/sdk/publishing).
 
-The charm supports Juju deployment to all Kubernetes environments: [MicroK8s](https://microk8s.io/), [Charmed Kubernetes](https://ubuntu.com/kubernetes/charmed-k8s), [GKE](https://charmhub.io/mysql-k8s/docs/h-deploy-gke), [Amazon EKS](https://aws.amazon.com/eks/), ...
+The charm supports Juju deployment to all Kubernetes environments: {ref}`MicroK8s <microk8s>`, {ref}`Canonical Kubernetes <canonical-k8s>`, {ref}`Google Kubernetes Engine <gke>`, {ref}`Amazon EKS <eks>`, and {ref}`Azure Kubernetes Service <aks>`.
 
-The OCI/ROCK ships the following components based on the [`charmed-mysql` snap](https://canonical-charmed-mysql.readthedocs-hosted.com/explanation/architecture):
+The OCI/ROCK ships the following components based on the {ref}`charmed-mysql snap <architecture>`:
 
 * MySQL Community Edition
 * MySQL Router

--- a/docs/explanation/security/cryptography.md
+++ b/docs/explanation/security/cryptography.md
@@ -23,7 +23,7 @@ The Charmed MySQL snap packages the MySQL workload along with the necessary depe
 ```{tab-item} K8s
 :sync: k8s
 
-Charmed MySQL K8s and Charmed MySQL Router K8s operators use a pinned version of the [Charmed MySQL rock](https://github.com/orgs/canonical/packages/container/package/charmed-mysql) to provide reproducible and secure environments.
+Charmed MySQL K8s and Charmed MySQL Router K8s operators use a pinned version of the [Charmed MySQL rock](https://github.com/canonical/charmed-mysql-rock/pkgs/container/charmed-mysql) to provide reproducible and secure environments.
 
 The rock is an OCI image derived from the respective snap. The Charmed MySQL K8s snap packages the MySQL workload along with the necessary dependencies and utilities required for the operators’ lifecycle. For more details, see the snap contents in the [snapcraft.yaml file](https://github.com/canonical/charmed-mysql-snap/blob/8.4/edge/snap/snapcraft.yaml).
 ```

--- a/docs/explanation/users.md
+++ b/docs/explanation/users.md
@@ -19,8 +19,8 @@ The operator uses the following internal database users:
 
 * `charmed-replication` - the user to manage replication in the MySQL InnoDB ClusterSet.
 * `charmed-operator` - the user that operates MySQL instances.
-* `charmed-stats` - the user for [COS integration](enable-monitoring).
-* `charmed-backup` - the user to [perform/list/restore backups](/how-to/back-up-and-restore/create-a-backup).
+* `charmed-stats` - the user for {ref}`COS integration <enable-monitoring>`.
+* `charmed-backup` - the user to {ref}`manage backups <create-a-backup>`.
 * `mysql_innodb_cluster_#######` - the [internal recovery users](https://dev.mysql.com/doc/mysql-shell/8.4/en/innodb-cluster-user-accounts.html#mysql-innodb-cluster-users-created) which enable connections between the servers in the cluster. Dedicated user created for each Juju unit/InnoDB Cluster member.
 * `mysql_innodb_cs_#######` - the internal recovery user which enable connections between MySQl InnoDB Clusters in ClusterSet. One user is created for entire MySQL ClusterSet.
 

--- a/docs/explanation/users.md
+++ b/docs/explanation/users.md
@@ -19,7 +19,7 @@ The operator uses the following internal database users:
 
 * `charmed-replication` - the user to manage replication in the MySQL InnoDB ClusterSet.
 * `charmed-operator` - the user that operates MySQL instances.
-* `charmed-stats` - the user for [COS integration](/how-to/monitoring-cos/enable-monitoring).
+* `charmed-stats` - the user for [COS integration](enable-monitoring).
 * `charmed-backup` - the user to [perform/list/restore backups](/how-to/back-up-and-restore/create-a-backup).
 * `mysql_innodb_cluster_#######` - the [internal recovery users](https://dev.mysql.com/doc/mysql-shell/8.4/en/innodb-cluster-user-accounts.html#mysql-innodb-cluster-users-created) which enable connections between the servers in the cluster. Dedicated user created for each Juju unit/InnoDB Cluster member.
 * `mysql_innodb_cs_#######` - the internal recovery user which enable connections between MySQl InnoDB Clusters in ClusterSet. One user is created for entire MySQL ClusterSet.

--- a/docs/how-to/back-up-and-restore/create-a-backup.md
+++ b/docs/how-to/back-up-and-restore/create-a-backup.md
@@ -11,7 +11,7 @@ This guide contains recommended steps and useful commands for creating and manag
 
 ## Prerequisites
 
-* [Configured settings for S3 storage](/how-to/back-up-and-restore/configure-s3-aws)
+* {ref}`Configured settings for S3 storage <configure-s3-aws>`
 
 ---
 

--- a/docs/how-to/back-up-and-restore/restore-a-backup.md
+++ b/docs/how-to/back-up-and-restore/restore-a-backup.md
@@ -9,12 +9,12 @@ myst:
 
 This is a guide for performing a basic restore (restoring a locally made backup).
 
-To restore a backup that was made from the a *different* cluster, (i.e. cluster migration via restore), see [](/how-to/back-up-and-restore/migrate-a-cluster).
+To restore a backup that was made from the a *different* cluster, (i.e. cluster migration via restore), see {ref}`migrate-a-cluster`.
 
 ## Prerequisites
 
 - A MySQL deployment {ref}`scaled down <scale>` to one unit (scale it up after the backup is restored)
-- [A backup in your S3 storage](/how-to/back-up-and-restore/create-a-backup)
+- {ref}`A backup in your S3 storage <create-a-backup>`
 
 ---
 

--- a/docs/how-to/charm-development/integrate-with-your-charm.md
+++ b/docs/how-to/charm-development/integrate-with-your-charm.md
@@ -26,7 +26,7 @@ Refer to [mysql-test-app](https://github.com/canonical/mysql-test-app) as a prac
 ## Troubleshooting and testing
 
 * To learn the basics of charm debugging, start with [Juju > How to debug a charm](https://juju.is/docs/sdk/debug-a-charm)
-* To troubleshoot Charmed MySQL, see the [Troubleshooting](/reference/troubleshooting/index) page.
+* To learn about troubleshoot Charmed MySQL, see {ref}`troubleshooting`
 * To test the charm, see {ref}`charm-testing`
 
 ## FAQ

--- a/docs/how-to/deploy/airgapped.md
+++ b/docs/how-to/deploy/airgapped.md
@@ -193,5 +193,5 @@ Use the official {ref}`release notes <release-notes>` as a reference.
 
 * [Enterprise Store documentation](https://documentation.ubuntu.com/enterprise-store/main/) (formerly Snap Store Proxy)
 * [Installing Charmed Kubernetes offline](https://ubuntu.com/kubernetes/docs/install-offline)
-* [Install Charmed Kubeflow in an airgapped environment](https://documentation.ubuntu.com/charmed-kubeflow/how-to/install/install-airgapped/)
+* [Install Charmed Kubeflow in an airgapped environment](https://documentation.ubuntu.com/charmed-kubeflow/latest/how-to/install/install-air-gapped/)
 * [Wikipedia | Air gap (networking)](https://en.wikipedia.org/wiki/Air_gap_(networking))

--- a/docs/how-to/deploy/multi-az/gke.md
+++ b/docs/how-to/deploy/multi-az/gke.md
@@ -286,8 +286,7 @@ mydatabase/2   active    idle   10.80.1.6
 
 At this point we can relax and enjoy the protection from Cloud Availability zones!
 
-To survive a complete cloud outage, we recommend setting up [cluster-cluster asynchronous replication](/how-to/cluster-cluster-replication/deploy).
-
+To survive a complete cloud outage, we recommend setting up {ref}`cluster-cluster asynchronous replication <cluster-cluster-deploy>`.
 
 ## Remove GKE setup
 

--- a/docs/how-to/refresh/single-cluster/refresh-single-cluster.md
+++ b/docs/how-to/refresh/single-cluster/refresh-single-cluster.md
@@ -286,7 +286,7 @@ Target the leader unit:
 ```
 ````
 
-`resume-refresh` will rollout the refresh for the following unit, always from the highest ordinal number to the lowest. For each successful refreshed unit, the process will roll out the next automatically.
+`resume-refresh` will roll out the refresh for the following unit, always from the highest ordinal number to the lowest. For each successful refreshed unit, the process will roll out the next automatically.
 
 ## Step 7: Roll back
 

--- a/docs/reference/plugins-extensions.md
+++ b/docs/reference/plugins-extensions.md
@@ -11,25 +11,9 @@ The following list contains all plugins/extensions supported by Charmed MySQL in
 
 If you need support for other extensions, feel free to {ref}`contact us <contacts>`.
 
-````{tab-set}
-```{tab-item} VM
-:sync: vm
-
-| Plugin/extension name          | Revision                                                                     |
-|--------------------------------|------------------------------------------------------------------------------|
-| [plugin-audit-enabled](/explanation/logs/audit-logs)         | [272+](https://github.com/canonical/mysql-operator/releases/tag/rev273) |
-
-```
-
-```{tab-item} K8s
-:sync: k8s
-
-| Plugin/extension name          | Revision                                                                     |
-|--------------------------------|------------------------------------------------------------------------------|
-| [plugin-audit-enabled](/explanation/logs/audit-logs)         | [178+](https://github.com/canonical/mysql-k8s-operator/releases/tag/rev179) |
-
-```
-````
+| Plugin/extension name                    | Revision    |
+|------------------------------------------|-------------|
+| {ref}`plugin-audit-enabled <audit-logs>` | All         |
 
 
 

--- a/docs/reference/troubleshooting/index.md
+++ b/docs/reference/troubleshooting/index.md
@@ -75,7 +75,7 @@ See [Juju logs documentation](https://juju.is/docs/juju/log) to learn more about
 
 ## Check snap services (VM only)
 
-Check the operator [architecture](/explanation/architecture) first to be familiar with the content of the snap, operator building blocks, and Juju units.
+Check the operator {ref}`architecture <architecture>` first to be familiar with the content of the snap, operator building blocks, and Juju units.
 
 To enter a unit, use:
 


### PR DESCRIPTION
This PR fixes a broken reference that is causing the documentation build for 8.4 to [fail on Read The Docs.](https://app.readthedocs.com/projects/canonical-charmed-mysql/builds/3864189/#44420483--246) and a leftover spelling error.

I've also included some miscellaneous (non-critical) polishing of some formatting and old Markdown references.

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
