### PR TITLE
[MISC] 8.0 - Cleanup K8s legacy permissions fix [revert]

### DIFF
--- a/kubernetes/metadata.yaml
+++ b/kubernetes/metadata.yaml
@@ -31,7 +31,7 @@ resources:
   mysql-image:
     type: oci-image
     description: Ubuntu LTS Docker image for MySQL
-    upstream-source: ghcr.io/canonical/charmed-mysql@sha256:82013980ad6da9b09d62348c02ece1c0ebf5847f8c0af62d341555122d2bd7ca
+    upstream-source: ghcr.io/canonical/charmed-mysql@sha256:824b302484f83dbbd2cf4506f620a48e53f20053f6ff3c57aa6123e121705bfc
 
 peers:
   database-peers:

--- a/kubernetes/src/charm.py
+++ b/kubernetes/src/charm.py
@@ -684,6 +684,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         # bootstrap the data directory and users
         logger.info("Initializing mysqld")
         try:
+            self._mysql.fix_data_dir(container)
             self._mysql.initialise_mysqld()
 
             # Add the pebble layer

--- a/kubernetes/src/mysql_k8s_helpers.py
+++ b/kubernetes/src/mysql_k8s_helpers.py
@@ -196,6 +196,32 @@ class MySQL(MySQLBase):
         executor.set_container(self.container)
         return executor
 
+    def fix_data_dir(self, container: Container) -> None:
+        """Ensure the data directory for mysql is writable for the "mysql" user.
+
+        Until the ability to set fsGroup and fsGroupChangePolicy via Pod securityContext
+        is available we fix permissions incorrectly with chown.
+        """
+        if not container.exists(MYSQL_DATA_DIR):
+            container.make_dir(MYSQL_DATA_DIR, user=MYSQL_SYSTEM_USER, group=MYSQL_SYSTEM_GROUP)
+            return
+
+        paths = container.list_files(MYSQL_DATA_DIR, itself=True)
+        logger.debug(f"Data directory ownership: {paths[0].user}:{paths[0].group}")
+        if paths[0].user != MYSQL_SYSTEM_USER or paths[0].group != MYSQL_SYSTEM_GROUP:
+            logger.debug(f"Changing ownership to {MYSQL_SYSTEM_USER}:{MYSQL_SYSTEM_GROUP}")
+            try:
+                process = container.exec([
+                    "chown",
+                    "-R",
+                    f"{MYSQL_SYSTEM_USER}:{MYSQL_SYSTEM_GROUP}",
+                    MYSQL_DATA_DIR,
+                ])
+                process.wait()
+            except ExecError as e:
+                logger.error(f"Exited with code {e.exit_code}. Stderr:\n{e.stderr}")
+                raise MySQLInitialiseMySQLDError(e.stderr or "") from None
+
     @retry(reraise=True, stop=stop_after_delay(30), wait=wait_fixed(5))
     def initialise_mysqld(self) -> None:
         """Execute instance first run.

--- a/kubernetes/tests/spread/integration/test_backup_pitr_aws.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_backup_pitr_aws.py/task.yaml
@@ -2,8 +2,6 @@ summary: test_backup_pitr_aws.py
 environment:
   TEST_MODULE: test_backup_pitr_aws.py
 execute: |
-  # TODO: Un-comment when we revert to the version of MySQL PITR which worked in 8.0
-  # tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
-  exit 0
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_backup_pitr_gcp.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_backup_pitr_gcp.py/task.yaml
@@ -2,8 +2,6 @@ summary: test_backup_pitr_gcp.py
 environment:
   TEST_MODULE: test_backup_pitr_gcp.py
 execute: |
-  # TODO: Un-comment when we revert to the version of MySQL PITR which worked in 8.0
-  # tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
-  exit 0
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/unit/test_charm.py
+++ b/kubernetes/tests/unit/test_charm.py
@@ -161,6 +161,7 @@ class TestCharm(unittest.TestCase):
     @patch("mysql_k8s_helpers.MySQL.configure_instance")
     @patch("mysql_k8s_helpers.MySQL.create_cluster")
     @patch("mysql_k8s_helpers.MySQL.initialise_mysqld")
+    @patch("mysql_k8s_helpers.MySQL.fix_data_dir")
     @patch("mysql_k8s_helpers.MySQL.is_instance_in_cluster")
     @patch("mysql_k8s_helpers.MySQL.get_member_state", return_value="ONLINE")
     @patch("mysql_k8s_helpers.MySQL.get_member_role", return_value="PRIMARY")
@@ -181,6 +182,7 @@ class TestCharm(unittest.TestCase):
         _get_member_state,
         _is_instance_in_cluster,
         _initialise_mysqld,
+        _fix_data_dir,
         _create_cluster,
         _configure_instance,
         _configure_mysql_router_roles,

--- a/machines/tests/spread/integration/test_backup_pitr_aws.py/task.yaml
+++ b/machines/tests/spread/integration/test_backup_pitr_aws.py/task.yaml
@@ -2,9 +2,7 @@ summary: test_backup_pitr_aws.py
 environment:
   TEST_MODULE: test_backup_pitr_aws.py
 execute: |
-  # TODO: Un-comment when we revert to the version of MySQL PITR which worked in 8.0
-  # tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
-  exit 0
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 backends:

--- a/machines/tests/spread/integration/test_backup_pitr_gcp.py/task.yaml
+++ b/machines/tests/spread/integration/test_backup_pitr_gcp.py/task.yaml
@@ -2,9 +2,7 @@ summary: test_backup_pitr_gcp.py
 environment:
   TEST_MODULE: test_backup_pitr_gcp.py
 execute: |
-  # TODO: Un-comment when we revert to the version of MySQL PITR which worked in 8.0
-  # tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
-  exit 0
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
 backends:


### PR DESCRIPTION
This PR reverts the previous cleanup of the data directory permissions work-around in PR https://github.com/canonical/mysql-operators/pull/168.

Additionally, PITR tests are enabled again.
