### PR TITLE
[DPE-9747] 8.0 - Enable upgrade tests

### DIFF
--- a/kubernetes/metadata.yaml
+++ b/kubernetes/metadata.yaml
@@ -24,7 +24,7 @@ charm-user: non-root
 containers:
   mysql:
     uid: 584788
-    gig: 584788
+    gid: 584788
     resource: mysql-image
     mounts:
       - storage: database

--- a/kubernetes/metadata.yaml
+++ b/kubernetes/metadata.yaml
@@ -34,7 +34,7 @@ resources:
   mysql-image:
     type: oci-image
     description: Ubuntu LTS Docker image for MySQL
-    upstream-source: ghcr.io/canonical/charmed-mysql@sha256:a12c9643253c877d81dba58b1a9b88990b931e84719deb567eba12804968d0d6
+    upstream-source: ghcr.io/canonical/charmed-mysql@sha256:82013980ad6da9b09d62348c02ece1c0ebf5847f8c0af62d341555122d2bd7ca
 
 peers:
   database-peers:


### PR DESCRIPTION
This PR re-enables upgrade tests after a root-less K8s charm was released to the `8.0/edge` channel.