### PR TITLE
[MISC] Run integration tests on GitHub-hosted runners with Ubuntu 22.04

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -114,6 +114,10 @@ jobs:
       - name: Checkout
         timeout-minutes: 3
         uses: actions/checkout@v6
+      - name: Install Python for tests
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
       - name: Set up environment
         timeout-minutes: 5
         run: |

--- a/kubernetes/spread.yaml
+++ b/kubernetes/spread.yaml
@@ -81,6 +81,8 @@ backends:
 
       sudo passwd --delete "$USER"
 
+      sudo systemctl reload ssh || sudo systemctl restart ssh
+
       ADDRESS localhost
     # HACK: spread does not pass environment variables set on runner
     # Manually pass specific environment variables

--- a/kubernetes/spread.yaml
+++ b/kubernetes/spread.yaml
@@ -91,9 +91,9 @@ backends:
       GCP_ACCESS_KEY: '$(HOST: echo $GCP_ACCESS_KEY)'
       GCP_SECRET_KEY: '$(HOST: echo $GCP_SECRET_KEY)'
     systems:
-      - ubuntu-24.04:
+      - ubuntu-22.04:
           username: runner
-      - ubuntu-24.04-arm:
+      - ubuntu-22.04-arm:
           username: runner
 
 suites:

--- a/kubernetes/spread.yaml
+++ b/kubernetes/spread.yaml
@@ -110,6 +110,7 @@ kill-timeout: 3h
 environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
   CONCIERGE_JUJU_CHANNEL/juju36: 3.6/stable
+  pythonLocation: '$(HOST: echo $pythonLocation)'
 prepare: |
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"
@@ -120,7 +121,7 @@ prepare: |
   concierge prepare --trace
 
   pipx install tox poetry
-  poetry env use python3.12
+  poetry env use $pythonLocation/bin/python
 prepare-each: |
   cd "$SPREAD_PATH"
   concierge prepare --trace
@@ -129,4 +130,4 @@ prepare-each: |
   # https://bugs.launchpad.net/juju/+bug/2065050
   juju set-model-constraints arch="$(dpkg --print-architecture)"
 
-  poetry env use python3.12
+  poetry env use $pythonLocation/bin/python

--- a/kubernetes/spread.yaml
+++ b/kubernetes/spread.yaml
@@ -92,6 +92,8 @@ backends:
       AWS_SECRET_KEY: '$(HOST: echo $AWS_SECRET_KEY)'
       GCP_ACCESS_KEY: '$(HOST: echo $GCP_ACCESS_KEY)'
       GCP_SECRET_KEY: '$(HOST: echo $GCP_SECRET_KEY)'
+      LD_LIBRARY_PATH: '$(HOST: echo $LD_LIBRARY_PATH)'
+      PKG_CONFIG_PATH: '$(HOST: echo $PKG_CONFIG_PATH)'
     systems:
       - ubuntu-22.04:
           username: runner

--- a/kubernetes/spread.yaml
+++ b/kubernetes/spread.yaml
@@ -120,6 +120,7 @@ prepare: |
   concierge prepare --trace
 
   pipx install tox poetry
+  poetry env use python3.12
 prepare-each: |
   cd "$SPREAD_PATH"
   concierge prepare --trace
@@ -127,3 +128,5 @@ prepare-each: |
   # Unable to set constraint on all models because of Juju bug:
   # https://bugs.launchpad.net/juju/+bug/2065050
   juju set-model-constraints arch="$(dpkg --print-architecture)"
+
+  poetry env use python3.12

--- a/machines/spread.yaml
+++ b/machines/spread.yaml
@@ -95,6 +95,8 @@ backends:
       UBUNTU_PRO_TOKEN: '$(HOST: echo $UBUNTU_PRO_TOKEN)'
       LANDSCAPE_ACCOUNT_NAME: '$(HOST: echo $LANDSCAPE_ACCOUNT_NAME)'
       LANDSCAPE_REGISTRATION_KEY: '$(HOST: echo $LANDSCAPE_REGISTRATION_KEY)'
+      LD_LIBRARY_PATH: '$(HOST: echo $LD_LIBRARY_PATH)'
+      PKG_CONFIG_PATH: '$(HOST: echo $PKG_CONFIG_PATH)'
     systems:
       - ubuntu-22.04:
           username: runner

--- a/machines/spread.yaml
+++ b/machines/spread.yaml
@@ -123,6 +123,7 @@ prepare: |
   concierge prepare --trace
 
   pipx install tox poetry
+  poetry env use python3.12
 prepare-each: |
   cd "$SPREAD_PATH"
   concierge prepare --trace
@@ -130,3 +131,5 @@ prepare-each: |
   # Unable to set constraint on all models because of Juju bug:
   # https://bugs.launchpad.net/juju/+bug/2065050
   juju set-model-constraints arch="$(dpkg --print-architecture)"
+
+  poetry env use python3.12

--- a/machines/spread.yaml
+++ b/machines/spread.yaml
@@ -81,6 +81,8 @@ backends:
 
       sudo passwd --delete "$USER"
 
+      sudo systemctl reload ssh || sudo systemctl restart ssh
+
       ADDRESS localhost
     # HACK: spread does not pass environment variables set on runner
     # Manually pass specific environment variables

--- a/machines/spread.yaml
+++ b/machines/spread.yaml
@@ -113,6 +113,7 @@ kill-timeout: 3h
 environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
   CONCIERGE_JUJU_CHANNEL/juju36: 3.6/stable
+  pythonLocation: '$(HOST: echo $pythonLocation)'
 prepare: |
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"
@@ -123,7 +124,7 @@ prepare: |
   concierge prepare --trace
 
   pipx install tox poetry
-  poetry env use python3.12
+  poetry env use $pythonLocation/bin/python
 prepare-each: |
   cd "$SPREAD_PATH"
   concierge prepare --trace
@@ -132,4 +133,4 @@ prepare-each: |
   # https://bugs.launchpad.net/juju/+bug/2065050
   juju set-model-constraints arch="$(dpkg --print-architecture)"
 
-  poetry env use python3.12
+  poetry env use $pythonLocation/bin/python

--- a/machines/spread.yaml
+++ b/machines/spread.yaml
@@ -94,9 +94,9 @@ backends:
       LANDSCAPE_ACCOUNT_NAME: '$(HOST: echo $LANDSCAPE_ACCOUNT_NAME)'
       LANDSCAPE_REGISTRATION_KEY: '$(HOST: echo $LANDSCAPE_REGISTRATION_KEY)'
     systems:
-      - ubuntu-24.04:
+      - ubuntu-22.04:
           username: runner
-      - ubuntu-24.04-arm:
+      - ubuntu-22.04-arm:
           username: runner
 
 suites:


### PR DESCRIPTION
## Issue

This addresses the CI breakage observed because of the latest `ubuntu-24.04` images upgrading to Linux 6.17.

Approaches that didn't work:
- downgrading Juju (agent and agent + CLI) https://github.com/canonical/mysql-operators/pull/185
- adding delays https://github.com/canonical/mysql-operators/pull/188

This should be a temporary measure until we have assurance that the kernel issues have been addressed or mitigated.

## Solution

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
