### PR TITLE
[DPE-8810] Create MySQL 8.0 to 8.4 migration

### DIFF
--- a/docs/how-to/data-migration/index.md
+++ b/docs/how-to/data-migration/index.md
@@ -12,6 +12,7 @@ myst:
 :maxdepth: 2
 
 Migrate data via mysqldump <migrate-data-via-mysqldump>
+Migrate data via mysqlsh <migrate-data-via-mysqlsh>
 Migrate data via mydumper <migrate-data-via-mydumper>
 Migrate data via backup/restore <migrate-data-via-backup-restore>
 ```

--- a/docs/how-to/data-migration/index.md
+++ b/docs/how-to/data-migration/index.md
@@ -7,6 +7,16 @@ myst:
 (data-migration)=
 # Migrate data
 
+For guidance about moving data from a MySQL 8.0 charm to a MySQL 8.4 charm, start here:
+
+```{toctree}
+:titlesonly:
+:maxdepth: 2
+
+Migrate data from MySQL 8.0 to 8.4 <migrate-data-from-8.0-to-8.4>
+```
+
+More generic data migration guides:
 ```{toctree}
 :titlesonly:
 :maxdepth: 2

--- a/docs/how-to/data-migration/migrate-data-from-8.0-to-8.4.md
+++ b/docs/how-to/data-migration/migrate-data-from-8.0-to-8.4.md
@@ -8,7 +8,7 @@ myst:
 # Migrate data from MySQL 8.0 to 8.4
 
 Charmed MySQL 8.4 introduces breaking changes regarding permissions, operator usernames, and refresh mechanisms.
-It is recommended to migrate the data on a manual manner from the 8.0 database to the 8.4 database.
+It is recommended to manually migrate the data from the 8.0 database to the 8.4 database.
 
 There are two possible ways to do so:
 

--- a/docs/how-to/data-migration/migrate-data-from-8.0-to-8.4.md
+++ b/docs/how-to/data-migration/migrate-data-from-8.0-to-8.4.md
@@ -1,0 +1,18 @@
+---
+myst:
+  html_meta:
+    description: "Migrate database data from Charmed MySQL 8.0 to Charmed MySQL 8.4."
+---
+
+(migrate-data-from-8.0-to-8.4)=
+# Migrate data from MySQL 8.0 to 8.4
+
+Charmed MySQL 8.4 introduces breaking changes regarding permissions, operator usernames, and refresh mechanisms.
+It is recommended to migrate the data on a manual manner from the 8.0 database to the 8.4 database.
+
+There are two possible ways to do so:
+
+```{seealso}
+* {ref}`migrate-data-mysqldump`
+* {ref}`migrate-data-mysqlsh`
+```

--- a/docs/how-to/data-migration/migrate-data-via-backup-restore.md
+++ b/docs/how-to/data-migration/migrate-data-via-backup-restore.md
@@ -23,8 +23,8 @@ The approach described below is a general recommendation, but we **cannot guaran
 
 And, as always, try it out in a test environment before migrating in production!
 
