### PR TITLE
[DPE-7899] 8.4 - Migrate to TLS v4 (II)

### DIFF
--- a/docs/how-to/tls/disable-tls.md
+++ b/docs/how-to/tls/disable-tls.md
@@ -52,3 +52,21 @@ Separate the certificates charm and the Charmed MySQL application on the `client
     juju remove-relation self-signed-certificates mysql-k8s:client-certificates
 ```
 ````
+
+## Disable peer-to-peer encryption
+
+Separate the certificates charm and the Charmed MySQL application on the `peer-certificates` endpoint:
+
+````{tab-set}
+```{tab-item} VM
+:sync: vm
+
+    juju remove-relation self-signed-certificates mysql:peer-certificates
+```
+
+```{tab-item} K8s
+:sync: k8s
+
+    juju remove-relation self-signed-certificates mysql-k8s:peer-certificates
+```
+````

--- a/docs/how-to/tls/enable-tls.md
+++ b/docs/how-to/tls/enable-tls.md
@@ -49,6 +49,24 @@ Integrate the certificates charm with the Charmed MySQL application on the `clie
 ```
 ````
 
+## Enable peer-to-peer encryption
+
+Integrate the certificates charm with the Charmed MySQL application on the `peer-certificates` endpoint:
+
+````{tab-set}
+```{tab-item} VM
+:sync: vm
+
+    juju integrate self-signed-certificates mysql:peer-certificates
+```
+
+```{tab-item} K8s
+:sync: k8s
+
+    juju integrate self-signed-certificates mysql-k8s:peer-certificates
+```
+````
+
 ## Certificate expiration and rotation
 
 Charmed MySQL provides full automation of certificate rotation.

--- a/kubernetes/lib/charms/mysql/v0/mysql.py
+++ b/kubernetes/lib/charms/mysql/v0/mysql.py
@@ -2921,15 +2921,46 @@ class MySQLBase(ABC):
         require_tls: bool = False,
     ) -> None:
         """Setup client-connection TLS files and requirement mode."""
-        tls_var = "require_secure_transport"
-        tls_val = "ON" if require_tls else "OFF"
+        client = self._instance_client_tcp
+        usage = "ON" if require_tls else "OFF"
 
         try:
-            self._instance_client_tcp.set_instance_variable(Scope.PERSIST, "ssl_ca", ca_path)
-            self._instance_client_tcp.set_instance_variable(Scope.PERSIST, "ssl_key", key_path)
-            self._instance_client_tcp.set_instance_variable(Scope.PERSIST, "ssl_cert", cert_path)
-            self._instance_client_tcp.set_instance_variable(Scope.PERSIST, tls_var, tls_val)
-            self._instance_client_tcp.reload_instance_certs()
+            client.set_instance_variable(Scope.PERSIST, "ssl_ca", ca_path)
+            client.set_instance_variable(Scope.PERSIST, "ssl_key", key_path)
+            client.set_instance_variable(Scope.PERSIST, "ssl_cert", cert_path)
+            client.set_instance_variable(Scope.PERSIST, "require_secure_transport", usage)
+            client.reload_instance_certs()
+        except ExecutionError as e:
+            raise MySQLTLSSetupError() from e
+
+    def setup_group_tls(
+        self,
+        ca_path: str = "ca.pem",
+        key_path: str = "server-key.pem",
+        cert_path: str = "server-cert.pem",
+        require_tls: bool = False,
+    ) -> None:
+        """Setup group-replication TLS files and requirement mode."""
+        client = self._instance_client_tcp
+        usage_recovery = "ON" if require_tls else "OFF"
+        usage_replication = "REQUIRED" if require_tls else "DISABLED"
+
+        try:
+            client.set_instance_variable(
+                Scope.PERSIST, "group_replication_recovery_ssl_ca", ca_path
+            )
+            client.set_instance_variable(
+                Scope.PERSIST, "group_replication_recovery_ssl_key", key_path
+            )
+            client.set_instance_variable(
+                Scope.PERSIST, "group_replication_recovery_ssl_cert", cert_path
+            )
+            client.set_instance_variable(
+                Scope.PERSIST, "group_replication_recovery_use_ssl", usage_recovery
+            )
+            client.set_instance_variable(
+                Scope.PERSIST, "group_replication_ssl_mode", usage_replication
+            )
         except ExecutionError as e:
             raise MySQLTLSSetupError() from e
 

--- a/kubernetes/metadata.yaml
+++ b/kubernetes/metadata.yaml
@@ -69,6 +69,10 @@ requires:
     interface: tls-certificates
     limit: 1
     optional: true
+  peer-certificates:
+    interface: tls-certificates
+    limit: 1
+    optional: true
   s3-parameters:
     interface: s3
     limit: 1

--- a/kubernetes/src/charm.py
+++ b/kubernetes/src/charm.py
@@ -10,13 +10,15 @@ from ops.main import main
 if is_wrong_architecture() and __name__ == "__main__":
     main(WrongArchitectureWarningCharm)
 
+import json
 import logging
 import random
 from time import sleep
 
 import charm_refresh
 import ops
