### PR TITLE
[MISC] Fix wrong waiting logic in self-healing test, undo Juju 2 workarounds

### DIFF
--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_setup_crash.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_setup_crash.py
@@ -2,7 +2,6 @@
 # See LICENSE file for licensing details.
 
 import logging
-import os
 
 import jubilant
 from jubilant import Juju
@@ -11,17 +10,16 @@ from ...helpers_ha import (
     CHARM_METADATA,
     delete_k8s_pod,
     get_mysql_primary_unit,
-    load_mysql_test_data,
     update_interval,
     wait_for_apps_status,
-    wait_for_unit_status,
+    wait_for_unit_message,
 )
 
 MYSQL_APP_NAME = "mysql-k8s"
 MINUTE_SECS = 60
 
 
-def test_deploy_single_unit_cluster(juju: Juju, charm: str) -> None:
+def test_deploy_and_crash_during_cluster_setup_and_recover(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
     juju.deploy(
@@ -30,45 +28,23 @@ def test_deploy_single_unit_cluster(juju: Juju, charm: str) -> None:
         base="ubuntu@24.04",
         config={"profile": "testing"},
         resources={"mysql-image": CHARM_METADATA["resources"]["mysql-image"]["upstream-source"]},
-        num_units=1,
+        num_units=3,
         trust=True,
     )
 
-    logging.info("Wait for applications to become active")
-    juju.wait(
-        ready=wait_for_apps_status(jubilant.all_active, MYSQL_APP_NAME),
-        error=jubilant.any_blocked,
-        timeout=20 * MINUTE_SECS,
-    )
-
-    if path := os.getenv("DATA_SOURCE_PATH"):
-        logging.info("Loading test database")
-        load_mysql_test_data(juju, MYSQL_APP_NAME, path)
-
-
-def test_crash_during_cluster_setup(juju: Juju, charm: str) -> None:
-    """Test primary crash during startup.
-
-    It must recover/end setup when the primary got offline.
-    """
-    mysql_primary = get_mysql_primary_unit(juju, MYSQL_APP_NAME)
-
-    # NOTE: This is prone to race conditions:
-    # if the units clear the "waiting" phase too quickly,
-    # this status function will never activate
-    logging.info("Scaling to 3 units")
-    juju.add_unit(MYSQL_APP_NAME, num_units=2)
+    logging.info("Wait for the first unit to be configured as primary")
     juju.wait(
         ready=lambda status: any((
             *(
-                wait_for_unit_status(MYSQL_APP_NAME, unit_name, "waiting")(status)
+                wait_for_unit_message(MYSQL_APP_NAME, unit_name, "Primary")(status)
                 for unit_name in status.get_units(MYSQL_APP_NAME)
             ),
         )),
         error=jubilant.any_blocked,
         timeout=20 * MINUTE_SECS,
-        successes=1,
     )
+
+    mysql_primary = get_mysql_primary_unit(juju, MYSQL_APP_NAME)
 
     logging.info("Deleting pod")
     delete_k8s_pod(juju, mysql_primary)

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_setup_crash.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_setup_crash.py
@@ -14,6 +14,7 @@ from ...helpers_ha import (
     load_mysql_test_data,
     update_interval,
     wait_for_apps_status,
+    wait_for_unit_status,
 )
 
 MYSQL_APP_NAME = "mysql-k8s"
@@ -30,6 +31,7 @@ def test_deploy_single_unit_cluster(juju: Juju, charm: str) -> None:
         config={"profile": "testing"},
         resources={"mysql-image": CHARM_METADATA["resources"]["mysql-image"]["upstream-source"]},
         num_units=1,
+        trust=True,
     )
 
     logging.info("Wait for applications to become active")
