### PR TITLE
[fix] add missing references to release notes

### DIFF
--- a/docs/reference/release-notes/k8s/index.md
+++ b/docs/reference/release-notes/k8s/index.md
@@ -23,6 +23,7 @@ All revisions of MySQL described below are built for *Ubuntu 22.04 LTS (Jammy)*.
 
 | Revision (`amd`) | Revision (`arm`) | Revision (`s390x`) | MySQL version | Juju version | {ref}`TLS <enable-tls>`* | {ref}`Monitoring <enable-monitoring>` | {ref}`In-place upgrades <refresh-single-cluster>`| {ref}`Cluster-cluster replication <cluster-cluster-replication>` |
 |:-----:|:-----:|:-----:|:------:|:---------:|:--------:|:--------:|:--------:|:--------:|
+| [400] | [399] | [401] | 8.0.44 | `3.5.4+`  | ![check] | ![check] | ![check] | ![check] |
 | [343] | [344] | [342] | 8.0.44 | `3.5.4+`  | ![check] | ![check] | ![check] | ![check] |
 | [255] | [254] |       | 8.0.41 | `3.5.4+`  | ![check] | ![check] | ![check] | ![check] |
 | [240] | [241] |       | 8.0.41 | `3.5.4+`  | ![check] | ![check] | ![check] | ![check] | 
@@ -40,6 +41,7 @@ All revisions of MySQL described below are built for *Ubuntu 22.04 LTS (Jammy)*.
 :titlesonly:
 :hidden:
 
+Revisions 399-401 <revisions-399-401>
 Revisions 342-344 <revisions-342-344>
 Revisions 254-255 <revisions-254-255>
 Revisions 240-241 <revisions-240-241>
@@ -53,6 +55,9 @@ Revision 75  <revision-75>
 ```
 
 <!-- LINKS -->
+[401]: revisions-399-401.md
+[400]: revisions-399-401.md
+[399]: revisions-399-401.md
 [342]: revisions-342-344.md
 [343]: revisions-342-344.md
 [344]: revisions-342-344.md


### PR DESCRIPTION
Address PR#191 [comment](https://github.com/canonical/mysql-operators/pull/191#issuecomment-4163452732)
