### PR TITLE
[DPE-9788] Run nightly tests on 8.4/edge and 8.0/edge

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -22,6 +22,9 @@ jobs:
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v48.1.2
     with:
       path-to-charm-directory: ${{ matrix.path }}
+    permissions:
+      actions: read
+      contents: read
 
   integration-test:
     name: Integration tests

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,14 +1,14 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
-name: Scheduled run
+name: Nightly tests
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 on:
-  schedule:
-    - cron: '53 0 * * *'  # Daily at 00:53 UTC
+  # Triggered on schedule by .github/workflows/scheduled_ci_*.yaml on default branch
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/schedule_8_0_edge.yaml
+++ b/.github/workflows/schedule_8_0_edge.yaml
@@ -1,0 +1,21 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+name: Scheduled run (8.0/edge)
+
+on:
+  # GitHub will only trigger workflows `on: schedule` for workflow files in the default GitHub branch
+  schedule:
+    - cron: '53 23 * * *'  # Daily at 23:53 UTC
+
+jobs:
+  trigger:
+    name: Trigger workflow on branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Trigger workflow
+        run: gh workflow --repo '${{ github.repository }}' run nightly.yaml --ref 8.0/edge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      actions: write  # Needed to trigger workflow

--- a/.github/workflows/schedule_8_4_edge.yaml
+++ b/.github/workflows/schedule_8_4_edge.yaml
@@ -1,0 +1,21 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+name: Scheduled run (8.4/edge)
+
+on:
+  # GitHub will only trigger workflows `on: schedule` for workflow files in the default GitHub branch
+  schedule:
+    - cron: '53 0 * * *'  # Daily at 00:53 UTC
+
+jobs:
+  trigger:
+    name: Trigger workflow on branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Trigger workflow
+        run: gh workflow --repo '${{ github.repository }}' run nightly.yaml --ref 8.4/edge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      actions: write  # Needed to trigger workflow


### PR DESCRIPTION
## Issue

This will make sure Allure reports are available on both branches. A continuation of #258 and #259.

## Solution

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
