### PR TITLE
[DPE-7909] Normalize config names to "-"

### DIFF
--- a/docs/explanation/logs/audit-logs.md
+++ b/docs/explanation/logs/audit-logs.md
@@ -57,7 +57,7 @@ The audit plugin is enabled by default in the charm, but it's possible to disabl
 
 Valid values are `false` and `true` (default). By setting it to false, existing logs are still kept in the `archive_audit` directory.
 
-### `logs_audit_policy` 
+### `logs-audit-policy`
 
 Audit log policy:
 
@@ -65,13 +65,13 @@ Audit log policy:
 ```{tab-item} VM
 :sync: vm
 
-    juju config mysql logs_audit_policy=queries
+    juju config mysql logs-audit-policy=queries
 ```
 
 ```{tab-item} K8s
 :sync: k8s
 
-    juju config mysql-k8s logs_audit_policy=queries
+    juju config mysql-k8s logs-audit-policy=queries
 ```
 ````
 

--- a/docs/explanation/logs/index.md
+++ b/docs/explanation/logs/index.md
@@ -147,10 +147,10 @@ Following the configuration options exposed by the charm:
 | Configuration option | Description | Default value |
 | --- | --- | --- |
 | `plugin-audit-enabled` | Enable or disable the audit log | `true` |
-| `logs_audit_policy` | The audit log policy ("all", "logins", "queries") | `logins` |
-| `logs_retention_period` | The number of days to keep the rotated logs | `auto` |
+| `logs-audit-policy` | The audit log policy ("all", "logins", "queries") | `logins` |
+| `logs-retention-period` | The number of days to keep the rotated logs | `auto` |
 
-The `logs_retention_period` option accepts an integer value of 3 or greater, or the special value
+The `logs-retention-period` option accepts an integer value of 3 or greater, or the special value
 `auto`. When set to "auto" (default), the retention period is 3 days, except when COS-related,
 where it is 1 day
 

--- a/docs/explanation/security/index.md
+++ b/docs/explanation/security/index.md
@@ -101,11 +101,11 @@ The logs are stored in the `/var/snap/charmed-mysql/common/var/log/mysql` direct
 
 We recommend setting the retention period to a value greater than the default (three days):
 
-    juju config mysql logs_retention_period=14 # days
+    juju config mysql logs-retention-period=14 # days
 
 By default, the audit log records logins and logouts. To include the SQL queries executed by each user:
 
-    juju config mysql logs_audit_policy=all
+    juju config mysql logs-audit-policy=all
 ```
 
 ```{tab-item} K8s
@@ -115,11 +115,11 @@ The logs are stored in the `/var/log/mysql` directory of the mysql container, an
 
 We recommend setting the retention period to a value greater than the default (three days):
 
-    juju config mysql-k8s logs_retention_period=14 # days
+    juju config mysql-k8s logs-retention-period=14 # days
 
 By default, the audit log records logins and logouts. To include the SQL queries executed by each user:
 
-    juju config mysql-k8s logs_audit_policy=all
+    juju config mysql-k8s logs-audit-policy=all
 ```
 ````
 

--- a/kubernetes/config.yaml
+++ b/kubernetes/config.yaml
@@ -34,17 +34,17 @@ options:
       Ref. at https://docs.percona.com/percona-server/8.4/audit-log-plugin.html#audit_log_strategy
     type: string
     default: async
-  binlog_retention_days:
+  binlog-retention-days:
     description: Number of days for binary logs retention
     type: int
     default: 7
-  logs_audit_policy:
+  logs-audit-policy:
     description: |
       Audit log policy. Allowed values are: "all", "logins" (default), "queries".
       Ref. at https://docs.percona.com/percona-server/8.4/audit-log-plugin.html#audit_log_policy
     type: string
     default: logins
-  logs_retention_period:
+  logs-retention-period:
     description: |
       Specifies the retention period for rotated logs, in days. Accepts an integer value of 3 or
       greater, or the special value "auto". When set to "auto" (default), the retention period is

--- a/machines/config.yaml
+++ b/machines/config.yaml
@@ -33,17 +33,17 @@ options:
       Ref. at https://docs.percona.com/percona-server/8.4/audit-log-plugin.html#audit_log_strategy
     type: string
     default: async
-  binlog_retention_days:
+  binlog-retention-days:
     description: Number of days for binary logs retention
     type: int
     default: 7
-  logs_audit_policy:
+  logs-audit-policy:
     description: |
       Audit log policy. Allowed values are: "all", "logins" (default), "queries".
       Ref. at https://docs.percona.com/percona-server/8.4/audit-log-plugin.html#audit_log_policy
     type: string
     default: logins
-  logs_retention_period:
+  logs-retention-period:
     description: |
       Specifies the retention period for rotated logs, in days. Accepts an integer value of 3 or
       greater, or the special value "auto". When set to "auto" (default), the retention period is

--- a/machines/tests/unit/test_log_rotation_setup.py
+++ b/machines/tests/unit/test_log_rotation_setup.py
@@ -42,7 +42,7 @@ class TestLogRotationSetup(unittest.TestCase):
     def test_log_syncing(
         self, mock_setup, mock_exist, mock_is_peer_data_set, mock_charm_on_created
     ):
-        self.harness.update_config({"logs_retention_period": "auto"})
+        self.harness.update_config({"logs-retention-period": "auto"})
         self.harness.add_relation(COS_AGENT_RELATION_NAME, "grafana-agent")
         positions = (
             "positions:\n  '/var/snap/charmed-mysql/common/var/log/mysql/error.log': '466'\n"
@@ -58,7 +58,7 @@ class TestLogRotationSetup(unittest.TestCase):
 
     @patch("mysql_vm_helpers.MySQL.setup_logrotate_and_cron")
     def test_cos_relation_broken(self, mock_setup):
-        self.harness.update_config({"logs_retention_period": "auto"})
+        self.harness.update_config({"logs-retention-period": "auto"})
         event = MagicMock()
         self.charm.log_rotation_setup._cos_relation_broken(event)
         self.assertNotIn("logs_synced", self.harness.charm.unit_peer_data)


### PR DESCRIPTION
## Issue

Same as https://github.com/canonical/postgresql-k8s-operator/pull/1174

## Solution

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
