### PR TITLE
[DPE-9789] 8.0 - Rootless K8s container [revert]

### DIFF
--- a/kubernetes/metadata.yaml
+++ b/kubernetes/metadata.yaml
@@ -19,12 +19,9 @@ website:
   - https://github.com/canonical/mysql-operators
 maintainers:
   - Canonical Data Platform <data-platform@lists.launchpad.net>
-charm-user: non-root
 
 containers:
   mysql:
-    uid: 584788
-    gid: 584788
     resource: mysql-image
     mounts:
       - storage: database


### PR DESCRIPTION
This PR partially reverts the [PR](https://github.com/canonical/mysql-operators/pull/169) introducing root-less containers in Charmed MySQL 8.0.

We are not entirely sure of the implications when it comes to a _rollback_ (juju refresh to an older version of the charm), when switching between non-root to root modes. In addition, the inclusion of the `charm-root` metadata field is only parsed in Juju 3.6+ envs (see [release notes](https://discourse.charmhub.io/t/juju-3-6-0-released/16027#rootless-charms-on-k8s-3)), making it useless for most of our supported juju versions.

