### PR TITLE
[DPE-9747] 8.4 - Enable upgrade tests

### DIFF
--- a/kubernetes/metadata.yaml
+++ b/kubernetes/metadata.yaml
@@ -24,7 +24,7 @@ charm-user: non-root
 containers:
   mysql:
     uid: 584788
-    gig: 584788
+    gid: 584788
     resource: mysql-image
     mounts:
       - storage: database

--- a/kubernetes/tests/integration/integration/high_availability/test_upgrade.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_upgrade.py
@@ -102,7 +102,11 @@ def test_refresh_from_edge(juju: Juju, charm: str, continuous_writes) -> None:
     logging.info("Wait for refresh to start")
     juju.wait(
         ready=wait_for_apps_status(jubilant.any_blocked, MYSQL_APP_NAME),
-        timeout=10 * MINUTE_SECS,
+        timeout=5 * MINUTE_SECS,
+    )
+    juju.wait(
+        ready=wait_for_unit_status(MYSQL_APP_NAME, mysql_units[-1], "blocked"),
+        timeout=5 * MINUTE_SECS,
     )
 
     mysql_status = juju.status().apps[MYSQL_APP_NAME]

--- a/kubernetes/tests/integration/release/high_availability/test_upgrade_from_stable.py
+++ b/kubernetes/tests/integration/release/high_availability/test_upgrade_from_stable.py
@@ -18,6 +18,7 @@ from ...helpers_ha import (
     get_app_units,
     get_mysql_primary_unit,
     wait_for_apps_status,
+    wait_for_unit_status,
 )
 
 MYSQL_APP_NAME = "mysql-k8s"
@@ -142,7 +143,11 @@ def refresh_from_stable(juju: Juju, charm: str) -> None:
     logging.info("Wait for refresh to start")
     juju.wait(
         ready=wait_for_apps_status(jubilant.any_blocked, MYSQL_APP_NAME),
-        timeout=10 * MINUTE_SECS,
+        timeout=5 * MINUTE_SECS,
+    )
+    juju.wait(
+        ready=wait_for_unit_status(MYSQL_APP_NAME, mysql_units[-1], "blocked"),
+        timeout=5 * MINUTE_SECS,
     )
 
     mysql_status = juju.status().apps[MYSQL_APP_NAME]

--- a/kubernetes/tests/spread/integration/test_async_replication_upgrade.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_async_replication_upgrade.py/task.yaml
@@ -2,8 +2,6 @@ summary: test_async_replication_upgrade.py
 environment:
   TEST_MODULE: high_availability/test_async_replication_upgrade.py
 execute: |
-  # TODO: Uncomment when the root-less K8s charm has been released to the `8.4/edge` channel
-  # tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
-  exit 0
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_upgrade.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_upgrade.py/task.yaml
@@ -2,8 +2,6 @@ summary: test_upgrade.py
 environment:
   TEST_MODULE: high_availability/test_upgrade.py
 execute: |
-  # TODO: Uncomment when the root-less K8s charm has been released to the `8.4/edge` channel
-  # tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
-  exit 0
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results


### PR DESCRIPTION
This PR re-enables upgrade tests after a root-less K8s charm was released to the `8.4/edge` channel.