-* Retrieve root/admin level credentials from legacy charm.
-  * Example: {ref}`mysqldump-obtain-legacy-credentials`
+* Retrieve root/admin level credentials from the old charm.
+  * Example: {ref}`mysqldump-obtain-existing-credentials`
 * Install [Percona XtraBackup](https://www.percona.com/software/mysql-database/percona-xtrabackup) inside the old charm OR remotely.
   * Ensure the version is compatible with xtrabackup in `Charmed MySQL` revision you are going to deploy. See [installation examples](https://docs.percona.com/percona-xtrabackup/8.4/installation.html).
   * You can also use the [`charmed-mysql` snap](https://snapcraft.io/charmed-mysql) or [rock](https://github.com/canonical/charmed-mysql-rock) directly. For more details, see {ref}`architecture`.
@@ -38,4 +38,3 @@ And, as always, try it out in a test environment before migrating in production!
 * Schedule and perform the final production migration
 
 Do you have questions? {ref}`Contact us <contacts>` if you are interested in such a data migration!
-

--- a/docs/how-to/data-migration/migrate-data-via-mydumper.md
+++ b/docs/how-to/data-migration/migrate-data-via-mydumper.md
@@ -8,6 +8,7 @@ myst:
 # Migrate database data via `mydumper`
 
 This guide describes how to copy data from a MySQL charm to another MySQL charm, regardless of their version (8.0 / 8.4 / ...).
+It does not apply to data migrations from a non charm database, or any legacy type of charm (MariaDB / Percona-cluster / ...).
 
 ```{seealso}
 * {ref}`migrate-data-mysqldump`
@@ -32,49 +33,45 @@ Always perform the migration in a test environment before performing it in produ
 ```shell
 wget https://github.com/mydumper/mydumper/releases/download/v0.15.1-3/mydumper_0.15.1-3.jammy_amd64.deb && \
 sudo apt install ./mydumper_0.15.1-3.jammy_amd64.deb
- ```
+```
 
 ## Obtain existing database credentials
 
 Get username, password and IP of the existing database:
 
-`````{tab-set}
-````{tab-item} VM
+````{tab-set}
+```{tab-item} VM
 :sync: vm
 
-    When the existing database is a MySQL 8.0 charm:
-    ```shell
+When the existing database is a MySQL 8.0 charm:
+
     OLD_DB_USER=$(juju run mysql-80/leader get-password username=serverconfig | yq '.username')
     OLD_DB_PASS=$(juju run mysql-80/leader get-password username=serverconfig | yq '.password')
     OLD_DB_HOST=$(juju show-unit mysql-80/0 | yq '.[] | .address')
-    ```
-    
-    When the existing database is a MySQL 8.4 charm:
-    ```shell
+
+When the existing database is a MySQL 8.4 charm:
+
     OLD_DB_USER=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.username')
     OLD_DB_PASS=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.password')
     OLD_DB_HOST=$(juju show-unit mysql-84/0 | yq '.[] | .address')
-    ```
-````
+```
 
-````{tab-item} K8s
+```{tab-item} K8s
 :sync: k8s
 
-    When the existing database is a MySQL 8.0 charm:
-    ```shell
+When the existing database is a MySQL 8.0 charm:
+
     OLD_DB_USER=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.username')
     OLD_DB_PASS=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.password')
     OLD_DB_HOST=$(juju show-unit mysql-k8s-80/0 | yq '.[] | .address')
-    ```
-    
-    When the existing database is a MySQL 8.4 charm:
-    ```shell
+
+When the existing database is a MySQL 8.4 charm:
+
     OLD_DB_USER=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.username')
     OLD_DB_PASS=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.password')
     OLD_DB_HOST=$(juju show-unit mysql-k8s-84/0 | yq '.[] | .address')
-    ```
+```
 ````
-`````
 
 ### Deploy a new MySQL charm
 
@@ -82,65 +79,61 @@ This step can be skipped if the charm that the data migration will be targeting 
 
 To deploy a new MySQL charm database:
 
-`````{tab-set}
-````{tab-item} VM
+````{tab-set}
+```{tab-item} VM
 :sync: vm
 
     # Use any of the stable channels
     # juju deploy mysql --channel 8.0/stable -n 3
     # juju deploy mysql --channel 8.4/stable -n 3
-````
+```
 
-````{tab-item} K8s
+```{tab-item} K8s
 :sync: k8s
 
     # Use any of the stable channels
     # juju deploy mysql-k8s --channel 8.0/stable -n 3
     # juju deploy mysql-k8s --channel 8.4/stable -n 3
+```
 ````
-`````
 
 ## Obtain new database credentials
 
 Get username, password and IP of the new database:
 
-`````{tab-set}
-````{tab-item} VM
+````{tab-set}
+```{tab-item} VM
 :sync: vm
 
-    When the new database is a MySQL 8.0 charm:
-    ```shell
+When the new database is a MySQL 8.0 charm:
+
     NEW_DB_USER=$(juju run mysql-80/leader get-password username=serverconfig | yq '.username')
     NEW_DB_PASS=$(juju run mysql-80/leader get-password username=serverconfig | yq '.password')
     NEW_DB_HOST=$(juju show-unit mysql-80/0 | yq '.[] | .address')
-    ```
 
-    When the new database is a MySQL 8.4 charm:
-    ```shell
+When the new database is a MySQL 8.4 charm:
+
     NEW_DB_USER=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.username')
     NEW_DB_PASS=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.password')
     NEW_DB_HOST=$(juju show-unit mysql-84/0 | yq '.[] | .address')
-    ```
-````
+```
 
-````{tab-item} K8s
+```{tab-item} K8s
 :sync: k8s
 
-    When the new database is a MySQL 8.0 charm:
-    ```shell
+When the new database is a MySQL 8.0 charm:
+
     NEW_DB_USER=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.username')
     NEW_DB_PASS=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.password')
     NEW_DB_HOST=$(juju show-unit mysql-k8s-80/0 | yq '.[] | .address')
-    ```
-    
-    When the new database is a MySQL 8.4 charm:
-    ```shell
+
+When the new database is a MySQL 8.4 charm:
+
     NEW_DB_USER=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.username')
     NEW_DB_PASS=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.password')
     NEW_DB_HOST=$(juju show-unit mysql-k8s-84/0 | yq '.[] | .address')
-    ```
+```
 ````
-`````
 
 ## Migrate database
 

--- a/docs/how-to/data-migration/migrate-data-via-mydumper.md
+++ b/docs/how-to/data-migration/migrate-data-via-mydumper.md
@@ -45,15 +45,15 @@ Get username, password and IP of the existing database:
 
 When the existing database is a MySQL 8.0 charm:
 
-    OLD_DB_USER=$(juju run mysql-80/leader get-password username=serverconfig | yq '.username')
-    OLD_DB_PASS=$(juju run mysql-80/leader get-password username=serverconfig | yq '.password')
-    OLD_DB_HOST=$(juju show-unit mysql-80/0 | yq '.[] | .address')
+    OLD_DB_USER=$(juju run mysql/leader get-password username=serverconfig | yq '.username')
+    OLD_DB_PASS=$(juju run mysql/leader get-password username=serverconfig | yq '.password')
+    OLD_DB_HOST=$(juju show-unit mysql/0 | yq '.[] | .address')
 
 When the existing database is a MySQL 8.4 charm:
 
-    OLD_DB_USER=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.username')
-    OLD_DB_PASS=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.password')
-    OLD_DB_HOST=$(juju show-unit mysql-84/0 | yq '.[] | .address')
+    OLD_DB_USER=$(juju run mysql/leader get-password username=charmed-operator | yq '.username')
+    OLD_DB_PASS=$(juju run mysql/leader get-password username=charmed-operator | yq '.password')
+    OLD_DB_HOST=$(juju show-unit mysql/0 | yq '.[] | .address')
 ```
 
 ```{tab-item} K8s
@@ -61,15 +61,15 @@ When the existing database is a MySQL 8.4 charm:
 
 When the existing database is a MySQL 8.0 charm:
 
-    OLD_DB_USER=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.username')
-    OLD_DB_PASS=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.password')
-    OLD_DB_HOST=$(juju show-unit mysql-k8s-80/0 | yq '.[] | .address')
+    OLD_DB_USER=$(juju run mysql-k8s/leader get-password username=serverconfig | yq '.username')
+    OLD_DB_PASS=$(juju run mysql-k8s/leader get-password username=serverconfig | yq '.password')
+    OLD_DB_HOST=$(juju show-unit mysql-k8s/0 | yq '.[] | .address')
 
 When the existing database is a MySQL 8.4 charm:
 
-    OLD_DB_USER=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.username')
-    OLD_DB_PASS=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.password')
-    OLD_DB_HOST=$(juju show-unit mysql-k8s-84/0 | yq '.[] | .address')
+    OLD_DB_USER=$(juju run mysql-k8s/leader get-password username=charmed-operator | yq '.username')
+    OLD_DB_PASS=$(juju run mysql-k8s/leader get-password username=charmed-operator | yq '.password')
+    OLD_DB_HOST=$(juju show-unit mysql-k8s/0 | yq '.[] | .address')
 ```
 ````
 
@@ -103,15 +103,15 @@ Get username, password and IP of the new database:
 
 When the new database is a MySQL 8.0 charm:
 
-    NEW_DB_USER=$(juju run mysql-80/leader get-password username=serverconfig | yq '.username')
-    NEW_DB_PASS=$(juju run mysql-80/leader get-password username=serverconfig | yq '.password')
-    NEW_DB_HOST=$(juju show-unit mysql-80/0 | yq '.[] | .address')
+    NEW_DB_USER=$(juju run mysql/leader get-password username=serverconfig | yq '.username')
+    NEW_DB_PASS=$(juju run mysql/leader get-password username=serverconfig | yq '.password')
+    NEW_DB_HOST=$(juju show-unit mysql/0 | yq '.[] | .address')
 
 When the new database is a MySQL 8.4 charm:
 
-    NEW_DB_USER=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.username')
-    NEW_DB_PASS=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.password')
-    NEW_DB_HOST=$(juju show-unit mysql-84/0 | yq '.[] | .address')
+    NEW_DB_USER=$(juju run mysql/leader get-password username=charmed-operator | yq '.username')
+    NEW_DB_PASS=$(juju run mysql/leader get-password username=charmed-operator | yq '.password')
+    NEW_DB_HOST=$(juju show-unit mysql/0 | yq '.[] | .address')
 ```
 
 ```{tab-item} K8s
@@ -119,15 +119,15 @@ When the new database is a MySQL 8.4 charm:
 
 When the new database is a MySQL 8.0 charm:
 
-    NEW_DB_USER=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.username')
-    NEW_DB_PASS=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.password')
-    NEW_DB_HOST=$(juju show-unit mysql-k8s-80/0 | yq '.[] | .address')
+    NEW_DB_USER=$(juju run mysql-k8s/leader get-password username=serverconfig | yq '.username')
+    NEW_DB_PASS=$(juju run mysql-k8s/leader get-password username=serverconfig | yq '.password')
+    NEW_DB_HOST=$(juju show-unit mysql-k8s/0 | yq '.[] | .address')
 
 When the new database is a MySQL 8.4 charm:
 
-    NEW_DB_USER=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.username')
-    NEW_DB_PASS=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.password')
-    NEW_DB_HOST=$(juju show-unit mysql-k8s-84/0 | yq '.[] | .address')
+    NEW_DB_USER=$(juju run mysql-k8s/leader get-password username=charmed-operator | yq '.username')
+    NEW_DB_PASS=$(juju run mysql-k8s/leader get-password username=charmed-operator | yq '.password')
+    NEW_DB_HOST=$(juju show-unit mysql-k8s/0 | yq '.[] | .address')
 ```
 ````
 

--- a/docs/how-to/data-migration/migrate-data-via-mydumper.md
+++ b/docs/how-to/data-migration/migrate-data-via-mydumper.md
@@ -1,71 +1,154 @@
 ---
 myst:
   html_meta:
-    description: "Migrate MySQL data using mydumper and myloader: install tools, dump from source with serverconfig credentials, and import into Charmed MySQL."
+    description: "Migrate MySQL data using mydumper: install tools, dump and import into Charmed MySQL."
 ---
 
 (migrate-data-mydumper)=
-# Migrate data via mydumper
+# Migrate database data via `mydumper`
 
-[mydumper](https://github.com/mydumper/mydumper) is a powerful MySQL logical data-migration tool. It includes
+This guide describes how to copy data from a MySQL charm to another MySQL charm, regardless of their version (8.0 / 8.4 / ...).
 
-* `mydumper` - responsible to export a consistent of MySQL databases
-* `myloader` - reads the dump from mydumper, connects the to destination database and imports the data
-
-Both tools use multi-threading capabilities and support S3 storage to write/read dumps. <!--MyDumper is Open Source and maintained by the community, it is not a Percona, MariaDB, MySQL or Canonical product.-->
+```{seealso}
+* {ref}`migrate-data-mysqldump`
+* {ref}`migrate-data-mysqlsh`
+* {ref}`migrate-data-backup-restore`
+```
 
 ## Prepare
 
 Before migrating data, verify the {ref}`system-requirements`.
 
-## Install `mydumper`
+```{caution}
+Always perform the migration in a test environment before performing it in production!
+```
 
-Install the latest version from [GitHub](https://github.com/mydumper/mydumper/releases):
+## Prerequisites
+
+- Client machine with access to deployed legacy charm
+- Enough storage in the cluster to support backup/restore of the databases
+- `mydumper` on client machine (install the latest version from [GitHub](https://github.com/mydumper/mydumper/releases)):
 
 ```shell
 wget https://github.com/mydumper/mydumper/releases/download/v0.15.1-3/mydumper_0.15.1-3.jammy_amd64.deb && \
 sudo apt install ./mydumper_0.15.1-3.jammy_amd64.deb
-```
+ ```
 
-## Dump database
+## Obtain existing database credentials
 
-Dump database using Charmed MySQL operator user `charmed-operator`:
+Get username, password and IP of the existing database:
 
-
-````{tab-set}
-```{tab-item} VM
+`````{tab-set}
+````{tab-item} VM
 :sync: vm
 
-    # Collect credentials
-    DB_NAME=<your_db_name>
-    OLD_DB_IP=$(juju show-unit mysql/0 | yq '.[] | .public-address')
-    OLD_DB_USER=serverconfig
-    OLD_DB_PASS=$(juju run mysql/leader get-password username=${OLD_DB_USER}| yq '.password')
-
-    # Test connection
-    mysql -h ${OLD_DB_IP} -u ${OLD_DB_USER} --password=${OLD_DB_PASS} ${DB_NAME}
-
-    # Dump database using mydumper
-    mydumper -h ${OLD_DB_IP} -u ${OLD_DB_USER} -p ${OLD_DB_PASS} -B ${DB_NAME}
-```
-
-```{tab-item} K8s
-:sync: k8s
-
-    # Collect credentials
-    DB_NAME=<your_db_name>
-    OLD_DB_IP=$(juju show-unit mysql-k8s/0 | yq '.[] | .public-address')
-    OLD_DB_USER=serverconfig
-    OLD_DB_PASS=$(juju run mysql-k8s/leader get-password username=${OLD_DB_USER}| yq '.password')
-
-    # Test connection
-    mysql -h ${OLD_DB_IP} -u ${OLD_DB_USER} --password=${OLD_DB_PASS} ${DB_NAME}
-
-    # Dump database using mydumper
-    mydumper -h ${OLD_DB_IP} -u ${OLD_DB_USER} -p ${OLD_DB_PASS} -B ${DB_NAME}
-```
+    When the existing database is a MySQL 8.0 charm:
+    ```shell
+    OLD_DB_USER=$(juju run mysql-80/leader get-password username=serverconfig | yq '.username')
+    OLD_DB_PASS=$(juju run mysql-80/leader get-password username=serverconfig | yq '.password')
+    OLD_DB_HOST=$(juju show-unit mysql-80/0 | yq '.[] | .address')
+    ```
+    
+    When the existing database is a MySQL 8.4 charm:
+    ```shell
+    OLD_DB_USER=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.username')
+    OLD_DB_PASS=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.password')
+    OLD_DB_HOST=$(juju show-unit mysql-84/0 | yq '.[] | .address')
+    ```
 ````
 
+````{tab-item} K8s
+:sync: k8s
+
+    When the existing database is a MySQL 8.0 charm:
+    ```shell
+    OLD_DB_USER=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.username')
+    OLD_DB_PASS=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.password')
+    OLD_DB_HOST=$(juju show-unit mysql-k8s-80/0 | yq '.[] | .address')
+    ```
+    
+    When the existing database is a MySQL 8.4 charm:
+    ```shell
+    OLD_DB_USER=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.username')
+    OLD_DB_PASS=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.password')
+    OLD_DB_HOST=$(juju show-unit mysql-k8s-84/0 | yq '.[] | .address')
+    ```
+````
+`````
+
+### Deploy a new MySQL charm
+
+This step can be skipped if the charm that the data migration will be targeting is already deployed.
+
+To deploy a new MySQL charm database:
+
+`````{tab-set}
+````{tab-item} VM
+:sync: vm
+
+    # Use any of the stable channels
+    # juju deploy mysql --channel 8.0/stable -n 3
+    # juju deploy mysql --channel 8.4/stable -n 3
+````
+
+````{tab-item} K8s
+:sync: k8s
+
+    # Use any of the stable channels
+    # juju deploy mysql-k8s --channel 8.0/stable -n 3
+    # juju deploy mysql-k8s --channel 8.4/stable -n 3
+````
+`````
+
+## Obtain new database credentials
+
+Get username, password and IP of the new database:
+
+`````{tab-set}
+````{tab-item} VM
+:sync: vm
+
+    When the new database is a MySQL 8.0 charm:
+    ```shell
+    NEW_DB_USER=$(juju run mysql-80/leader get-password username=serverconfig | yq '.username')
+    NEW_DB_PASS=$(juju run mysql-80/leader get-password username=serverconfig | yq '.password')
+    NEW_DB_HOST=$(juju show-unit mysql-80/0 | yq '.[] | .address')
+    ```
+
+    When the new database is a MySQL 8.4 charm:
+    ```shell
+    NEW_DB_USER=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.username')
+    NEW_DB_PASS=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.password')
+    NEW_DB_HOST=$(juju show-unit mysql-84/0 | yq '.[] | .address')
+    ```
+````
+
+````{tab-item} K8s
+:sync: k8s
+
+    When the new database is a MySQL 8.0 charm:
+    ```shell
+    NEW_DB_USER=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.username')
+    NEW_DB_PASS=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.password')
+    NEW_DB_HOST=$(juju show-unit mysql-k8s-80/0 | yq '.[] | .address')
+    ```
+    
+    When the new database is a MySQL 8.4 charm:
+    ```shell
+    NEW_DB_USER=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.username')
+    NEW_DB_PASS=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.password')
+    NEW_DB_HOST=$(juju show-unit mysql-k8s-84/0 | yq '.[] | .address')
+    ```
+````
+`````
+
+## Migrate database
+
+Dump database using the existing Charmed MySQL operator username, password and IP:
+
+```shell
+mydumper -h ${OLD_DB_HOST} -u ${OLD_DB_USER} -p ${OLD_DB_PASS} -B <your_db_name>
+```
 
 The content of the database dump is stored in a newly created folder, e.g. `export-20230927-123337` (which can be stored on S3-compatible storage):
 
@@ -82,13 +165,8 @@ drwxr-x--- 18 ubuntu ubuntu   4096 Sep 27 12:34 ..
 -rw-rw-r--  1 ubuntu ubuntu    499 Sep 27 12:33 metadata
 ```
 
-## Restore
+Restore database using the new Charmed MySQL operator username, password and IP:
 
 ```shell
-NEW_DB_IP=...
-NEW_DB_USER=charmed-operator
-NEW_DB_PASS=...
-
-myloader -h ${NEW_DB_IP} -u ${NEW_DB_USER} -p ${NEW_DB_PASS} --directory=export-20230927-123337 --overwrite-tables
+myloader -h ${NEW_DB_HOST} -u ${NEW_DB_USER} -p ${NEW_DB_PASS} --directory=export-20230927-123337 --overwrite-tables
 ```
-

--- a/docs/how-to/data-migration/migrate-data-via-mydumper.md
+++ b/docs/how-to/data-migration/migrate-data-via-mydumper.md
@@ -83,17 +83,13 @@ To deploy a new MySQL charm database:
 ```{tab-item} VM
 :sync: vm
 
-    # Use any of the stable channels
-    # juju deploy mysql --channel 8.0/stable -n 3
-    # juju deploy mysql --channel 8.4/stable -n 3
+    juju deploy mysql --channel 8.4/stable -n 3
 ```
 
 ```{tab-item} K8s
 :sync: k8s
 
-    # Use any of the stable channels
-    # juju deploy mysql-k8s --channel 8.0/stable -n 3
-    # juju deploy mysql-k8s --channel 8.4/stable -n 3
+    juju deploy mysql-k8s --channel 8.4/stable -n 3
 ```
 ````
 

--- a/docs/how-to/data-migration/migrate-data-via-mysqldump.md
+++ b/docs/how-to/data-migration/migrate-data-via-mysqldump.md
@@ -1,60 +1,21 @@
 ---
 myst:
   html_meta:
-    description: "Migrate database data from legacy MySQL or MariaDB charms to modern Charmed MySQL using mysqldump, with environment preparation and migration checks."
+    description: "Migrate database data using mysqldump, with environment preparation and migration checks."
 ---
 
 (migrate-data-mysqldump)=
 # Migrate database data via `mysqldump`
 
-This guide describes how to copy data:
-* from a legacy MySQL charm to a modern MySQL charm
-* from a modern MySQL charm to a different installation of the same modern MySQL charm. 
+This guide describes how to copy data from a MySQL charm to another MySQL charm, regardless of their version (8.0 / 8.4 / ...).
 
 Note that this guide describes how to migrate database **data** only.
 
 ```{seealso}
 * {ref}`migrate-data-mydumper`
-* {ref}`migrate-data-backup-restore` (recommended for migrations between modern charms)
+* {ref}`migrate-data-mysqlsh`
+* {ref}`migrate-data-backup-restore`
 ```
-
-## Do you need to migrate?
-
-`````{tab-set}
-````{tab-item} VM
-:sync: vm
-
-Legacy MariaDB/MySQL charms for **machines**:
-
-* [MariaDB](https://charmhub.io/mariadb)
-* [Percona Cluster](https://charmhub.io/percona-cluster)
-* [MySQL InnoDB Cluster](https://charmhub.io/mysql-innodb-cluster)
-
-To check if a database migration is required, run the following commands, where `DB_CHARM` is the name of your legacy database application:
-
-```shell
-DB_CHARM= < mariadb | percona-cluster | mysql-innodb-cluster >
-juju show-application ${DB_CHARM} | yq '.[] | .charm'
-```
-````
-
-````{tab-item} K8s
-:sync: k8s
-
-Legacy MariaDB/MySQL charms for **Kubernetes**:
-
-* [OSM MariaDB K8s](https://charmhub.io/charmed-osm-mariadb-k8s)
-
-To check if a database migration is required, run the following commands, where `DB_CHARM` is the name of your legacy database application:
-
-```shell
-DB_CHARM= < mydb | charmed-osm-mariadb-k8s >
-juju show-application ${DB_CHARM} | yq '.[] | .charm'
-```
-````
-`````
-
-No migration is necessary if the output above is `mysql`.
 
 ## Prepare
 
@@ -67,108 +28,128 @@ Always perform the migration in a test environment before performing it in produ
 ## Prerequisites
 
 - Client machine with access to deployed legacy charm
-- Juju 3.6 or later
-  - See also: {ref}`upgrade-juju`
 - Enough storage in the cluster to support backup/restore of the databases
 - `mysql-client` on client machine (install by running `sudo apt install mysql-client`)
 
-```{caution}
-Most legacy database charms support old Ubuntu series only, while [Juju 3.x does NOT support Ubuntu Bionic](https://documentation.ubuntu.com/juju/3.6/releasenotes/unsupported/juju_3.x.x/#juju-3-0-0-22-oct-2022).
-
-It is recommended to use the latest stable revision of the charm on Ubuntu Jammy and Juju 3.x
-```
-
-(mysqldump-obtain-legacy-credentials)=
+(mysqldump-obtain-existing-credentials)=
 ## Obtain existing database credentials
 
-Set `DB_APP` to the name of the desired unit: 
+Get username, password and IP of the existing database:
 
 `````{tab-set}
 ````{tab-item} VM
 :sync: vm
 
-```shell
-DB_APP= < mariadb/0 | percona-cluster/leader | mysql-innodb-cluster/1 >
-```
-
+    When the existing database is a MySQL 8.0 charm:
+    ```shell
+    OLD_DB_USER=$(juju run mysql-80/leader get-password username=serverconfig | yq '.username')
+    OLD_DB_PASS=$(juju run mysql-80/leader get-password username=serverconfig | yq '.password')
+    OLD_DB_HOST=$(juju show-unit mysql-80/0 | yq '.[] | .address')
+    ```
+    
+    When the existing database is a MySQL 8.4 charm:
+    ```shell
+    OLD_DB_USER=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.username')
+    OLD_DB_PASS=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.password')
+    OLD_DB_HOST=$(juju show-unit mysql-84/0 | yq '.[] | .address')
+    ```
 ````
+
 ````{tab-item} K8s
 :sync: k8s
 
-```shell
-DB_APP= < mydb/0 | charmed-osm-mariadb-k8s/0 >
-```
+    When the existing database is a MySQL 8.0 charm:
+    ```shell
+    OLD_DB_USER=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.username')
+    OLD_DB_PASS=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.password')
+    OLD_DB_HOST=$(juju show-unit mysql-k8s-80/0 | yq '.[] | .address')
+    ```
+    
+    When the existing database is a MySQL 8.4 charm:
+    ```shell
+    OLD_DB_USER=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.username')
+    OLD_DB_PASS=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.password')
+    OLD_DB_HOST=$(juju show-unit mysql-k8s-84/0 | yq '.[] | .address')
+    ```
 ````
 `````
 
-Get username and password of the existing legacy database from the database relation. The username is usually `root`, and the password is specified in the `mysql` relation by `root_password`:
+### Deploy a new MySQL charm
 
-```shell
-OLD_DB_RELATION_ID=$(juju show-unit ${DB_APP} | yq '.[] | .relation-info | select(.[].endpoint == "mysql") | .[0] | .relation-id')
+This step can be skipped if the charm that the data migration will be targeting is already deployed.
 
-OLD_DB_USER=root
-
-OLD_DB_PASS=$(bash -c "juju run --unit ${DB_APP} 'relation-get -r ${OLD_DB_RELATION_ID} - ${DB_APP}' | grep root_password" | awk '{print $2}')
-
-OLD_DB_IP=$(juju show-unit ${DB_APP} | yq '.[] | .address')
-```
-
-
-## Deploy new MySQL databases and obtain credentials
-
-Deploy new MySQL databases. In this example, 3 units are deployed:
+To deploy a new MySQL charm database:
 
 `````{tab-set}
 ````{tab-item} VM
 :sync: vm
 
-```shell
-juju deploy mysql --channel 8.4/edge -n 3
-```
-
-Obtain credentials for each new database by executing the following commands, once per database:
-
-```shell
-NEW_DB_USER=$(juju run mysql/leader get-password | yq '.username')
-NEW_DB_PASS=$(juju run mysql/leader get-password | yq '.password')
-NEW_DB_IP=$(juju show-unit mysql/0 | yq '.[] | .address')
-```
-
+    # Use any of the stable channels
+    # juju deploy mysql --channel 8.0/stable -n 3
+    # juju deploy mysql --channel 8.4/stable -n 3
 ````
+
 ````{tab-item} K8s
 :sync: k8s
 
-```shell
-juju deploy mysql-k8s --trust --channel 8.4/edge -n 3
-```
+    # Use any of the stable channels
+    # juju deploy mysql-k8s --channel 8.0/stable -n 3
+    # juju deploy mysql-k8s --channel 8.4/stable -n 3
+````
+`````
 
-Obtain credentials for each new database by executing the following commands, once per database:
+## Obtain new database credentials
 
-```shell
-NEW_DB_USER=$(juju run mysql-k8s/leader get-password | yq '.username')
-NEW_DB_PASS=$(juju run mysql-k8s/leader get-password | yq '.password')
-NEW_DB_IP=$(juju show-unit mysql-k8s/0 | yq '.[] | .address')
-```
+Get username, password and IP of the new database:
+
+`````{tab-set}
+````{tab-item} VM
+:sync: vm
+
+    When the new database is a MySQL 8.0 charm:
+    ```shell
+    NEW_DB_USER=$(juju run mysql-80/leader get-password username=serverconfig | yq '.username')
+    NEW_DB_PASS=$(juju run mysql-80/leader get-password username=serverconfig | yq '.password')
+    NEW_DB_HOST=$(juju show-unit mysql-80/0 | yq '.[] | .address')
+    ```
+
+    When the new database is a MySQL 8.4 charm:
+    ```shell
+    NEW_DB_USER=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.username')
+    NEW_DB_PASS=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.password')
+    NEW_DB_HOST=$(juju show-unit mysql-84/0 | yq '.[] | .address')
+    ```
+````
+
+````{tab-item} K8s
+:sync: k8s
+
+    When the new database is a MySQL 8.0 charm:
+    ```shell
+    NEW_DB_USER=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.username')
+    NEW_DB_PASS=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.password')
+    NEW_DB_HOST=$(juju show-unit mysql-k8s-80/0 | yq '.[] | .address')
+    ```
+    
+    When the new database is a MySQL 8.4 charm:
+    ```shell
+    NEW_DB_USER=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.username')
+    NEW_DB_PASS=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.password')
+    NEW_DB_HOST=$(juju show-unit mysql-k8s-84/0 | yq '.[] | .address')
+    ```
 ````
 `````
 
 ## Migrate database
 
 The next step is to use the credentials and information obtained in previous steps to perform the database migration.
-
-First, ensure that there are no new connections are made and that database is not altered.
-
-Remove the relation between your charm and the legacy MySQL charm:
-
-```shell
-juju remove-relation <your_application> <legacy_charm>
-```
+Ensure that there are no new connections are made and that database is not altered.
 
 Connect to the legacy database to verify the connection:
 
 ```shell
 mysql \
-  --host=${OLD_DB_IP} \
+  --host=${OLD_DB_HOST} \
   --user=${OLD_DB_USER} \
   --password=${OLD_DB_PASS} \
   -e "show databases"
@@ -186,7 +167,7 @@ Create a backup of each database file using the `mysqldump` utility, username, p
 OLD_DB_DUMP="legacy-mysql-${DB_NAME}.sql"
 
 mysqldump \
-  --host=${OLD_DB_IP} \
+  --host=${OLD_DB_HOST} \
   --user=${OLD_DB_USER} \
   --password=${OLD_DB_PASS} \
   --column-statistics=0 \
@@ -198,7 +179,7 @@ Connect to the new database using username, password, and unit's IP address, and
 
 ```shell
 mysql \
-  --host=${NEW_DB_IP} \
+  --host=${NEW_DB_HOST} \
   --user=${NEW_DB_USER} \
   --password=${NEW_DB_PASS} \
   < "${OLD_DB_DUMP}"
@@ -229,7 +210,7 @@ Create a dump for the new MySQL database and compare it to the backup created ea
 ```shell
 NEW_DB_DUMP="new-mysql-${DB_NAME}.sql"
 mysqldump \
---host=${NEW_DB_IP} \
+--host=${NEW_DB_HOST} \
 --user=${NEW_DB_USER} \
 --password=${NEW_DB_PASS} \
 --column-statistics=0 \
@@ -237,10 +218,6 @@ mysqldump \
 
 > "${NEW_DB_DUMP}"
 diff "${OLD_DB_DUMP}" "${NEW_DB_DUMP}"
-```
-
-```{note}
-Some variables will vary between legacy and modern charms, namely: `${NEW_DB_PASS}` and `${NEW_DB_IP}`. These must be adjusted for the correct database, accordingly.
 ```
 
 The difference between two SQL backup files should be limited to server versions, IP addresses, timestamps and other non data related information. 
@@ -298,5 +275,5 @@ Output:
 Test your application and if you are happy with a data migration, do not forget to remove legacy charms to keep the house clean:
 
 ```shell
-juju remove-application --destroy-storage <legacy_charm>
+juju remove-application --destroy-storage <old_charm>
 ```

--- a/docs/how-to/data-migration/migrate-data-via-mysqldump.md
+++ b/docs/how-to/data-migration/migrate-data-via-mysqldump.md
@@ -81,17 +81,13 @@ To deploy a new MySQL charm database:
 ```{tab-item} VM
 :sync: vm
 
-    # Use any of the stable channels
-    # juju deploy mysql --channel 8.0/stable -n 3
-    # juju deploy mysql --channel 8.4/stable -n 3
+    juju deploy mysql --channel 8.4/edge -n 3
 ```
 
 ```{tab-item} K8s
 :sync: k8s
 
-    # Use any of the stable channels
-    # juju deploy mysql-k8s --channel 8.0/stable -n 3
-    # juju deploy mysql-k8s --channel 8.4/stable -n 3
+    juju deploy mysql-k8s --channel 8.4/edge -n 3
 ```
 ````
 

--- a/docs/how-to/data-migration/migrate-data-via-mysqldump.md
+++ b/docs/how-to/data-migration/migrate-data-via-mysqldump.md
@@ -8,6 +8,7 @@ myst:
 # Migrate database data via `mysqldump`
 
 This guide describes how to copy data from a MySQL charm to another MySQL charm, regardless of their version (8.0 / 8.4 / ...).
+It does not apply to data migrations from a non charm database, or any legacy type of charm (MariaDB / Percona-cluster / ...).
 
 Note that this guide describes how to migrate database **data** only.
 
@@ -36,43 +37,39 @@ Always perform the migration in a test environment before performing it in produ
 
 Get username, password and IP of the existing database:
 
-`````{tab-set}
-````{tab-item} VM
+````{tab-set}
+```{tab-item} VM
 :sync: vm
 
-    When the existing database is a MySQL 8.0 charm:
-    ```shell
+When the existing database is a MySQL 8.0 charm:
+
     OLD_DB_USER=$(juju run mysql-80/leader get-password username=serverconfig | yq '.username')
     OLD_DB_PASS=$(juju run mysql-80/leader get-password username=serverconfig | yq '.password')
     OLD_DB_HOST=$(juju show-unit mysql-80/0 | yq '.[] | .address')
-    ```
-    
-    When the existing database is a MySQL 8.4 charm:
-    ```shell
+
+When the existing database is a MySQL 8.4 charm:
+
     OLD_DB_USER=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.username')
     OLD_DB_PASS=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.password')
     OLD_DB_HOST=$(juju show-unit mysql-84/0 | yq '.[] | .address')
-    ```
-````
+```
 
-````{tab-item} K8s
+```{tab-item} K8s
 :sync: k8s
 
-    When the existing database is a MySQL 8.0 charm:
-    ```shell
+When the existing database is a MySQL 8.0 charm:
+
     OLD_DB_USER=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.username')
     OLD_DB_PASS=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.password')
     OLD_DB_HOST=$(juju show-unit mysql-k8s-80/0 | yq '.[] | .address')
-    ```
-    
-    When the existing database is a MySQL 8.4 charm:
-    ```shell
+
+When the existing database is a MySQL 8.4 charm:
+
     OLD_DB_USER=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.username')
     OLD_DB_PASS=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.password')
     OLD_DB_HOST=$(juju show-unit mysql-k8s-84/0 | yq '.[] | .address')
-    ```
+```
 ````
-`````
 
 ### Deploy a new MySQL charm
 
@@ -80,65 +77,61 @@ This step can be skipped if the charm that the data migration will be targeting 
 
 To deploy a new MySQL charm database:
 
-`````{tab-set}
-````{tab-item} VM
+````{tab-set}
+```{tab-item} VM
 :sync: vm
 
     # Use any of the stable channels
     # juju deploy mysql --channel 8.0/stable -n 3
     # juju deploy mysql --channel 8.4/stable -n 3
-````
+```
 
-````{tab-item} K8s
+```{tab-item} K8s
 :sync: k8s
 
     # Use any of the stable channels
     # juju deploy mysql-k8s --channel 8.0/stable -n 3
     # juju deploy mysql-k8s --channel 8.4/stable -n 3
+```
 ````
-`````
 
 ## Obtain new database credentials
 
 Get username, password and IP of the new database:
 
-`````{tab-set}
-````{tab-item} VM
+````{tab-set}
+```{tab-item} VM
 :sync: vm
 
-    When the new database is a MySQL 8.0 charm:
-    ```shell
+When the new database is a MySQL 8.0 charm:
+
     NEW_DB_USER=$(juju run mysql-80/leader get-password username=serverconfig | yq '.username')
     NEW_DB_PASS=$(juju run mysql-80/leader get-password username=serverconfig | yq '.password')
     NEW_DB_HOST=$(juju show-unit mysql-80/0 | yq '.[] | .address')
-    ```
 
-    When the new database is a MySQL 8.4 charm:
-    ```shell
+When the new database is a MySQL 8.4 charm:
+
     NEW_DB_USER=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.username')
     NEW_DB_PASS=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.password')
     NEW_DB_HOST=$(juju show-unit mysql-84/0 | yq '.[] | .address')
-    ```
-````
+```
 
-````{tab-item} K8s
+```{tab-item} K8s
 :sync: k8s
 
-    When the new database is a MySQL 8.0 charm:
-    ```shell
+When the new database is a MySQL 8.0 charm:
+
     NEW_DB_USER=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.username')
     NEW_DB_PASS=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.password')
     NEW_DB_HOST=$(juju show-unit mysql-k8s-80/0 | yq '.[] | .address')
-    ```
-    
-    When the new database is a MySQL 8.4 charm:
-    ```shell
+
+When the new database is a MySQL 8.4 charm:
+
     NEW_DB_USER=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.username')
     NEW_DB_PASS=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.password')
     NEW_DB_HOST=$(juju show-unit mysql-k8s-84/0 | yq '.[] | .address')
-    ```
+```
 ````
-`````
 
 ## Migrate database
 
@@ -210,13 +203,13 @@ Create a dump for the new MySQL database and compare it to the backup created ea
 ```shell
 NEW_DB_DUMP="new-mysql-${DB_NAME}.sql"
 mysqldump \
---host=${NEW_DB_HOST} \
---user=${NEW_DB_USER} \
---password=${NEW_DB_PASS} \
---column-statistics=0 \
---databases ${DB_NAME} \
+  --host=${NEW_DB_HOST} \
+  --user=${NEW_DB_USER} \
+  --password=${NEW_DB_PASS} \
+  --column-statistics=0 \
+  --databases ${DB_NAME} \
+  > "${NEW_DB_DUMP}"
 
-> "${NEW_DB_DUMP}"
 diff "${OLD_DB_DUMP}" "${NEW_DB_DUMP}"
 ```
 

--- a/docs/how-to/data-migration/migrate-data-via-mysqldump.md
+++ b/docs/how-to/data-migration/migrate-data-via-mysqldump.md
@@ -43,15 +43,15 @@ Get username, password and IP of the existing database:
 
 When the existing database is a MySQL 8.0 charm:
 
-    OLD_DB_USER=$(juju run mysql-80/leader get-password username=serverconfig | yq '.username')
-    OLD_DB_PASS=$(juju run mysql-80/leader get-password username=serverconfig | yq '.password')
-    OLD_DB_HOST=$(juju show-unit mysql-80/0 | yq '.[] | .address')
+    OLD_DB_USER=$(juju run mysql/leader get-password username=serverconfig | yq '.username')
+    OLD_DB_PASS=$(juju run mysql/leader get-password username=serverconfig | yq '.password')
+    OLD_DB_HOST=$(juju show-unit mysql/0 | yq '.[] | .address')
 
 When the existing database is a MySQL 8.4 charm:
 
-    OLD_DB_USER=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.username')
-    OLD_DB_PASS=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.password')
-    OLD_DB_HOST=$(juju show-unit mysql-84/0 | yq '.[] | .address')
+    OLD_DB_USER=$(juju run mysql/leader get-password username=charmed-operator | yq '.username')
+    OLD_DB_PASS=$(juju run mysql/leader get-password username=charmed-operator | yq '.password')
+    OLD_DB_HOST=$(juju show-unit mysql/0 | yq '.[] | .address')
 ```
 
 ```{tab-item} K8s
@@ -59,15 +59,15 @@ When the existing database is a MySQL 8.4 charm:
 
 When the existing database is a MySQL 8.0 charm:
 
-    OLD_DB_USER=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.username')
-    OLD_DB_PASS=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.password')
-    OLD_DB_HOST=$(juju show-unit mysql-k8s-80/0 | yq '.[] | .address')
+    OLD_DB_USER=$(juju run mysql-k8s/leader get-password username=serverconfig | yq '.username')
+    OLD_DB_PASS=$(juju run mysql-k8s/leader get-password username=serverconfig | yq '.password')
+    OLD_DB_HOST=$(juju show-unit mysql-k8s/0 | yq '.[] | .address')
 
 When the existing database is a MySQL 8.4 charm:
 
-    OLD_DB_USER=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.username')
-    OLD_DB_PASS=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.password')
-    OLD_DB_HOST=$(juju show-unit mysql-k8s-84/0 | yq '.[] | .address')
+    OLD_DB_USER=$(juju run mysql-k8s/leader get-password username=charmed-operator | yq '.username')
+    OLD_DB_PASS=$(juju run mysql-k8s/leader get-password username=charmed-operator | yq '.password')
+    OLD_DB_HOST=$(juju show-unit mysql-k8s/0 | yq '.[] | .address')
 ```
 ````
 
@@ -101,15 +101,15 @@ Get username, password and IP of the new database:
 
 When the new database is a MySQL 8.0 charm:
 
-    NEW_DB_USER=$(juju run mysql-80/leader get-password username=serverconfig | yq '.username')
-    NEW_DB_PASS=$(juju run mysql-80/leader get-password username=serverconfig | yq '.password')
-    NEW_DB_HOST=$(juju show-unit mysql-80/0 | yq '.[] | .address')
+    NEW_DB_USER=$(juju run mysql/leader get-password username=serverconfig | yq '.username')
+    NEW_DB_PASS=$(juju run mysql/leader get-password username=serverconfig | yq '.password')
+    NEW_DB_HOST=$(juju show-unit mysql/0 | yq '.[] | .address')
 
 When the new database is a MySQL 8.4 charm:
 
-    NEW_DB_USER=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.username')
-    NEW_DB_PASS=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.password')
-    NEW_DB_HOST=$(juju show-unit mysql-84/0 | yq '.[] | .address')
+    NEW_DB_USER=$(juju run mysql/leader get-password username=charmed-operator | yq '.username')
+    NEW_DB_PASS=$(juju run mysql/leader get-password username=charmed-operator | yq '.password')
+    NEW_DB_HOST=$(juju show-unit mysql/0 | yq '.[] | .address')
 ```
 
 ```{tab-item} K8s
@@ -117,15 +117,15 @@ When the new database is a MySQL 8.4 charm:
 
 When the new database is a MySQL 8.0 charm:
 
-    NEW_DB_USER=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.username')
-    NEW_DB_PASS=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.password')
-    NEW_DB_HOST=$(juju show-unit mysql-k8s-80/0 | yq '.[] | .address')
+    NEW_DB_USER=$(juju run mysql-k8s/leader get-password username=serverconfig | yq '.username')
+    NEW_DB_PASS=$(juju run mysql-k8s/leader get-password username=serverconfig | yq '.password')
+    NEW_DB_HOST=$(juju show-unit mysql-k8s/0 | yq '.[] | .address')
 
 When the new database is a MySQL 8.4 charm:
 
-    NEW_DB_USER=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.username')
-    NEW_DB_PASS=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.password')
-    NEW_DB_HOST=$(juju show-unit mysql-k8s-84/0 | yq '.[] | .address')
+    NEW_DB_USER=$(juju run mysql-k8s/leader get-password username=charmed-operator | yq '.username')
+    NEW_DB_PASS=$(juju run mysql-k8s/leader get-password username=charmed-operator | yq '.password')
+    NEW_DB_HOST=$(juju show-unit mysql-k8s/0 | yq '.[] | .address')
 ```
 ````
 

--- a/docs/how-to/data-migration/migrate-data-via-mysqlsh.md
+++ b/docs/how-to/data-migration/migrate-data-via-mysqlsh.md
@@ -79,17 +79,13 @@ To deploy a new MySQL charm database:
 ```{tab-item} VM
 :sync: vm
 
-    # Use any of the stable channels
-    # juju deploy mysql --channel 8.0/stable -n 3
-    # juju deploy mysql --channel 8.4/stable -n 3
+    juju deploy mysql --channel 8.4/edge -n 3
 ```
 
 ```{tab-item} K8s
 :sync: k8s
 
-    # Use any of the stable channels
-    # juju deploy mysql-k8s --channel 8.0/stable -n 3
-    # juju deploy mysql-k8s --channel 8.4/stable -n 3
+    juju deploy mysql-k8s --channel 8.4/edge -n 3
 ```
 ````
 

--- a/docs/how-to/data-migration/migrate-data-via-mysqlsh.md
+++ b/docs/how-to/data-migration/migrate-data-via-mysqlsh.md
@@ -1,0 +1,177 @@
+---
+myst:
+  html_meta:
+    description: "Migrate database data using mysqlsh, with environment preparation."
+---
+
+(migrate-data-mysqlsh)=
+# Migrate database data via `mysqlsh`
+
+This guide describes how to copy data from a MySQL charm to another MySQL charm, regardless of their version (8.0 / 8.4 / ...).
+
+```{seealso}
+* {ref}`migrate-data-mydumper`
+* {ref}`migrate-data-mysqldump`
+* {ref}`migrate-data-backup-restore`
+```
+
+## Prepare
+
+Before migrating data, verify the {ref}`system-requirements`.
+
+```{caution}
+Always perform the migration in a test environment before performing it in production!
+```
+
+## Prerequisites
+
+- Client machine with access to both deployed charms
+- Enough storage in the cluster to support backup/restore of the databases
+- `mysql-shell` on client machine (install by running `sudo apt install mysql-shell`)
+
+
+## Obtain existing database credentials
+
+Get username, password and IP of the existing database:
+
+`````{tab-set}
+````{tab-item} VM
+:sync: vm
+
+    When the existing database is a MySQL 8.0 charm:
+    ```shell
+    OLD_DB_USER=$(juju run mysql-80/leader get-password username=serverconfig | yq '.username')
+    OLD_DB_PASS=$(juju run mysql-80/leader get-password username=serverconfig | yq '.password')
+    OLD_DB_HOST=$(juju show-unit mysql-80/0 | yq '.[] | .address')
+    ```
+    
+    When the existing database is a MySQL 8.4 charm:
+    ```shell
+    OLD_DB_USER=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.username')
+    OLD_DB_PASS=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.password')
+    OLD_DB_HOST=$(juju show-unit mysql-84/0 | yq '.[] | .address')
+    ```
+````
+
+````{tab-item} K8s
+:sync: k8s
+
+    When the existing database is a MySQL 8.0 charm:
+    ```shell
+    OLD_DB_USER=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.username')
+    OLD_DB_PASS=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.password')
+    OLD_DB_HOST=$(juju show-unit mysql-k8s-80/0 | yq '.[] | .address')
+    ```
+    
+    When the existing database is a MySQL 8.4 charm:
+    ```shell
+    OLD_DB_USER=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.username')
+    OLD_DB_PASS=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.password')
+    OLD_DB_HOST=$(juju show-unit mysql-k8s-84/0 | yq '.[] | .address')
+    ```
+````
+`````
+
+### Deploy a new MySQL charm
+
+This step can be skipped if the charm that the data migration will be targeting is already deployed.
+
+To deploy a new MySQL charm database:
+
+`````{tab-set}
+````{tab-item} VM
+:sync: vm
+
+    # Use any of the stable channels
+    # juju deploy mysql --channel 8.0/stable -n 3
+    # juju deploy mysql --channel 8.4/stable -n 3
+````
+
+````{tab-item} K8s
+:sync: k8s
+
+    # Use any of the stable channels
+    # juju deploy mysql-k8s --channel 8.0/stable -n 3
+    # juju deploy mysql-k8s --channel 8.4/stable -n 3
+````
+`````
+
+## Obtain new database credentials
+
+Get username, password and IP of the new database:
+
+`````{tab-set}
+````{tab-item} VM
+:sync: vm
+
+    When the new database is a MySQL 8.0 charm:
+    ```shell
+    NEW_DB_USER=$(juju run mysql-80/leader get-password username=serverconfig | yq '.username')
+    NEW_DB_PASS=$(juju run mysql-80/leader get-password username=serverconfig | yq '.password')
+    NEW_DB_HOST=$(juju show-unit mysql-80/0 | yq '.[] | .address')
+    ```
+
+    When the new database is a MySQL 8.4 charm:
+    ```shell
+    NEW_DB_USER=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.username')
+    NEW_DB_PASS=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.password')
+    NEW_DB_HOST=$(juju show-unit mysql-84/0 | yq '.[] | .address')
+    ```
+````
+
+````{tab-item} K8s
+:sync: k8s
+
+    When the new database is a MySQL 8.0 charm:
+    ```shell
+    NEW_DB_USER=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.username')
+    NEW_DB_PASS=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.password')
+    NEW_DB_HOST=$(juju show-unit mysql-k8s-80/0 | yq '.[] | .address')
+    ```
+    
+    When the new database is a MySQL 8.4 charm:
+    ```shell
+    NEW_DB_USER=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.username')
+    NEW_DB_PASS=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.password')
+    NEW_DB_HOST=$(juju show-unit mysql-k8s-84/0 | yq '.[] | .address')
+    ```
+````
+`````
+
+## Migrate database
+
+The next step is to use the credentials and information obtained in previous steps to perform the database migration.
+Ensure that there are no new connections are made and that database is not altered.
+
+Connect to the old database to allow dumping files into the local file system:
+
+```shell
+mysqlsh --sql \
+  --host=${OLD_DB_HOST} \
+  --user=${OLD_DB_USER} \
+  --password=${OLD_DB_PASS}
+
+SET GLOBAL LOCAL_INFILE=1;
+```
+
+Connect to the old database using username, password, and unit's IP address obtained earlier; and dump the instance data.
+
+```shell
+mysqlsh --py \
+  --host=${OLD_DB_HOST} \
+  --user=${OLD_DB_USER} \
+  --password=${OLD_DB_PASS}
+
+util.dump_instance('mysql-data.dump', {'threads': 4, 'users': False, 'excludeSchemas': ['mysql_innodb_cluster_metadata']})
+```
+
+Connect to the new database using username, password, and unit's IP address obtained earlier; and restore the instance data.
+
+```shell
+mysqlsh --py \
+  --host=${NEW_DB_HOST} \
+  --user=${NEW_DB_USER} \
+  --password=${NEW_DB_PASS}
+
+util.load_dump('mysql-data.dump', {'threads': 4})
+```

--- a/docs/how-to/data-migration/migrate-data-via-mysqlsh.md
+++ b/docs/how-to/data-migration/migrate-data-via-mysqlsh.md
@@ -8,6 +8,7 @@ myst:
 # Migrate database data via `mysqlsh`
 
 This guide describes how to copy data from a MySQL charm to another MySQL charm, regardless of their version (8.0 / 8.4 / ...).
+It does not apply to data migrations from a non charm database, or any legacy type of charm (MariaDB / Percona-cluster / ...).
 
 ```{seealso}
 * {ref}`migrate-data-mydumper`
@@ -34,43 +35,39 @@ Always perform the migration in a test environment before performing it in produ
 
 Get username, password and IP of the existing database:
 
-`````{tab-set}
-````{tab-item} VM
+````{tab-set}
+```{tab-item} VM
 :sync: vm
 
-    When the existing database is a MySQL 8.0 charm:
-    ```shell
+When the existing database is a MySQL 8.0 charm:
+
     OLD_DB_USER=$(juju run mysql-80/leader get-password username=serverconfig | yq '.username')
     OLD_DB_PASS=$(juju run mysql-80/leader get-password username=serverconfig | yq '.password')
     OLD_DB_HOST=$(juju show-unit mysql-80/0 | yq '.[] | .address')
-    ```
-    
-    When the existing database is a MySQL 8.4 charm:
-    ```shell
+
+When the existing database is a MySQL 8.4 charm:
+
     OLD_DB_USER=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.username')
     OLD_DB_PASS=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.password')
     OLD_DB_HOST=$(juju show-unit mysql-84/0 | yq '.[] | .address')
-    ```
-````
+```
 
-````{tab-item} K8s
+```{tab-item} K8s
 :sync: k8s
 
-    When the existing database is a MySQL 8.0 charm:
-    ```shell
+When the existing database is a MySQL 8.0 charm:
+
     OLD_DB_USER=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.username')
     OLD_DB_PASS=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.password')
     OLD_DB_HOST=$(juju show-unit mysql-k8s-80/0 | yq '.[] | .address')
-    ```
-    
-    When the existing database is a MySQL 8.4 charm:
-    ```shell
+
+When the existing database is a MySQL 8.4 charm:
+
     OLD_DB_USER=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.username')
     OLD_DB_PASS=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.password')
     OLD_DB_HOST=$(juju show-unit mysql-k8s-84/0 | yq '.[] | .address')
-    ```
+```
 ````
-`````
 
 ### Deploy a new MySQL charm
 
@@ -78,65 +75,61 @@ This step can be skipped if the charm that the data migration will be targeting 
 
 To deploy a new MySQL charm database:
 
-`````{tab-set}
-````{tab-item} VM
+````{tab-set}
+```{tab-item} VM
 :sync: vm
 
     # Use any of the stable channels
     # juju deploy mysql --channel 8.0/stable -n 3
     # juju deploy mysql --channel 8.4/stable -n 3
-````
+```
 
-````{tab-item} K8s
+```{tab-item} K8s
 :sync: k8s
 
     # Use any of the stable channels
     # juju deploy mysql-k8s --channel 8.0/stable -n 3
     # juju deploy mysql-k8s --channel 8.4/stable -n 3
+```
 ````
-`````
 
 ## Obtain new database credentials
 
 Get username, password and IP of the new database:
 
-`````{tab-set}
-````{tab-item} VM
+````{tab-set}
+```{tab-item} VM
 :sync: vm
 
-    When the new database is a MySQL 8.0 charm:
-    ```shell
+When the new database is a MySQL 8.0 charm:
+
     NEW_DB_USER=$(juju run mysql-80/leader get-password username=serverconfig | yq '.username')
     NEW_DB_PASS=$(juju run mysql-80/leader get-password username=serverconfig | yq '.password')
     NEW_DB_HOST=$(juju show-unit mysql-80/0 | yq '.[] | .address')
-    ```
 
-    When the new database is a MySQL 8.4 charm:
-    ```shell
+When the new database is a MySQL 8.4 charm:
+
     NEW_DB_USER=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.username')
     NEW_DB_PASS=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.password')
     NEW_DB_HOST=$(juju show-unit mysql-84/0 | yq '.[] | .address')
-    ```
-````
+```
 
-````{tab-item} K8s
+```{tab-item} K8s
 :sync: k8s
 
-    When the new database is a MySQL 8.0 charm:
-    ```shell
+When the new database is a MySQL 8.0 charm:
+
     NEW_DB_USER=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.username')
     NEW_DB_PASS=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.password')
     NEW_DB_HOST=$(juju show-unit mysql-k8s-80/0 | yq '.[] | .address')
-    ```
-    
-    When the new database is a MySQL 8.4 charm:
-    ```shell
+
+When the new database is a MySQL 8.4 charm:
+
     NEW_DB_USER=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.username')
     NEW_DB_PASS=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.password')
     NEW_DB_HOST=$(juju show-unit mysql-k8s-84/0 | yq '.[] | .address')
-    ```
+```
 ````
-`````
 
 ## Migrate database
 

--- a/docs/how-to/data-migration/migrate-data-via-mysqlsh.md
+++ b/docs/how-to/data-migration/migrate-data-via-mysqlsh.md
@@ -41,15 +41,15 @@ Get username, password and IP of the existing database:
 
 When the existing database is a MySQL 8.0 charm:
 
-    OLD_DB_USER=$(juju run mysql-80/leader get-password username=serverconfig | yq '.username')
-    OLD_DB_PASS=$(juju run mysql-80/leader get-password username=serverconfig | yq '.password')
-    OLD_DB_HOST=$(juju show-unit mysql-80/0 | yq '.[] | .address')
+    OLD_DB_USER=$(juju run mysql/leader get-password username=serverconfig | yq '.username')
+    OLD_DB_PASS=$(juju run mysql/leader get-password username=serverconfig | yq '.password')
+    OLD_DB_HOST=$(juju show-unit mysql/0 | yq '.[] | .address')
 
 When the existing database is a MySQL 8.4 charm:
 
-    OLD_DB_USER=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.username')
-    OLD_DB_PASS=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.password')
-    OLD_DB_HOST=$(juju show-unit mysql-84/0 | yq '.[] | .address')
+    OLD_DB_USER=$(juju run mysql/leader get-password username=charmed-operator | yq '.username')
+    OLD_DB_PASS=$(juju run mysql/leader get-password username=charmed-operator | yq '.password')
+    OLD_DB_HOST=$(juju show-unit mysql/0 | yq '.[] | .address')
 ```
 
 ```{tab-item} K8s
@@ -57,15 +57,15 @@ When the existing database is a MySQL 8.4 charm:
 
 When the existing database is a MySQL 8.0 charm:
 
-    OLD_DB_USER=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.username')
-    OLD_DB_PASS=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.password')
-    OLD_DB_HOST=$(juju show-unit mysql-k8s-80/0 | yq '.[] | .address')
+    OLD_DB_USER=$(juju run mysql-k8s/leader get-password username=serverconfig | yq '.username')
+    OLD_DB_PASS=$(juju run mysql-k8s/leader get-password username=serverconfig | yq '.password')
+    OLD_DB_HOST=$(juju show-unit mysql-k8s/0 | yq '.[] | .address')
 
 When the existing database is a MySQL 8.4 charm:
 
-    OLD_DB_USER=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.username')
-    OLD_DB_PASS=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.password')
-    OLD_DB_HOST=$(juju show-unit mysql-k8s-84/0 | yq '.[] | .address')
+    OLD_DB_USER=$(juju run mysql-k8s/leader get-password username=charmed-operator | yq '.username')
+    OLD_DB_PASS=$(juju run mysql-k8s/leader get-password username=charmed-operator | yq '.password')
+    OLD_DB_HOST=$(juju show-unit mysql-k8s/0 | yq '.[] | .address')
 ```
 ````
 
@@ -99,15 +99,15 @@ Get username, password and IP of the new database:
 
 When the new database is a MySQL 8.0 charm:
 
-    NEW_DB_USER=$(juju run mysql-80/leader get-password username=serverconfig | yq '.username')
-    NEW_DB_PASS=$(juju run mysql-80/leader get-password username=serverconfig | yq '.password')
-    NEW_DB_HOST=$(juju show-unit mysql-80/0 | yq '.[] | .address')
+    NEW_DB_USER=$(juju run mysql/leader get-password username=serverconfig | yq '.username')
+    NEW_DB_PASS=$(juju run mysql/leader get-password username=serverconfig | yq '.password')
+    NEW_DB_HOST=$(juju show-unit mysql/0 | yq '.[] | .address')
 
 When the new database is a MySQL 8.4 charm:
 
-    NEW_DB_USER=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.username')
-    NEW_DB_PASS=$(juju run mysql-84/leader get-password username=charmed-operator | yq '.password')
-    NEW_DB_HOST=$(juju show-unit mysql-84/0 | yq '.[] | .address')
+    NEW_DB_USER=$(juju run mysql/leader get-password username=charmed-operator | yq '.username')
+    NEW_DB_PASS=$(juju run mysql/leader get-password username=charmed-operator | yq '.password')
+    NEW_DB_HOST=$(juju show-unit mysql/0 | yq '.[] | .address')
 ```
 
 ```{tab-item} K8s
@@ -115,15 +115,15 @@ When the new database is a MySQL 8.4 charm:
 
 When the new database is a MySQL 8.0 charm:
 
-    NEW_DB_USER=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.username')
-    NEW_DB_PASS=$(juju run mysql-k8s-80/leader get-password username=serverconfig | yq '.password')
-    NEW_DB_HOST=$(juju show-unit mysql-k8s-80/0 | yq '.[] | .address')
+    NEW_DB_USER=$(juju run mysql-k8s/leader get-password username=serverconfig | yq '.username')
+    NEW_DB_PASS=$(juju run mysql-k8s/leader get-password username=serverconfig | yq '.password')
+    NEW_DB_HOST=$(juju show-unit mysql-k8s/0 | yq '.[] | .address')
 
 When the new database is a MySQL 8.4 charm:
 
-    NEW_DB_USER=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.username')
-    NEW_DB_PASS=$(juju run mysql-k8s-84/leader get-password username=charmed-operator | yq '.password')
-    NEW_DB_HOST=$(juju show-unit mysql-k8s-84/0 | yq '.[] | .address')
+    NEW_DB_USER=$(juju run mysql-k8s/leader get-password username=charmed-operator | yq '.username')
+    NEW_DB_PASS=$(juju run mysql-k8s/leader get-password username=charmed-operator | yq '.password')
+    NEW_DB_HOST=$(juju show-unit mysql-k8s/0 | yq '.[] | .address')
 ```
 ````
 

--- a/docs/how-to/monitoring/enable-alert-rules.md
+++ b/docs/how-to/monitoring/enable-alert-rules.md
@@ -19,7 +19,7 @@ This guide will show how to set up [Pushover](https://pushover.net/) to receive 
 
 ```{seealso}
 * {ref}`alert-rules`
-* [Observability documentation > Add alert rules](https://documentation.ubuntu.com/observability/latest/how-to/adding-alert-rules/)
+* [Observability documentation > Add alert rules](https://documentation.ubuntu.com/observability/latest/how-to/integrate/adding-alert-rules/)
 ```
 
 ## Prerequisites


### PR DESCRIPTION
This PR creates a documentation page to explain the different methods to migrate data from Charmed MySQL 8.0 to Charmed MySQL 8.4, suggesting folks to use MySQL official tools for now (i.e. `mysqldump` or `mysqlsh`). The existing data-migration pages have been tweaked to:

- Remove any references to "legacy charms", as those guides will live in the 8.0 documentation.
- Target different charm users depending on whether the migration source was a 8.0 or 8.4 charm.
- Harmonize guide sections across them, having all _prepare_, _prerequisites_ and _obtain database credentials_ steps.


---

Depends on PR https://github.com/canonical/mysql-operators/pull/219
