### PR TITLE
[MISC] 8.4 - Expose database endpoint in TF module

### DIFF
--- a/kubernetes/terraform/main.tf
+++ b/kubernetes/terraform/main.tf
@@ -17,4 +17,8 @@ resource "juju_application" "mysql_server" {
   config      = var.config
   constraints = var.constraints
   units       = var.units
+
+  expose {
+    endpoints = "database"
+  }
 }

--- a/machines/terraform/main.tf
+++ b/machines/terraform/main.tf
@@ -17,4 +17,8 @@ resource "juju_application" "mysql_server" {
   constraints       = var.constraints
   endpoint_bindings = var.endpoint_bindings
   units             = var.units
+
+  expose {
+    endpoints = "database"
+  }
 }


### PR DESCRIPTION
This PR addresses issue https://github.com/canonical/mysql-operators/issues/186, by exposing the `database` endpoint making _Cross Model Relations_ (CMR) easier.