-from charmlibs.rollingops import RollingOpsManager
+from charmlibs.pathops import LocalPath
+from charmlibs.rollingops import OperationResult, RollingOpsManager
 from charms.data_platform_libs.v1.data_models import TypedCharmBase
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.loki_k8s.v0.loki_push_api import LogProxyConsumer
@@ -188,9 +190,12 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
 
         self.rolling_ops = RollingOpsManager(
             charm=self,
-            base_dir="/var/lib/rollingops",
+            base_dir=LocalPath("/var/lib/juju/rollingops"),
             peer_relation_name="rolling-ops",
-            callback_targets={"restart": self._restart},
+            callback_targets={
+                "replication": self._restart_group_replication,
+                "restart": self._restart,
+            },
         )
 
         self.log_rotate_manager = LogRotateManager(self)
@@ -553,16 +558,54 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             except RetryError:
                 raise
 
-    def _restart(self) -> None:
+    def _restart_group_replication(self) -> OperationResult:
+        """Restarts Group replication on the instance."""
+        relation = self.model.get_relation("rolling-ops")
+        if not relation:
+            logger.info("Skipping group replication restart")
+            return OperationResult.RETRY_RELEASE
+
+        ongoing_ops = [relation.data[unit].get("operations", "[]") for unit in self.peers.units]
+        ongoing_ops = [json.loads(op) for op in ongoing_ops]
+
+        if self.is_unit_primary and any(ongoing_ops):
+            logger.info("Skipping group replication restart")
+            return OperationResult.RETRY_RELEASE
+
+        if self.is_unit_primary and self.app.planned_units() > 1:
+            try:
+                new_primary = self.get_unit_address(self.peers.units.pop())
+                logger.debug(f"Switching primary to {new_primary}")
+                self._mysql.set_cluster_primary(new_primary)
+            except MySQLSetClusterPrimaryError:
+                logger.warning("Changing primary failed")
+                return OperationResult.RETRY_HOLD
+
+        cluster_primary = self._mysql.get_cluster_primary_address()
+        if not cluster_primary:
+            logger.warning("Getting primary failed")
+            return OperationResult.RETRY_HOLD
+
+        logger.info("Recreating group replication")
+        self._mysql.rejoin_instance_to_cluster(
+            unit_address=self.unit_address,
+            unit_label=self.unit_label,
+            from_instance=cluster_primary,
+        )
+
+        self._on_update_status(None)
+        return OperationResult.RELEASE
+
+    def _restart(self) -> OperationResult:
         """Restart the service."""
         container = self.unit.get_container(CONTAINER_NAME)
         if not container.can_connect():
-            return
+            return OperationResult.RETRY_HOLD
 
         if not self.unit_initialized():
             logger.debug("Restarting standalone mysqld")
             container.restart(MYSQLD_SERVICE)
-            return
+            return OperationResult.RETRY_HOLD
 
         if self.app.planned_units() > 1 and self.is_unit_primary:
             try:
@@ -580,6 +623,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         self.recover_unit_after_restart()
 
         self._on_update_status(None)
+        return OperationResult.RELEASE
 
     # =========================================================================
     # Charm event handlers

--- a/kubernetes/src/constants.py
+++ b/kubernetes/src/constants.py
@@ -22,6 +22,7 @@ BACKUPS_PASSWORD_KEY = "backups-password"  # noqa: S105
 CONTAINER_RESTARTS = "unit-container-restarts"
 UNIT_ENDPOINTS_KEY = "unit-endpoints"
 TLS_CLIENT_RELATION = "client-certificates"
+TLS_PEER_RELATION = "peer-certificates"
 TLS_SSL_CA_FILE = "custom-ca.pem"
 TLS_SSL_KEY_FILE = "custom-server-key.pem"
 TLS_SSL_CERT_FILE = "custom-server-cert.pem"

--- a/kubernetes/src/relations/tls.py
+++ b/kubernetes/src/relations/tls.py
@@ -11,6 +11,10 @@ from charmlibs.interfaces.tls_certificates import (
     CertificateRequestAttributes,
     TLSCertificatesRequiresV4,
 )
+from charms.mysql.v0.async_replication import (
+    RELATION_CONSUMER,
+    RELATION_OFFER,
+)
 from charms.mysql.v0.mysql import MySQLTLSSetupError
 from mysql_shell.models import InstanceState
 from ops.framework import EventBase, EventSource, Object
@@ -21,7 +25,9 @@ from ops.pebble import PathError, ProtocolError
 from constants import (
     DB_RELATION_NAME,
     MYSQL_DATA_DIR,
+    PEER,
     TLS_CLIENT_RELATION,
+    TLS_PEER_RELATION,
     TLS_SSL_CA_FILE,
     TLS_SSL_CERT_FILE,
     TLS_SSL_KEY_FILE,
@@ -69,12 +75,32 @@ class TLS(Object):
             ],
             refresh_events=[self.refresh_tls_certificates_event],
         )
