### PR TITLE
[MISC] Reintroduce `--model` parameter for pytest runs

### DIFF
--- a/kubernetes/tests/integration/conftest.py
+++ b/kubernetes/tests/integration/conftest.py
@@ -25,6 +25,17 @@ def pytest_configure(config):
     config.option.log_date_format = "%b %d %H:%M:%S"
 
 
+def pytest_addoption(parser):
+    """Adds command line parameter ``--model`` (see help for details)."""
+    parser.addoption(
+        "--model",
+        action="store",
+        default="testing",
+        help="model name or ':auto:' for temporary model, default to 'testing'",
+        required=False,
+    )
+
+
 @pytest.fixture(scope="session")
 def charm():
     # Return str instead of pathlib.Path since python-libjuju's model.deploy(), juju deploy, and
@@ -64,5 +75,12 @@ def cloud_configs_gcp() -> tuple[dict[str, str], dict[str, str]]:
 
 
 @pytest.fixture(scope="module")
-def juju() -> jubilant.Juju:
-    return jubilant.Juju(model="testing")
+def juju(request: pytest.FixtureRequest):
+    """Pytest fixture that yields a new :meth:`jubilant.Juju` object."""
+    model = request.config.getoption("--model")
+
+    if model == ":auto:":
+        with jubilant.temp_model() as juju:
+            yield juju
+    else:
+        yield jubilant.Juju(model=model)

--- a/machines/tests/integration/conftest.py
+++ b/machines/tests/integration/conftest.py
@@ -25,6 +25,17 @@ def pytest_configure(config):
     config.option.log_date_format = "%b %d %H:%M:%S"
 
 
+def pytest_addoption(parser):
+    """Adds command line parameter ``--model`` (see help for details)."""
+    parser.addoption(
+        "--model",
+        action="store",
+        default="testing",
+        help="model name or ':auto:' for temporary model, default to 'testing'",
+        required=False,
+    )
+
+
 @pytest.fixture(scope="session")
 def charm():
     # Return str instead of pathlib.Path since python-libjuju's model.deploy(), juju deploy, and
@@ -64,5 +75,12 @@ def cloud_configs_gcp() -> tuple[dict[str, str], dict[str, str]]:
 
 
 @pytest.fixture(scope="module")
-def juju() -> jubilant.Juju:
-    return jubilant.Juju(model="testing")
+def juju(request: pytest.FixtureRequest):
+    """Pytest fixture that yields a new :meth:`jubilant.Juju` object."""
+    model = request.config.getoption("--model")
+
+    if model == ":auto:":
+        with jubilant.temp_model() as juju:
+            yield juju
+    else:
+        yield jubilant.Juju(model=model)


### PR DESCRIPTION
## Issue

I used to find the `--model` parameter very useful when running tests, so I'd like to propose reintroducing it. Example use cases:
- Launch the tests to a new model (`testing2`, or just an auto-generated one) while you destroy and recreate `testing` (which in the case of K8s takes quite a bit of time, or may be even blocked by things like https://github.com/juju/juju/issues/22075)
- Launch the tests in 2 different models to compare logs

I've been keeping dirtier versions of this to myself, but it's annoying to have those uncommitted changes all the time, so I'd like to include this in the source tree. This is much simpler than what we had before #62, in that the parameter is completely optional and has a default value of `testing`.

Happy to backport this to 8.0/edge if approved.

## Solution

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
