### PR TITLE
Update documentation link to version 8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ juju destroy-model mysql --destroy-storage --yes
 
 ## Documentation
 
-See the [official documentation](https://canonical-charmed-mysql.readthedocs-hosted.com/) for more operational guidance, such as deployment on specific clouds, TLS, monitoring, backups, and troubleshooting.
+See the [official documentation](https://canonical-charmed-mysql.readthedocs-hosted.com/8.0) for more operational guidance, such as deployment on specific clouds, TLS, monitoring, backups, and troubleshooting.
 
 ## Relations
 


### PR DESCRIPTION
Declaring version in the URL explicitly so that it does not redirect to `8.4` (default).

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