+        self.peer_certificate = TLSCertificatesRequiresV4(
+            self.charm,
+            TLS_PEER_RELATION,
+            certificate_requests=[
+                CertificateRequestAttributes(
+                    common_name=self._get_peer_common_name(),
+                    sans_dns={
+                        *self._common_hosts,
+                        *self._get_peer_addresses(),
+                    },
+                ),
+            ],
+            refresh_events=[self.refresh_tls_certificates_event],
+        )
 
         self.framework.observe(
             self.client_certificate.on.certificate_available, self._on_client_certificate_available
         )
         self.framework.observe(
+            self.peer_certificate.on.certificate_available, self._on_peer_certificate_available
+        )
+        self.framework.observe(
             self.charm.on[TLS_CLIENT_RELATION].relation_broken, self._on_client_relation_broken
+        )
+        self.framework.observe(
+            self.charm.on[TLS_PEER_RELATION].relation_broken, self._on_peer_relation_broken
         )
 
     def _get_common_name(self) -> str:
@@ -88,6 +114,10 @@ class TLS(Object):
         """Get a common name for the client certificate attributes."""
         return self._get_common_name()
 
+    def _get_peer_common_name(self) -> str:
+        """Get a common name for the peer certificate attributes."""
+        return self._get_common_name()
+
     def _get_client_addresses(self) -> set[str]:
         """Get a set of client connection addresses for the certificate attributes."""
         client_addresses = set()
@@ -95,6 +125,18 @@ class TLS(Object):
             client_addresses.add(addr)
 
         return client_addresses
