### PR TITLE
[DPE-9537] 8.4 - Bump artifacts

### DIFF
--- a/kubernetes/lib/charms/mysql/v0/backups.py
+++ b/kubernetes/lib/charms/mysql/v0/backups.py
@@ -754,8 +754,8 @@ class MySQLBackups(Object):
             )
             logger.debug(f"Stdout of mysql-pitr-helper restore command: {stdout}")
             logger.debug(f"Stderr of mysql-pitr-helper restore command: {stderr}")
-        except MySQLRestorePitrError:
-            return False, f"Failed to restore point-in-time-recovery to the {restore_to_time}"
+        except MySQLRestorePitrError as e:
+            return False, f"Failed to restore point-in-time-recovery: {e}"
         return True, ""
 
     def _post_restore(self) -> tuple[bool, str]:

--- a/kubernetes/metadata.yaml
+++ b/kubernetes/metadata.yaml
@@ -31,7 +31,7 @@ resources:
   mysql-image:
     type: oci-image
     description: Ubuntu LTS Docker image for MySQL
-    upstream-source: ghcr.io/canonical/charmed-mysql@sha256:5e3ab326cb01f31a9e096ada50cb87ebd27671a990ad5e4f565ca5d1e5c48a3b
+    upstream-source: ghcr.io/canonical/charmed-mysql@sha256:143b30eaade9e55b5756d38d4bedac29d41adb5e6f30c21f7eec596ab1138564
 
 peers:
   database-peers:

--- a/kubernetes/tests/spread/integration/test_backup_pitr_aws.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_backup_pitr_aws.py/task.yaml
@@ -2,8 +2,6 @@ summary: test_backup_pitr_aws.py
 environment:
   TEST_MODULE: test_backup_pitr_aws.py
 execute: |
-  # TODO: Un-comment when we release a version of MySQL PITR compatible with 8.4
-  # tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
-  exit 0
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_backup_pitr_gcp.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_backup_pitr_gcp.py/task.yaml
@@ -2,8 +2,6 @@ summary: test_backup_pitr_gcp.py
 environment:
   TEST_MODULE: test_backup_pitr_gcp.py
 execute: |
-  # TODO: Un-comment when we release a version of MySQL PITR compatible with 8.4
-  # tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
-  exit 0
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/lib/charms/mysql/v0/backups.py
+++ b/machines/lib/charms/mysql/v0/backups.py
@@ -753,8 +753,8 @@ class MySQLBackups(Object):
             )
             logger.debug(f"Stdout of mysql-pitr-helper restore command: {stdout}")
             logger.debug(f"Stderr of mysql-pitr-helper restore command: {stderr}")
-        except MySQLRestorePitrError:
-            return False, f"Failed to restore point-in-time-recovery to the {restore_to_time}"
+        except MySQLRestorePitrError as e:
+            return False, f"Failed to restore point-in-time-recovery: {e}"
         return True, ""
 
     def _post_restore(self) -> tuple[bool, str]:

--- a/machines/refresh_versions.toml
+++ b/machines/refresh_versions.toml
@@ -8,6 +8,6 @@ workload = "8.4"
 name = "charmed-mysql"
 
 [snap.revisions]
-x86_64 = "186"
-aarch64 = "185"
-s390x = "187"
+x86_64 = "200"
+aarch64 = "198"
+s390x = "199"

--- a/machines/tests/spread/integration/test_backup_pitr_aws.py/task.yaml
+++ b/machines/tests/spread/integration/test_backup_pitr_aws.py/task.yaml
@@ -2,9 +2,7 @@ summary: test_backup_pitr_aws.py
 environment:
   TEST_MODULE: test_backup_pitr_aws.py
 execute: |
-  # TODO: Un-comment when we release a version of MySQL PITR compatible with 8.4
-  # tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
-  exit 0
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 backends:

--- a/machines/tests/spread/integration/test_backup_pitr_gcp.py/task.yaml
+++ b/machines/tests/spread/integration/test_backup_pitr_gcp.py/task.yaml
@@ -2,9 +2,7 @@ summary: test_backup_pitr_gcp.py
 environment:
   TEST_MODULE: test_backup_pitr_gcp.py
 execute: |
-  # TODO: Un-comment when we release a version of MySQL PITR compatible with 8.4
-  # tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
-  exit 0
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 backends:


### PR DESCRIPTION
This PR bumps the K8s / VM artifacts to ship the charms with:

- PITR helper version 6 (recently updated from upstream).
- MySQL binaries version 8.4.8
