### PR TITLE
[MISC] 8.4 - Fix COS-related docs

### DIFF
--- a/docs/how-to/monitoring/enable-monitoring.md
+++ b/docs/how-to/monitoring/enable-monitoring.md
@@ -70,13 +70,23 @@ juju consume k8s:admin/cos.prometheus
 
 ## Deploy and integrate Grafana
 
-First, deploy the [grafana-agent](https://charmhub.io/grafana-agent) subordinate charm:
+First, deploy the [grafana-agent](https://charmhub.io/grafana-agent) / [grafana-agent-k8s](https://charmhub.io/grafana-agent-k8s) subordinate charm:
 
-```shell
-juju deploy grafana-agent
+````{tab-set}
+```{tab-item} VM
+:sync: vm
+
+    juju deploy grafana-agent
 ```
 
-Then, integrate (relate) it with Charmed MySQL
+```{tab-item} K8s
+:sync: k8s
+
+    juju deploy grafana-agent-k8s --trust
+```
+````
+
+Then, integrate it with Charmed MySQL
 
 ````{tab-set}
 ```{tab-item} VM
@@ -88,17 +98,31 @@ Then, integrate (relate) it with Charmed MySQL
 ```{tab-item} K8s
 :sync: k8s
 
-    juju integrate grafana-agent mysql-k8s:cos-agent
+    juju integrate grafana-agent-k8s mysql-k8s:grafana-dashboard
+    juju integrate grafana-agent-k8s mysql-k8s:logging
+    juju integrate grafana-agent-k8s mysql-k8s:metrics-endpoint
 ```
 ````
 
-Finally, integrate (relate) `grafana-agent` with consumed COS offers:
+Finally, integrate Grafana Agent with consumed COS offers:
 
-```shell
-juju integrate grafana-agent grafana
-juju integrate grafana-agent loki
-juju integrate grafana-agent prometheus
+````{tab-set}
+```{tab-item} VM
+:sync: vm
+
+    juju integrate grafana-agent grafana
+    juju integrate grafana-agent loki
+    juju integrate grafana-agent prometheus
 ```
+
+```{tab-item} K8s
+:sync: k8s
+
+    juju integrate grafana-agent-k8s grafana
+    juju integrate grafana-agent-k8s loki
+    juju integrate grafana-agent-k8s prometheus
+```
+````
 
 After this is complete, Grafana will show the new dashboards: `MySQL Exporter` and allows access for Charmed MySQL logs on Loki.
 
@@ -191,4 +215,3 @@ juju run grafana/leader get-admin-password --model <cos_k8s_controller>:<cos_mod
 ## Full example of COS integration (MySQL K8s)
 
 [![asciicast](https://asciinema.org/a/580608.svg)](https://asciinema.org/a/580608)
-

--- a/docs/how-to/monitoring/enable-tracing.md
+++ b/docs/how-to/monitoring/enable-tracing.md
@@ -72,21 +72,51 @@ juju consume k8s:admin/cos.tempo
 
 ## Consume interfaces
 
-First, deploy [Grafana Agent](https://charmhub.io/grafana-agent) from the `1/stable` channel:
+First, deploy [grafana-agent](https://charmhub.io/grafana-agent) / [grafana-agent-k8s](https://charmhub.io/grafana-agent-k8s) from the `1/stable` channel:
 
-```shell
-juju deploy grafana-agent --channel 1/stable
+````{tab-set}
+```{tab-item} VM
+:sync: vm
+
+    juju deploy grafana-agent --channel 1/stable
 ```
+
+```{tab-item} K8s
+:sync: k8s
+
+    juju deploy grafana-agent-k8s --channel 1/stable --trust
+```
+````
 
 Then, integrate Grafana Agent with Charmed MySQL:
-```
-juju integrate mysql:cos-agent grafana-agent:cos-agent
+````{tab-set}
+```{tab-item} VM
+:sync: vm
+
+    juju integrate mysql:cos-agent grafana-agent:cos-agent
 ```
 
-Finally, integrate Grafana Agent with the consumed interface from the previous section:
-```shell
-juju integrate grafana-agent:tracing tempo:tracing
+```{tab-item} K8s
+:sync: k8s
+
+    juju integrate mysql-k8s:tracing grafana-agent-k8s:tracing-provider
 ```
+````
+
+Finally, integrate Grafana Agent with the consumed interface from the previous section:
+````{tab-set}
+```{tab-item} VM
+:sync: vm
+
+    juju integrate grafana-agent:tracing tempo:tracing
+```
+
+```{tab-item} K8s
+:sync: k8s
+
+    juju integrate grafana-agent-k8s:tracing tempo:tracing
+```
+````
 
 Wait until the model settles. The following is an example of the `juju status --relations` on the Charmed MySQL model:
 
@@ -161,4 +191,3 @@ The Tempo traces will be accessible from Grafana under the `Explore` section wit
 </details>
 
 Feel free to read through the [Tempo HA documentation](https://discourse.charmhub.io/t/charmed-tempo-ha/15531) at your leisure to explore its deployment and its integrations.
-


### PR DESCRIPTION
This PR fixes the unified MySQL 8.4 [enable-monitoring](https://canonical-charmed-mysql.readthedocs-hosted.com/8.4/how-to/monitoring/enable-monitoring/) & [enable-tracing](https://canonical-charmed-mysql.readthedocs-hosted.com/8.4/how-to/monitoring/enable-tracing/) docs by making code substrate dependent.

#### References
- Legacy K8s [monitoring docs](https://github.com/canonical/mysql-k8s-operator/blob/0088c9583f63999ff37d982948e47b9e3e3fba2a/docs/how-to/monitoring-cos/enable-monitoring.md?plain=1#L64-L86).
- Legacy K8s [tracing docs](https://github.com/canonical/mysql-k8s-operator/blob/0088c9583f63999ff37d982948e47b9e3e3fba2a/docs/how-to/monitoring-cos/enable-tracing.md?plain=1#L70-L88).
- Legacy VM [monitoring docs](https://github.com/canonical/mysql-operator/blob/8b73ff31c76ab3234acd4e4172b0347073def2fa/docs/how-to/monitoring-cos/enable-monitoring.md?plain=1#L64-L84).
- Legacy VM [tracing docs](https://github.com/canonical/mysql-operator/blob/8b73ff31c76ab3234acd4e4172b0347073def2fa/docs/how-to/monitoring-cos/enable-tracing.md?plain=1#L68-L84).