+
+    def _get_peer_addresses(self) -> set[str]:
+        """Get a set of peer connection addresses for the certificate attributes."""
+        peer_addresses = set()
+        if addr := self.charm.get_unit_address(self.charm.unit, RELATION_CONSUMER):
+            peer_addresses.add(addr)
+        if addr := self.charm.get_unit_address(self.charm.unit, RELATION_OFFER):
+            peer_addresses.add(addr)
+        if addr := self.charm.get_unit_address(self.charm.unit, PEER):
+            peer_addresses.add(addr)
+
+        return peer_addresses
 
     def _get_client_tls_files(self) -> tuple[str | None, str | None, str | None]:
         """Prepare TLS files in special MySQL way.
@@ -109,6 +151,27 @@ class TLS(Object):
         key_file = None
 
         certs, private_key = self.client_certificate.get_assigned_certificates()
+        if private_key:
+            key_file = str(private_key)
+        if certs:
+            cert_file = str(certs[0].certificate)
+            ca_file = str(certs[0].ca)
+
+        return key_file, ca_file, cert_file
+
+    def _get_peer_tls_files(self) -> tuple[str | None, str | None, str | None]:
+        """Prepare TLS files in special MySQL way.
+
+        MySQL needs three files:
+        - CA file should have a full chain.
+        - Key file should have private key.
+        - Certificate file should have certificate without certificate chain.
+        """
+        ca_file = None
+        cert_file = None
+        key_file = None
+
+        certs, private_key = self.peer_certificate.get_assigned_certificates()
         if private_key:
             key_file = str(private_key)
         if certs:
@@ -149,6 +212,36 @@ class TLS(Object):
 
         self.charm.unit.status = self.charm.build_unit_workload_status()
 
+    def _on_peer_certificate_available(self, event: EventBase) -> None:
+        """Handler for the peer certificate available event."""
+        state = self.charm._mysql.get_member_state()
+        if state != InstanceState.ONLINE:
+            logger.debug("Unit not initialized yet, deferring peer TLS configuration.")
+            event.defer()
+            return
+
+        self.charm.unit.status = MaintenanceStatus("Enabling peer TLS")
+
+        try:
+            self._push_tls_files_to_workload()
+        except (PebbleConnectionError, PathError, ProtocolError) as e:
+            logger.error(f"Cannot push TLS certificates: {e}")
+            event.defer()
+            return
+
+        try:
+            self.charm._mysql.setup_group_tls(
+                ca_path=f"{MYSQL_DATA_DIR}/peer_{TLS_SSL_CA_FILE}",
+                key_path=f"{MYSQL_DATA_DIR}/peer_{TLS_SSL_KEY_FILE}",
+                cert_path=f"{MYSQL_DATA_DIR}/peer_{TLS_SSL_CERT_FILE}",
+                require_tls=True,
+            )
+            self.charm.rolling_ops.request_async_lock(callback_id="replication")
+        except MySQLTLSSetupError as e:
+            logger.error(f"Failed to enable peer TLS: {e}")
+            self.charm.unit.status = BlockedStatus("Failed to enable peer TLS.")
+            return
+
     def _on_client_relation_broken(self, _: EventBase) -> None:
         """Handler for the client relation broken event."""
         if self.charm.removing_unit:
@@ -167,6 +260,22 @@ class TLS(Object):
 
         self.charm.unit.status = self.charm.build_unit_workload_status()
 
+    def _on_peer_relation_broken(self, _: EventBase) -> None:
+        """Handler for the peer relation broken event."""
+        if self.charm.removing_unit:
+            logger.debug("Unit is being removed, skipping peer TLS cleanup.")
+            return
+
+        self.charm.unit.status = MaintenanceStatus("Disabling peer TLS")
+
+        try:
+            self.charm._mysql.setup_group_tls()
+            self.charm.rolling_ops.request_async_lock(callback_id="replication")
+        except MySQLTLSSetupError as e:
+            logger.error(f"Failed to disable peer TLS: {e}")
+            self.charm.unit.status = BlockedStatus("Failed to disable peer TLS.")
+            return
+
     def _push_tls_files_to_workload(self) -> None:
         """Push TLS files to unit."""
         key, ca, cert = self._get_client_tls_files()
@@ -181,4 +290,18 @@ class TLS(Object):
         if cert:
             self.charm._mysql.write_content_to_file(
                 f"{MYSQL_DATA_DIR}/client_{TLS_SSL_CERT_FILE}", cert, permission=0o400
+            )
+
+        key, ca, cert = self._get_peer_tls_files()
+        if key:
+            self.charm._mysql.write_content_to_file(
+                f"{MYSQL_DATA_DIR}/peer_{TLS_SSL_KEY_FILE}", key, permission=0o400
+            )
+        if ca:
+            self.charm._mysql.write_content_to_file(
+                f"{MYSQL_DATA_DIR}/peer_{TLS_SSL_CA_FILE}", ca, permission=0o400
+            )
+        if cert:
+            self.charm._mysql.write_content_to_file(
+                f"{MYSQL_DATA_DIR}/peer_{TLS_SSL_CERT_FILE}", cert, permission=0o400
             )

--- a/kubernetes/terraform/outputs.tf
+++ b/kubernetes/terraform/outputs.tf
@@ -16,6 +16,7 @@ output "requires" {
   description = "Map of all the required endpoints"
   value = {
     client_certificates = "client-certificates"
+    peer_certificates   = "peer-certificates"
     s3_parameters       = "s3-parameters"
     logging             = "logging"
     tracing             = "tracing"

--- a/kubernetes/tests/integration/integration/test_tls.py
+++ b/kubernetes/tests/integration/integration/test_tls.py
@@ -3,7 +3,6 @@
 
 import json
 import logging
-from time import sleep
 
 import jubilant
 from jubilant import Juju
@@ -25,10 +24,7 @@ logger = logging.getLogger(__name__)
 
 APP_NAME = CHARM_METADATA["name"]
 TLS_APP_NAME = "self-signed-certificates"
-
 CLUSTER_NAME = "test_cluster"
-MODEL_CONFIG = {"logging-config": "<root>=INFO;unit=DEBUG"}
-TLS_SETUP_SLEEP_TIME = 30
 TIMEOUT = 15 * MINUTE_SECS
 
 # Global config dictionary for connection testing
@@ -37,9 +33,6 @@ config = {}
 
 def test_build_and_deploy(juju: Juju, charm) -> None:
     """Build the charm and deploy 3 units to ensure a cluster is formed."""
-    # Set model configuration
-    juju.model_config(MODEL_CONFIG)
-
     logger.info(f"Deploying {APP_NAME}")
     juju.deploy(
         charm,
@@ -104,9 +97,18 @@ def test_enable_tls(juju: Juju) -> None:
     # Relate with TLS charm
     logger.info("Relate to TLS operator")
     juju.integrate(f"{APP_NAME}:client-certificates", f"{TLS_APP_NAME}:certificates")
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, APP_NAME, TLS_APP_NAME),
+        timeout=TIMEOUT,
+        delay=5,
+    )
 
-    # allow time for TLS enablement
-    sleep(TLS_SETUP_SLEEP_TIME)
+    juju.integrate(f"{APP_NAME}:peer-certificates", f"{TLS_APP_NAME}:certificates")
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, APP_NAME, TLS_APP_NAME),
+        timeout=TIMEOUT,
+        delay=5,
+    )
 
     # After relating to only encrypted connection should be possible
     logger.info("Asserting connections after relation")
@@ -132,9 +134,18 @@ def test_disable_tls(juju: Juju) -> None:
 
     logger.info("Removing relation")
     juju.remove_relation(f"{APP_NAME}:client-certificates", f"{TLS_APP_NAME}:certificates")
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, APP_NAME, TLS_APP_NAME),
+        timeout=TIMEOUT,
+        delay=5,
+    )
 
-    # Allow time for reconfigure
-    sleep(TLS_SETUP_SLEEP_TIME)
+    juju.remove_relation(f"{APP_NAME}:peer-certificates", f"{TLS_APP_NAME}:certificates")
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, APP_NAME, TLS_APP_NAME),
+        timeout=TIMEOUT,
+        delay=5,
+    )
 
     # After relation removal both encrypted and unencrypted connection should be possible
     for unit_name in app_units:

--- a/machines/lib/charms/mysql/v0/mysql.py
+++ b/machines/lib/charms/mysql/v0/mysql.py
@@ -2921,15 +2921,46 @@ class MySQLBase(ABC):
         require_tls: bool = False,
     ) -> None:
         """Setup client-connection TLS files and requirement mode."""
-        tls_var = "require_secure_transport"
-        tls_val = "ON" if require_tls else "OFF"
+        client = self._instance_client_tcp
+        usage = "ON" if require_tls else "OFF"
 
         try:
-            self._instance_client_tcp.set_instance_variable(Scope.PERSIST, "ssl_ca", ca_path)
-            self._instance_client_tcp.set_instance_variable(Scope.PERSIST, "ssl_key", key_path)
-            self._instance_client_tcp.set_instance_variable(Scope.PERSIST, "ssl_cert", cert_path)
-            self._instance_client_tcp.set_instance_variable(Scope.PERSIST, tls_var, tls_val)
-            self._instance_client_tcp.reload_instance_certs()
+            client.set_instance_variable(Scope.PERSIST, "ssl_ca", ca_path)
+            client.set_instance_variable(Scope.PERSIST, "ssl_key", key_path)
+            client.set_instance_variable(Scope.PERSIST, "ssl_cert", cert_path)
+            client.set_instance_variable(Scope.PERSIST, "require_secure_transport", usage)
+            client.reload_instance_certs()
+        except ExecutionError as e:
+            raise MySQLTLSSetupError() from e
+
+    def setup_group_tls(
+        self,
+        ca_path: str = "ca.pem",
+        key_path: str = "server-key.pem",
+        cert_path: str = "server-cert.pem",
+        require_tls: bool = False,
+    ) -> None:
+        """Setup group-replication TLS files and requirement mode."""
+        client = self._instance_client_tcp
+        usage_recovery = "ON" if require_tls else "OFF"
+        usage_replication = "REQUIRED" if require_tls else "DISABLED"
+
+        try:
+            client.set_instance_variable(
+                Scope.PERSIST, "group_replication_recovery_ssl_ca", ca_path
+            )
+            client.set_instance_variable(
+                Scope.PERSIST, "group_replication_recovery_ssl_key", key_path
+            )
+            client.set_instance_variable(
+                Scope.PERSIST, "group_replication_recovery_ssl_cert", cert_path
+            )
+            client.set_instance_variable(
+                Scope.PERSIST, "group_replication_recovery_use_ssl", usage_recovery
+            )
+            client.set_instance_variable(
+                Scope.PERSIST, "group_replication_ssl_mode", usage_replication
+            )
         except ExecutionError as e:
             raise MySQLTLSSetupError() from e
 

--- a/machines/metadata.yaml
+++ b/machines/metadata.yaml
@@ -45,6 +45,10 @@ requires:
     interface: tls-certificates
     limit: 1
     optional: true
+  peer-certificates:
+    interface: tls-certificates
+    limit: 1
+    optional: true
   s3-parameters:
     interface: s3
     limit: 1

--- a/machines/src/charm.py
+++ b/machines/src/charm.py
@@ -10,6 +10,7 @@ from ops.main import main
 if is_wrong_architecture() and __name__ == "__main__":
     main(WrongArchitectureWarningCharm)
 
+import json
 import logging
 import random
 import socket
@@ -17,7 +18,8 @@ from time import sleep
 
 import charm_refresh
 import ops
-from charmlibs.rollingops import RollingOpsManager
+from charmlibs.pathops import LocalPath
+from charmlibs.rollingops import OperationResult, RollingOpsManager
 from charms.data_platform_libs.v1.data_models import TypedCharmBase
 from charms.grafana_agent.v0.cos_agent import COSAgentProvider, ProtocolNotFoundError
 from charms.mysql.v0.async_replication import (
@@ -208,9 +210,12 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
 
         self.rolling_ops = RollingOpsManager(
             charm=self,
-            base_dir="/var/lib/rollingops",
+            base_dir=LocalPath("/var/lib/juju/rollingops"),
             peer_relation_name="rolling-ops",
-            callback_targets={"restart": self._restart},
+            callback_targets={
+                "replication": self._restart_group_replication,
+                "restart": self._restart,
+            },
         )
 
         self.mysql_logs = MySQLLogs(self)
@@ -1037,12 +1042,50 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             except RetryError:
                 raise
 
-    def _restart(self) -> None:
+    def _restart_group_replication(self) -> OperationResult:
+        """Restarts Group replication on the instance."""
+        relation = self.model.get_relation("rolling-ops")
+        if not relation:
+            logger.info("Skipping group replication restart")
+            return OperationResult.RETRY_RELEASE
+
+        ongoing_ops = [relation.data[unit].get("operations", "[]") for unit in self.peers.units]
+        ongoing_ops = [json.loads(op) for op in ongoing_ops]
+
+        if self.is_unit_primary() and any(ongoing_ops):
+            logger.info("Skipping group replication restart")
+            return OperationResult.RETRY_RELEASE
+
+        if self.is_unit_primary() and self.app.planned_units() > 1:
+            try:
+                new_primary = self.get_unit_address(self.peers.units.pop(), PEER)
+                logger.debug(f"Switching primary to {new_primary}")
+                self._mysql.set_cluster_primary(new_primary)
+            except MySQLSetClusterPrimaryError:
+                logger.warning("Changing primary failed")
+                return OperationResult.RETRY_HOLD
+
+        cluster_primary = self._mysql.get_cluster_primary_address()
+        if not cluster_primary:
+            logger.warning("Getting primary failed")
+            return OperationResult.RETRY_HOLD
+
+        logger.info("Recreating group replication")
+        self._mysql.rejoin_instance_to_cluster(
+            unit_address=self.unit_address,
+            unit_label=self.unit_label,
+            from_instance=cluster_primary,
+        )
+
+        self._on_update_status(None)
+        return OperationResult.RELEASE
+
+    def _restart(self) -> OperationResult:
         """Restart the service."""
         if not self.unit_initialized():
             logger.debug("Restarting standalone mysqld")
             self._mysql.restart_mysqld()
-            return
+            return OperationResult.RELEASE
 
         if self.app.planned_units() > 1 and self.is_unit_primary():
             try:
@@ -1060,6 +1103,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         self.recover_unit_after_restart()
 
         self._on_update_status(None)
+        return OperationResult.RELEASE
 
 
 if __name__ == "__main__":

--- a/machines/src/constants.py
+++ b/machines/src/constants.py
@@ -20,6 +20,7 @@ MONITORING_PASSWORD_KEY = "monitoring-password"  # noqa: S105
 BACKUPS_PASSWORD_KEY = "backups-password"  # noqa: S105
 
 TLS_CLIENT_RELATION = "client-certificates"
+TLS_PEER_RELATION = "peer-certificates"
 TLS_SSL_CA_FILE = "custom-ca.pem"
 TLS_SSL_KEY_FILE = "custom-server-key.pem"
 TLS_SSL_CERT_FILE = "custom-server-cert.pem"

--- a/machines/src/relations/tls.py
+++ b/machines/src/relations/tls.py
@@ -11,6 +11,10 @@ from charmlibs.interfaces.tls_certificates import (
     CertificateRequestAttributes,
     TLSCertificatesRequiresV4,
 )
+from charms.mysql.v0.async_replication import (
+    RELATION_CONSUMER,
+    RELATION_OFFER,
+)
 from charms.mysql.v0.mysql import MySQLTLSSetupError
 from mysql_shell.models import InstanceState
 from ops.framework import EventBase, EventSource, Object
@@ -21,7 +25,9 @@ from ops.pebble import PathError, ProtocolError
 from constants import (
     DB_RELATION_NAME,
     MYSQL_DATA_DIR,
+    PEER,
     TLS_CLIENT_RELATION,
+    TLS_PEER_RELATION,
     TLS_SSL_CA_FILE,
     TLS_SSL_CERT_FILE,
     TLS_SSL_KEY_FILE,
@@ -67,17 +73,41 @@ class TLS(Object):
             ],
             refresh_events=[self.refresh_tls_certificates_event],
         )
+        self.peer_certificate = TLSCertificatesRequiresV4(
+            self.charm,
+            TLS_PEER_RELATION,
+            certificate_requests=[
+                CertificateRequestAttributes(
+                    common_name=self._get_peer_common_name(),
+                    sans_dns={
+                        *self._common_hosts,
+                        *self._get_peer_addresses(),
+                    },
+                ),
+            ],
+            refresh_events=[self.refresh_tls_certificates_event],
+        )
 
         self.framework.observe(
             self.client_certificate.on.certificate_available, self._on_client_certificate_available
         )
         self.framework.observe(
+            self.peer_certificate.on.certificate_available, self._on_peer_certificate_available
+        )
+        self.framework.observe(
             self.charm.on[TLS_CLIENT_RELATION].relation_broken, self._on_client_relation_broken
+        )
+        self.framework.observe(
+            self.charm.on[TLS_PEER_RELATION].relation_broken, self._on_peer_relation_broken
         )
 
     def _get_client_common_name(self) -> str:
-        """Get a common name for the certificate attributes."""
+        """Get a common name for the client certificate attributes."""
         return self.charm.get_unit_address(self.charm.unit, DB_RELATION_NAME) or self.unit_name
+
+    def _get_peer_common_name(self) -> str:
+        """Get a common name for the peer certificate attributes."""
+        return self.charm.get_unit_address(self.charm.unit, PEER) or self.unit_name
 
     def _get_client_addresses(self) -> set[str]:
         """Get a set of client connection addresses for the certificate attributes."""
@@ -86,6 +116,18 @@ class TLS(Object):
             client_addresses.add(addr)
 
         return client_addresses
+
+    def _get_peer_addresses(self) -> set[str]:
+        """Get a set of peer connection addresses for the certificate attributes."""
+        peer_addresses = set()
+        if addr := self.charm.get_unit_address(self.charm.unit, RELATION_CONSUMER):
+            peer_addresses.add(addr)
+        if addr := self.charm.get_unit_address(self.charm.unit, RELATION_OFFER):
+            peer_addresses.add(addr)
+        if addr := self.charm.get_unit_address(self.charm.unit, PEER):
+            peer_addresses.add(addr)
+
+        return peer_addresses
 
     def _get_client_tls_files(self) -> tuple[str | None, str | None, str | None]:
         """Prepare TLS files in special MySQL way.
