### PR TITLE
Update promote action 8.0

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -5,21 +5,15 @@ name: Promote charm
 on:
   workflow_dispatch:
     inputs:
-      path-to-charm:
-        description: Promote charm in this path
+      revisions:
+        description: |
+          Comma-separated list of git revision tags to promote.
+          These must match the tags created by canonical/data-platform-workflows release_charm_edge.yaml
+
+          Single-charm repo example: 'rev123,rev124'
+          Monorepo example: 'mysql/rev123,mysql-k8s/rev124'
         required: true
-        type: choice
-        options:
-          - kubernetes
-          - machines
-      from-risk:
-        description: Promote from this Charmhub risk
-        required: true
-        type: choice
-        options:
-          - edge
-          - beta
-          - candidate
+        type: string
       to-risk:
         description: Promote to this Charmhub risk
         required: true
@@ -32,14 +26,12 @@ on:
 jobs:
   promote:
     name: Promote charm
-    uses: canonical/data-platform-workflows/.github/workflows/_promote_charm_legacy.yaml@v48.1.2
+    uses: canonical/data-platform-workflows/.github/workflows/_promote_charms.yaml@v49.0.1
     with:
-      track: '8.0'
-      from-risk: ${{ inputs.from-risk }}
+      track: '8.4'
+      revisions: ${{ inputs.revisions }}
       to-risk: ${{ inputs.to-risk }}
-      path-to-charm-directory: ${{ inputs.path-to-charm }}
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
     permissions:
-      actions: read
       contents: write  # Needed to edit GitHub releases

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -28,7 +28,7 @@ jobs:
     name: Promote charm
     uses: canonical/data-platform-workflows/.github/workflows/_promote_charms.yaml@v49.0.1
     with:
-      track: '8.4'
+      track: '8.0'
       revisions: ${{ inputs.revisions }}
       to-risk: ${{ inputs.to-risk }}
     secrets:

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -1,6 +1,6 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
-name: Promote charm
+name: Promote charms
 
 on:
   workflow_dispatch:
@@ -25,7 +25,7 @@ on:
 
 jobs:
   promote:
-    name: Promote charm
+    name: Promote charms
     uses: canonical/data-platform-workflows/.github/workflows/_promote_charms.yaml@v49.0.1
     with:
       track: '8.0'
@@ -34,4 +34,5 @@ jobs:
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
     permissions:
+      actions: read  # Needed for GitHub API call to get workflow version
       contents: write  # Needed to edit GitHub releases


### PR DESCRIPTION
Merges previous promote actions into a new one that handles both track layouts. The new action will now take a series of tags representing the charm revisions to promote.

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
