### PR TITLE
Update dependency pytest to v9 [SECURITY]

### DIFF
--- a/kubernetes/poetry.lock
+++ b/kubernetes/poetry.lock
@@ -1433,6 +1433,21 @@ files = [
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+description = "Pygments is a syntax highlighting package written in Python."
+optional = false
+python-versions = ">=3.9"
+groups = ["integration", "unit"]
+files = [
+    {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
+    {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
+]
+
+[package.extras]
+windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
 name = "pymacaroons"
 version = "0.13.0"
 description = "Macaroon library for Python"
@@ -1492,26 +1507,27 @@ pytz = "*"
 
 [[package]]
 name = "pytest"
-version = "7.4.4"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.10"
 groups = ["integration", "unit"]
 files = [
-    {file = "pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8"},
-    {file = "pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
-colorama = {version = "*", markers = "sys_platform == \"win32\""}
-exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
-iniconfig = "*"
-packaging = "*"
-pluggy = ">=0.12,<2.0"
-tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
+iniconfig = ">=1.0.1"
+packaging = ">=22"
+pluggy = ">=1.5,<2"
+pygments = ">=2.7.2"
+tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 
 [package.extras]
-testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "pytest-mock"

--- a/kubernetes/pyproject.toml
+++ b/kubernetes/pyproject.toml
@@ -36,13 +36,13 @@ lint = [
     "shellcheck-py~=0.9.0",
 ]
 unit = [
-    "pytest~=7.4",
+    "pytest~=9.0",
     "pytest-mock~=3.11",
     "coverage[toml]~=7.2",
     "parameterized~=0.9.0",
 ]
 integration = [
-    "pytest~=7.4",
+    "pytest~=9.0",
     "jinja2~=3.1",
     "juju~=3.6",
     "ops~=2.15",

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_stop_all.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_stop_all.py
@@ -69,7 +69,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         load_mysql_test_data(juju, MYSQL_APP_NAME, path)
 
 
-async def test_graceful_full_cluster_crash(juju: Juju, continuous_writes) -> None:
+def test_graceful_full_cluster_crash(juju: Juju, continuous_writes) -> None:
     """Pause test.
 
     A graceful simultaneous restart of all instances,

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_stop_primary.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_stop_primary.py
@@ -69,7 +69,7 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         load_mysql_test_data(juju, MYSQL_APP_NAME, path)
 
 
-async def test_graceful_crash_of_primary(juju: Juju, continuous_writes) -> None:
+def test_graceful_crash_of_primary(juju: Juju, continuous_writes) -> None:
     """Test to send SIGTERM to primary instance and then verify recovery."""
     # Ensure continuous writes still incrementing for all units
     check_mysql_units_writes_increment(juju, MYSQL_APP_NAME)

--- a/machines/poetry.lock
+++ b/machines/poetry.lock
@@ -1449,6 +1449,21 @@ files = [
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+description = "Pygments is a syntax highlighting package written in Python."
+optional = false
+python-versions = ">=3.9"
+groups = ["integration", "unit"]
+files = [
+    {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
+    {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
+]
+
+[package.extras]
+windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
 name = "pyhcl"
 version = "0.4.5"
 description = "HCL configuration parser for python"
@@ -1520,26 +1535,27 @@ pytz = "*"
 
 [[package]]
 name = "pytest"
-version = "7.4.4"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.10"
 groups = ["integration", "unit"]
 files = [
-    {file = "pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8"},
-    {file = "pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
-colorama = {version = "*", markers = "sys_platform == \"win32\""}
-exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
-iniconfig = "*"
-packaging = "*"
-pluggy = ">=0.12,<2.0"
-tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
+iniconfig = ">=1.0.1"
+packaging = ">=22"
+pluggy = ">=1.5,<2"
+pygments = ">=2.7.2"
+tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 
 [package.extras]
-testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "pytest-mock"

--- a/machines/pyproject.toml
+++ b/machines/pyproject.toml
@@ -36,13 +36,13 @@ lint = [
     "shellcheck-py~=0.9.0",
 ]
 unit = [
-    "pytest~=7.4",
+    "pytest~=9.0",
     "pytest-mock~=3.11",
     "coverage[toml]~=7.2",
     "parameterized~=0.9.0",
 ]
 integration = [
-    "pytest~=7.4",
+    "pytest~=9.0",
     "juju~=3.6",
     "mysql-connector-python~=9.1",
     "tenacity~=8.2",


### PR DESCRIPTION
This PR is a backport of the same security [PR](https://github.com/canonical/mysql-operators/pull/237) targeting `8.4/edge` branch.