@@ -100,6 +142,27 @@ class TLS(Object):
         key_file = None
 
         certs, private_key = self.client_certificate.get_assigned_certificates()
+        if private_key:
+            key_file = str(private_key)
+        if certs:
+            cert_file = str(certs[0].certificate)
+            ca_file = str(certs[0].ca)
+
+        return key_file, ca_file, cert_file
+
+    def _get_peer_tls_files(self) -> tuple[str | None, str | None, str | None]:
+        """Prepare TLS files in special MySQL way.
+
+        MySQL needs three files:
+        - CA file should have a full chain.
+        - Key file should have private key.
+        - Certificate file should have certificate without certificate chain.
+        """
+        ca_file = None
+        cert_file = None
+        key_file = None
+
+        certs, private_key = self.peer_certificate.get_assigned_certificates()
         if private_key:
             key_file = str(private_key)
         if certs:
@@ -140,6 +203,36 @@ class TLS(Object):
 
         self.charm.unit.status = self.charm.build_unit_workload_status()
 
+    def _on_peer_certificate_available(self, event: EventBase) -> None:
+        """Handler for the peer certificate available event."""
+        state = self.charm._mysql.get_member_state()
+        if state != InstanceState.ONLINE:
+            logger.debug("Unit not initialized yet, deferring peer TLS configuration.")
+            event.defer()
+            return
+
+        self.charm.unit.status = MaintenanceStatus("Enabling peer TLS")
+
+        try:
+            self._push_tls_files_to_workload()
+        except (PebbleConnectionError, PathError, ProtocolError) as e:
+            logger.error(f"Cannot push TLS certificates: {e}")
+            event.defer()
+            return
+
+        try:
+            self.charm._mysql.setup_group_tls(
+                ca_path=f"{MYSQL_DATA_DIR}/peer_{TLS_SSL_CA_FILE}",
+                key_path=f"{MYSQL_DATA_DIR}/peer_{TLS_SSL_KEY_FILE}",
+                cert_path=f"{MYSQL_DATA_DIR}/peer_{TLS_SSL_CERT_FILE}",
+                require_tls=True,
+            )
+            self.charm.rolling_ops.request_async_lock(callback_id="replication")
+        except MySQLTLSSetupError as e:
+            logger.error(f"Failed to enable peer TLS: {e}")
+            self.charm.unit.status = BlockedStatus("Failed to enable peer TLS.")
+            return
+
     def _on_client_relation_broken(self, _: EventBase) -> None:
         """Handler for the client relation broken event."""
         if self.charm.removing_unit:
