### PR TITLE
[MISC] 8.0 - Fix setup-crash test waiting condition

### DIFF
--- a/kubernetes/tests/integration/helpers_ha.py
+++ b/kubernetes/tests/integration/helpers_ha.py
@@ -660,6 +660,11 @@ def wait_for_apps_status(jubilant_status_func: JujuAppsStatusFn, *apps: str) -> 
     ))
 
 
+def wait_for_app_status(app_name: str, app_status: str) -> JujuModelStatusFn:
+    """Returns whether a Juju app has a specific status."""
+    return lambda status: status.apps[app_name].app_status.current == app_status
+
+
 def wait_for_unit_status(app_name: str, unit_name: str, unit_status: str) -> JujuModelStatusFn:
     """Returns whether a Juju unit to have a specific status."""
     return lambda status: (

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_setup_crash.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_setup_crash.py
@@ -11,6 +11,7 @@ from ...helpers_ha import (
     delete_k8s_pod,
     get_mysql_primary_unit,
     update_interval,
+    wait_for_app_status,
     wait_for_apps_status,
 )
 
@@ -48,7 +49,7 @@ def test_crash_during_cluster_setup(juju: Juju, charm: str) -> None:
     logging.info("Scaling to 3 units")
     juju.add_unit(MYSQL_APP_NAME, num_units=2)
     juju.wait(
-        ready=wait_for_apps_status(jubilant_backports.any_waiting, MYSQL_APP_NAME),
+        ready=wait_for_app_status(MYSQL_APP_NAME, "maintenance"),
         error=jubilant_backports.any_blocked,
         timeout=20 * MINUTE_SECS,
     )


### PR DESCRIPTION
This PR changes the wait condition for the K8s setup-crash test so:

- It does not wait for all agents to be `idle` (what the previous helper function forced it to).
- It does not wait for the app to reach `waiting` status, but `maintenance` instead.
