### PR TITLE
[MISC] 8.0 - Update promote workflow

### DIFF
--- a/.github/workflows/approve_renovate_pr.yaml
+++ b/.github/workflows/approve_renovate_pr.yaml
@@ -10,6 +10,6 @@ on:
 jobs:
   approve-pr:
     name: Approve Renovate pull request
-    uses: canonical/data-platform-workflows/.github/workflows/approve_renovate_pr.yaml@v48.1.1
+    uses: canonical/data-platform-workflows/.github/workflows/approve_renovate_pr.yaml@v48.1.2
     permissions:
       pull-requests: write  # Needed to approve PR

--- a/.github/workflows/check_pr.yaml
+++ b/.github/workflows/check_pr.yaml
@@ -15,4 +15,4 @@ on:
 jobs:
   check-pr:
     name: Check pull request
-    uses: canonical/data-platform-workflows/.github/workflows/check_charm_pr.yaml@v48.1.1
+    uses: canonical/data-platform-workflows/.github/workflows/check_charm_pr.yaml@v48.1.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,7 +95,7 @@ jobs:
         path:
           - kubernetes
           - machines
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v48.1.1
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v48.1.2
     with:
       path-to-charm-directory: ${{ matrix.path }}
 

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -5,6 +5,13 @@ name: Promote charm
 on:
   workflow_dispatch:
     inputs:
+      path-to-charm:
+        description: Promote charm in this path
+        required: true
+        type: choice
+        options:
+          - kubernetes
+          - machines
       from-risk:
         description: Promote from this Charmhub risk
         required: true
@@ -25,12 +32,14 @@ on:
 jobs:
   promote:
     name: Promote charm
-    uses: canonical/data-platform-workflows/.github/workflows/_promote_charms.yaml@v48.1.2
+    uses: canonical/data-platform-workflows/.github/workflows/_promote_charm_legacy.yaml@v48.1.2
     with:
       track: '8.0'
       from-risk: ${{ inputs.from-risk }}
       to-risk: ${{ inputs.to-risk }}
+      path-to-charm-directory: ${{ inputs.path-to-charm }}
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
     permissions:
+      actions: read
       contents: write  # Needed to edit GitHub releases

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -25,7 +25,7 @@ on:
 jobs:
   promote:
     name: Promote charm
-    uses: canonical/data-platform-workflows/.github/workflows/_promote_charms.yaml@v48.1.1
+    uses: canonical/data-platform-workflows/.github/workflows/_promote_charms.yaml@v48.1.2
     with:
       track: '8.0'
       from-risk: ${{ inputs.from-risk }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
         path:
           - kubernetes
           - machines
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v48.1.1
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v48.1.2
     with:
       path-to-charm-directory: ${{ matrix.path }}
     permissions:
@@ -75,7 +75,7 @@ jobs:
         path:
           - kubernetes
           - machines
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v48.1.1
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v48.1.2
     with:
       track: '8.0'
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}

--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -19,7 +19,7 @@ jobs:
         path:
           - kubernetes
           - machines
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v48.1.1
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v48.1.2
     with:
       path-to-charm-directory: ${{ matrix.path }}
 


### PR DESCRIPTION
This PR fixes the promotion workflow for the MySQL 8.0 charms, by:

- Target the `_promote_charm_legacy` workflow (only one supporting non refresh V3 charms, according to [this](https://github.com/canonical/data-platform-workflows)).
- Bump the `_promote_charm_legacy` workflow version, to one where mono-repo setups are supported.

---

Depends on https://github.com/canonical/data-platform-workflows/pull/365