@@ -158,6 +251,22 @@ class TLS(Object):
 
         self.charm.unit.status = self.charm.build_unit_workload_status()
 
+    def _on_peer_relation_broken(self, _: EventBase) -> None:
+        """Handler for the peer relation broken event."""
+        if self.charm.removing_unit:
+            logger.debug("Unit is being removed, skipping peer TLS cleanup.")
+            return
+
+        self.charm.unit.status = MaintenanceStatus("Disabling peer TLS")
+
+        try:
+            self.charm._mysql.setup_group_tls()
+            self.charm.rolling_ops.request_async_lock(callback_id="replication")
+        except MySQLTLSSetupError as e:
+            logger.error(f"Failed to disable peer TLS: {e}")
+            self.charm.unit.status = BlockedStatus("Failed to disable peer TLS.")
+            return
+
     def _push_tls_files_to_workload(self) -> None:
         """Push TLS files to unit."""
         key, ca, cert = self._get_client_tls_files()
@@ -172,4 +281,18 @@ class TLS(Object):
         if cert:
             self.charm._mysql.write_content_to_file(
                 f"{MYSQL_DATA_DIR}/client_{TLS_SSL_CERT_FILE}", cert, permission=0o400
+            )
+
+        key, ca, cert = self._get_peer_tls_files()
+        if key:
+            self.charm._mysql.write_content_to_file(
+                f"{MYSQL_DATA_DIR}/peer_{TLS_SSL_KEY_FILE}", key, permission=0o400
+            )
+        if ca:
+            self.charm._mysql.write_content_to_file(
+                f"{MYSQL_DATA_DIR}/peer_{TLS_SSL_CA_FILE}", ca, permission=0o400
+            )
+        if cert:
+            self.charm._mysql.write_content_to_file(
+                f"{MYSQL_DATA_DIR}/peer_{TLS_SSL_CERT_FILE}", cert, permission=0o400
             )