@@ -51,12 +53,21 @@ def test_crash_during_cluster_setup(juju: Juju, charm: str) -> None:
     """
     mysql_primary = get_mysql_primary_unit(juju, MYSQL_APP_NAME)
 
+    # NOTE: This is prone to race conditions:
+    # if the units clear the "waiting" phase too quickly,
+    # this status function will never activate
     logging.info("Scaling to 3 units")
     juju.add_unit(MYSQL_APP_NAME, num_units=2)
     juju.wait(
-        ready=wait_for_apps_status(jubilant.any_waiting, MYSQL_APP_NAME),
+        ready=lambda status: any((
+            *(
+                wait_for_unit_status(MYSQL_APP_NAME, unit_name, "waiting")(status)
+                for unit_name in status.get_units(MYSQL_APP_NAME)
+            ),
+        )),
         error=jubilant.any_blocked,
         timeout=20 * MINUTE_SECS,
+        successes=1,
     )
 
     logging.info("Deleting pod")

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_setup_crash.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_setup_crash.py
@@ -19,7 +19,7 @@ MYSQL_APP_NAME = "mysql-k8s"
 MINUTE_SECS = 60
 
 
-def test_deploy_and_crash_during_cluster_setup_and_recover(juju: Juju, charm: str) -> None:
+def test_build_and_deploy(juju: Juju, charm: str) -> None:
     """Simple test to ensure that the MySQL and application charms get deployed."""
     logging.info("Deploying MySQL cluster")
     juju.deploy(
@@ -44,6 +44,8 @@ def test_deploy_and_crash_during_cluster_setup_and_recover(juju: Juju, charm: st
         timeout=20 * MINUTE_SECS,
     )
 
+
+def test_crash_during_cluster_setup_and_recover(juju: Juju) -> None:
     mysql_primary = get_mysql_primary_unit(juju, MYSQL_APP_NAME)
 
     logging.info("Deleting pod")

--- a/kubernetes/tests/integration/integration/roles/test_database_dba_role.py
+++ b/kubernetes/tests/integration/integration/roles/test_database_dba_role.py
@@ -52,11 +52,11 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     juju.wait(
         ready=lambda status: all((
             *(
-                wait_for_unit_status(f"{INTEGRATOR_APP_NAME}1", unit_name, "blocked")
+                wait_for_unit_status(f"{INTEGRATOR_APP_NAME}1", unit_name, "blocked")(status)
                 for unit_name in status.get_units(f"{INTEGRATOR_APP_NAME}1")
             ),
             *(
-                wait_for_unit_status(f"{INTEGRATOR_APP_NAME}2", unit_name, "blocked")
+                wait_for_unit_status(f"{INTEGRATOR_APP_NAME}2", unit_name, "blocked")(status)
                 for unit_name in status.get_units(f"{INTEGRATOR_APP_NAME}2")
             ),
         )),

--- a/kubernetes/tests/integration/integration/roles/test_database_dba_role.py
+++ b/kubernetes/tests/integration/integration/roles/test_database_dba_role.py
@@ -17,7 +17,6 @@ from ...helpers_ha import (
     get_mysql_primary_unit,
     get_unit_address,
     wait_for_apps_status,
-    wait_for_unit_status,
 )
 
 DATABASE_APP_NAME = CHARM_METADATA["name"]
@@ -50,16 +49,9 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
         timeout=15 * MINUTE_SECS,
     )
     juju.wait(
-        ready=lambda status: all((
-            *(
-                wait_for_unit_status(f"{INTEGRATOR_APP_NAME}1", unit_name, "blocked")(status)
-                for unit_name in status.get_units(f"{INTEGRATOR_APP_NAME}1")
-            ),
-            *(
-                wait_for_unit_status(f"{INTEGRATOR_APP_NAME}2", unit_name, "blocked")(status)
-                for unit_name in status.get_units(f"{INTEGRATOR_APP_NAME}2")
-            ),
-        )),
+        ready=wait_for_apps_status(
+            jubilant.all_blocked, f"{INTEGRATOR_APP_NAME}1", f"{INTEGRATOR_APP_NAME}2"
+        ),
         timeout=15 * MINUTE_SECS,
     )
 

--- a/kubernetes/tests/integration/integration/roles/test_instance_dba_role.py
+++ b/kubernetes/tests/integration/integration/roles/test_instance_dba_role.py
@@ -43,7 +43,7 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     juju.wait(
         ready=lambda status: all((
             *(
-                wait_for_unit_status(INTEGRATOR_APP_NAME, unit_name, "blocked")
+                wait_for_unit_status(INTEGRATOR_APP_NAME, unit_name, "blocked")(status)
                 for unit_name in status.get_units(INTEGRATOR_APP_NAME)
             ),
         )),

--- a/kubernetes/tests/integration/integration/roles/test_instance_dba_role.py
+++ b/kubernetes/tests/integration/integration/roles/test_instance_dba_role.py
@@ -2,6 +2,7 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+
 import jubilant
 from jubilant import Juju
 
@@ -14,7 +15,6 @@ from ...helpers_ha import (
     get_mysql_server_credentials,
     get_unit_address,
     wait_for_apps_status,
-    wait_for_unit_status,
 )
 
 DATABASE_APP_NAME = CHARM_METADATA["name"]
@@ -41,12 +41,7 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
         timeout=15 * MINUTE_SECS,
     )
     juju.wait(
-        ready=lambda status: all((
-            *(
-                wait_for_unit_status(INTEGRATOR_APP_NAME, unit_name, "blocked")(status)
-                for unit_name in status.get_units(INTEGRATOR_APP_NAME)
-            ),
-        )),
+        ready=wait_for_apps_status(jubilant.all_blocked, INTEGRATOR_APP_NAME),
         timeout=15 * MINUTE_SECS,
     )
 

--- a/kubernetes/tests/integration/integration/roles/test_instance_roles.py
+++ b/kubernetes/tests/integration/integration/roles/test_instance_roles.py
@@ -18,7 +18,6 @@ from ...helpers_ha import (
     get_mysql_server_credentials,
     get_unit_address,
     wait_for_apps_status,
-    wait_for_unit_status,
 )
 
 DATABASE_APP_NAME = CHARM_METADATA["name"]
@@ -51,16 +50,9 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
         timeout=15 * MINUTE_SECS,
     )
     juju.wait(
-        ready=lambda status: all((
-            *(
-                wait_for_unit_status(f"{INTEGRATOR_APP_NAME}1", unit_name, "blocked")(status)
-                for unit_name in status.get_units(f"{INTEGRATOR_APP_NAME}1")
-            ),
-            *(
-                wait_for_unit_status(f"{INTEGRATOR_APP_NAME}2", unit_name, "blocked")(status)
-                for unit_name in status.get_units(f"{INTEGRATOR_APP_NAME}2")
-            ),
-        )),
+        ready=wait_for_apps_status(
+            jubilant.all_blocked, f"{INTEGRATOR_APP_NAME}1", f"{INTEGRATOR_APP_NAME}2"
+        ),
         timeout=15 * MINUTE_SECS,
     )
 
@@ -138,14 +130,7 @@ def test_charmed_read_role(juju: Juju):
 
     juju.remove_relation(f"{DATABASE_APP_NAME}:database", f"{INTEGRATOR_APP_NAME}1:mysql")
     juju.wait(
-        ready=lambda status: all((
-            # wait for relation to be fully removed before adding it again in the following test
-            jubilant.all_agents_idle(status, f"{INTEGRATOR_APP_NAME}1"),
-            *(
-                wait_for_unit_status(f"{INTEGRATOR_APP_NAME}1", unit_name, "blocked")(status)
-                for unit_name in status.get_units(f"{INTEGRATOR_APP_NAME}1")
-            ),
-        )),
+        ready=wait_for_apps_status(jubilant.all_blocked, f"{INTEGRATOR_APP_NAME}1"),
         timeout=15 * MINUTE_SECS,
     )
 
@@ -247,15 +232,8 @@ def test_charmed_dml_role(juju: Juju):
         f"{INTEGRATOR_APP_NAME}2:mysql",
     )
     juju.wait(
-        ready=lambda status: all((
-            *(
-                wait_for_unit_status(f"{INTEGRATOR_APP_NAME}1", unit_name, "blocked")(status)
-                for unit_name in status.get_units(f"{INTEGRATOR_APP_NAME}1")
-            ),
-            *(
-                wait_for_unit_status(f"{INTEGRATOR_APP_NAME}2", unit_name, "blocked")(status)
-                for unit_name in status.get_units(f"{INTEGRATOR_APP_NAME}2")
-            ),
-        )),
+        ready=wait_for_apps_status(
+            jubilant.all_blocked, f"{INTEGRATOR_APP_NAME}1", f"{INTEGRATOR_APP_NAME}2"
+        ),
         timeout=15 * MINUTE_SECS,
     )

--- a/kubernetes/tests/integration/integration/roles/test_instance_roles.py
+++ b/kubernetes/tests/integration/integration/roles/test_instance_roles.py
@@ -53,11 +53,11 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     juju.wait(
         ready=lambda status: all((
             *(
-                wait_for_unit_status(f"{INTEGRATOR_APP_NAME}1", unit_name, "blocked")
+                wait_for_unit_status(f"{INTEGRATOR_APP_NAME}1", unit_name, "blocked")(status)
                 for unit_name in status.get_units(f"{INTEGRATOR_APP_NAME}1")
             ),
             *(
-                wait_for_unit_status(f"{INTEGRATOR_APP_NAME}2", unit_name, "blocked")
+                wait_for_unit_status(f"{INTEGRATOR_APP_NAME}2", unit_name, "blocked")(status)
                 for unit_name in status.get_units(f"{INTEGRATOR_APP_NAME}2")
             ),
         )),
@@ -142,7 +142,7 @@ def test_charmed_read_role(juju: Juju):
             # wait for relation to be fully removed before adding it again in the following test
             jubilant.all_agents_idle(status, f"{INTEGRATOR_APP_NAME}1"),
             *(
-                wait_for_unit_status(f"{INTEGRATOR_APP_NAME}1", unit_name, "blocked")
+                wait_for_unit_status(f"{INTEGRATOR_APP_NAME}1", unit_name, "blocked")(status)
                 for unit_name in status.get_units(f"{INTEGRATOR_APP_NAME}1")
             ),
         )),
@@ -249,11 +249,11 @@ def test_charmed_dml_role(juju: Juju):
     juju.wait(
         ready=lambda status: all((
             *(
-                wait_for_unit_status(f"{INTEGRATOR_APP_NAME}1", unit_name, "blocked")
+                wait_for_unit_status(f"{INTEGRATOR_APP_NAME}1", unit_name, "blocked")(status)
                 for unit_name in status.get_units(f"{INTEGRATOR_APP_NAME}1")
             ),
             *(
-                wait_for_unit_status(f"{INTEGRATOR_APP_NAME}2", unit_name, "blocked")
+                wait_for_unit_status(f"{INTEGRATOR_APP_NAME}2", unit_name, "blocked")(status)
                 for unit_name in status.get_units(f"{INTEGRATOR_APP_NAME}2")
             ),
         )),


### PR DESCRIPTION
## Issue

This test has always been broken, see https://canonical.github.io/mysql-operators/89/#suites/39f0662952b7076f02d119b4ba71c27e/47b6f482785863e3/history

<img width="970" height="1044" alt="image" src="https://github.com/user-attachments/assets/74929449-b909-4006-b2e2-d6f959672bbc" />

With these changes, it passes locally.

## Solution

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