--- a/machines/terraform/outputs.tf
+++ b/machines/terraform/outputs.tf
@@ -15,6 +15,7 @@ output "requires" {
   description = "Map of all the required endpoints"
   value = {
     client_certificates = "client-certificates"
+    peer_certificates   = "peer-certificates"
     s3_parameters       = "s3-parameters"
     tracing             = "tracing"
   }

--- a/machines/tests/integration/integration/test_tls.py
+++ b/machines/tests/integration/integration/test_tls.py
@@ -3,7 +3,6 @@
 
 import json
 import logging
-from time import sleep
 
 import jubilant
 from jubilant import Juju
@@ -26,10 +25,7 @@ logger = logging.getLogger(__name__)
 
 APP_NAME = "mysql"
 TLS_APP_NAME = "self-signed-certificates"
-
 CLUSTER_NAME = "test_cluster"
-SLEEP_WAIT = 5
-TLS_SETUP_SLEEP_TIME = 30
 TIMEOUT = 15 * MINUTE_SECS
 
 config = {}
@@ -100,15 +96,17 @@ def test_enable_tls(juju: Juju) -> None:
     # Relate with TLS charm
     logger.info("Relate to TLS operator")
     juju.integrate(f"{APP_NAME}:client-certificates", f"{TLS_APP_NAME}:certificates")
-
-    # Wait for hooks start reconfiguring app
-    # add as a wait since app state does not change
-    # due tls setup running too briefly
-    sleep(TLS_SETUP_SLEEP_TIME)
-
     juju.wait(
-        jubilant.all_active,
+        ready=wait_for_apps_status(jubilant.all_active, APP_NAME, TLS_APP_NAME),
         timeout=TIMEOUT,
+        delay=5,
+    )
+
+    juju.integrate(f"{APP_NAME}:peer-certificates", f"{TLS_APP_NAME}:certificates")
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, APP_NAME, TLS_APP_NAME),
+        timeout=TIMEOUT,
+        delay=5,
     )
 
     # After relating to only encrypted connection should be possible
@@ -135,9 +133,18 @@ def test_disable_tls(juju: Juju) -> None:
 
     logger.info("Removing relation")
     juju.remove_relation(f"{APP_NAME}:client-certificates", f"{TLS_APP_NAME}:certificates")
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, APP_NAME, TLS_APP_NAME),
+        timeout=TIMEOUT,
+        delay=5,
+    )
 
-    # Allow time for reconfigure
-    sleep(TLS_SETUP_SLEEP_TIME)
+    juju.remove_relation(f"{APP_NAME}:peer-certificates", f"{TLS_APP_NAME}:certificates")
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, APP_NAME, TLS_APP_NAME),
+        timeout=TIMEOUT,
+        delay=5,
+    )
 
     # After relation removal both encrypted and unencrypted connection should be possible
     for unit_name in app_units:

--- a/machines/tests/unit/test_mysql.py
+++ b/machines/tests/unit/test_mysql.py
@@ -1569,6 +1569,32 @@ class TestMySQLBase(unittest.TestCase):
         self.mysql.setup_client_tls()
         self.mock_executor.execute_sql.assert_has_calls([call(query) for query in queries])
 
+    def test_setup_group_tls(self):
+        """Test the successful execution of setup_group_tls."""
+        queries = [
+            "SET @@PERSIST.`group_replication_recovery_ssl_ca` = 'ca_path'",
+            "SET @@PERSIST.`group_replication_recovery_ssl_key` = 'key_path'",
+            "SET @@PERSIST.`group_replication_recovery_ssl_cert` = 'cert_path'",
+            "SET @@PERSIST.`group_replication_recovery_use_ssl` = 'ON'",
+            "SET @@PERSIST.`group_replication_ssl_mode` = 'REQUIRED'",
+        ]
+
+        self.mysql.setup_group_tls("ca_path", "key_path", "cert_path", True)
+        self.mock_executor.execute_sql.assert_has_calls([call(query) for query in queries])
+
+    def test_restore_group_tls(self):
+        """Test the successful execution of setup_group_tls."""
+        queries = [
+            "SET @@PERSIST.`group_replication_recovery_ssl_ca` = 'ca.pem'",
+            "SET @@PERSIST.`group_replication_recovery_ssl_key` = 'server-key.pem'",
+            "SET @@PERSIST.`group_replication_recovery_ssl_cert` = 'server-cert.pem'",
+            "SET @@PERSIST.`group_replication_recovery_use_ssl` = 'OFF'",
+            "SET @@PERSIST.`group_replication_ssl_mode` = 'DISABLED'",
+        ]
+
+        self.mysql.setup_group_tls()
+        self.mock_executor.execute_sql.assert_has_calls([call(query) for query in queries])
+
     def test_kill_client_sessions(self):
         """Test kill_client_sessions."""
         search_query = (


### PR DESCRIPTION
This PR exposes a way to encrypt _peer-to-peer_ traffic using version 4 of the `tls-certificates` interface.

### Approach:

According to the docs (see last paragraph of [this page](https://dev.mysql.com/doc/refman/8.4/en/group-replication-secure-socket-layer-support-ssl.html)), when MySQL instances are clustered using `mysql` communication stack, the same variables that encrypt group-replication recovery, are used for group-replication communication. Therefore, [this page](https://dev.mysql.com/doc/refman/8.4/en/group-replication-configuring-ssl-for-recovery.html) specifies the variables used to configure the group-replication encryption.

In addition, MySQL group-replication encryption allows to define a _mode_. From those, the `REQUIRED` mode is proposed as a way to simplify the dynamic enabling / disabling of peer-to-peer encryption, in clusters whose instances will default to their own auto-generated certificates as a fallback (i.e. certificates coming from different CAs).

### Future work:

- Define the necessary logic to parse a manually configured private key for TLS certificates generation.

---

Depends on PR https://github.com/canonical/mysql-operators/pull/255