### PR TITLE
[DPE-9974] Fix initialization of VM charm with detached storage

### DIFF
--- a/kubernetes/tests/integration/helpers_ha.py
+++ b/kubernetes/tests/integration/helpers_ha.py
@@ -3,6 +3,7 @@
 # See LICENSE file for licensing details.
 
 import json
+import logging
 import subprocess
 import uuid
 from collections.abc import Callable, Generator
@@ -18,6 +19,7 @@ from lightkube.core.client import Client
 from lightkube.resources.core_v1 import Endpoints, PersistentVolume, PersistentVolumeClaim, Pod
 from tenacity import (
     Retrying,
+    before_sleep_log,
     retry,
     stop_after_attempt,
     stop_after_delay,
@@ -39,6 +41,8 @@ TEST_DATABASE_NAME = "testing"
 
 JujuModelStatusFn = Callable[[Status], bool]
 JujuAppsStatusFn = Callable[[Status, str], bool]
+
+logger = logging.getLogger(__name__)
 
 
 def check_mysql_instances_online(
@@ -604,6 +608,7 @@ def verify_mysql_test_data(juju: Juju, app_name: str, table_name: str, value: st
             reraise=True,
             stop=stop_after_delay(5 * MINUTE_SECS),
             wait=wait_fixed(10),
+            before_sleep=before_sleep_log(logger, logging.WARNING),
         ):
             with attempt:
                 output = execute_queries_on_unit(

--- a/kubernetes/tests/integration/integration/test_storage.py
+++ b/kubernetes/tests/integration/integration/test_storage.py
@@ -15,15 +15,21 @@ from constants import (
     MYSQL_TEMP_DIR,
 )
 
+from ..helpers import generate_random_string
 from ..helpers_ha import (
     CHARM_METADATA,
     MINUTE_SECS,
+    get_app_leader,
+    get_mysql_server_credentials,
+    insert_mysql_test_data,
+    verify_mysql_test_data,
     wait_for_apps_status,
 )
 
 logger = logging.getLogger(__name__)
 
 DATABASE_APP_NAME = "mysql-k8s"
+TABLE_NAME = "test-table"
 TIMEOUT = 15 * MINUTE_SECS
 
 
@@ -112,6 +118,43 @@ def test_logs_directory_has_only_expected_contents_after_initialization(juju: Ju
     )
 
     assert all(redolog_pattern.match(fname) for fname in actual_content)
+
+
+def test_scale_up_from_zero_preserves_attached_storage(juju: Juju) -> None:
+    """Ensure scaling down to zero and back up can reuse storage."""
+    logger.info("Creating test data")
+    test_data = generate_random_string(255)
+    insert_mysql_test_data(juju, DATABASE_APP_NAME, TABLE_NAME, test_data)
+    verify_mysql_test_data(juju, DATABASE_APP_NAME, TABLE_NAME, test_data)
+
+    mysql_app_leader = get_app_leader(juju, DATABASE_APP_NAME)
+    old_credentials = get_mysql_server_credentials(juju, mysql_app_leader)
+
+    logger.info("Scaling down to 0 units")
+    juju.remove_unit(DATABASE_APP_NAME, num_units=1)
+
+    # Sometimes the app will arrive to an "unknown" state, we can't check for "active"
+    juju.wait(
+        ready=lambda status: len(status.apps[DATABASE_APP_NAME].units) == 0,
+        timeout=TIMEOUT,
+    )
+
+    juju.add_unit(DATABASE_APP_NAME)
+
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, DATABASE_APP_NAME),
+        error=jubilant.any_error,
+        timeout=TIMEOUT,
+    )
+
+    # Check that credentials are the same
+    mysql_app_leader = get_app_leader(juju, DATABASE_APP_NAME)
+    new_credentials = get_mysql_server_credentials(juju, mysql_app_leader)
+
+    assert new_credentials == old_credentials
+
+    # Check that data is still there
+    verify_mysql_test_data(juju, DATABASE_APP_NAME, TABLE_NAME, test_data)
 
 
 def list_container_files(

--- a/machines/src/charm.py
+++ b/machines/src/charm.py
@@ -47,6 +47,7 @@ from charms.mysql.v0.mysql import (
     MySQLRebootFromCompleteOutageError,
     MySQLRejoinInstanceToClusterError,
     MySQLSetClusterPrimaryError,
+    MySQLStartMySQLDError,
     MySQLUnableToGetMemberStateError,
 )
 from object_storage import S3Requirer
@@ -334,6 +335,9 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             return
         except MySQLCreateCustomMySQLDConfigError:
             self.set_unit_status(BlockedStatus("Failed to create custom mysqld config"))
+            return
+        except MySQLStartMySQLDError:
+            self.set_unit_status(BlockedStatus("Failed to start mysqld server"))
             return
         except MySQLDNotRestartedError:
             self.set_unit_status(BlockedStatus("Failed to restart instance"))
@@ -678,6 +682,19 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         """Returns whether the unit is the primary."""
         return self._mysql.get_primary_label() == self.unit_label
 
+    @property
+    def is_new_unit(self) -> bool:
+        """Return whether the unit is a clean state.
+
+        e.g. scaling from zero units
+        """
+        _default_unit_data_keys = {
+            "egress-subnets",
+            "ingress-address",
+            "private-address",
+        }
+        return self.unit_peer_data.keys() == _default_unit_data_keys
+
     def get_unit_hostname(self, unit_name: str | None = None) -> str:
         """Get the hostname of the unit."""
         if unit_name:
@@ -769,8 +786,19 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         Create users and configuration to setup instance as an Group Replication node.
         Raised errors must be treated on handlers.
         """
+        self._mysql.write_mysqld_config()
+        self.log_rotation_setup.setup()
+
         if self._mysql.is_data_dir_initialised():
             logger.info("Data directory is already initialised, skipping configuration")
+            self._mysql.start_mysqld()
+            if self.is_new_unit and self.unit.is_leader():
+                # when unit is new and has data, it means the app is scaling out
+                # from zero units
+                logger.info("Scaling out from zero units")
+                # create the cluster due it being dissolved on scale-down
+                self.create_cluster()
+                self._on_update_status(None)
             return
 
         # ensure hostname can be resolved
@@ -779,9 +807,10 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         logger.info("Initializing MySQL data directory")
         self._mysql.initialise_mysqld()
 
-        self._mysql.write_mysqld_config()
-        self.log_rotation_setup.setup()
+        logger.info("Set operator user and restart mysqld")
         self._mysql.set_operator_user_and_start_mysqld()
+
+        logger.info("Configuring initialized mysqld")
         self._mysql.configure_mysql_router_roles()
         self._mysql.configure_mysql_system_roles()
         self._mysql.configure_mysql_system_users()

--- a/machines/src/charm.py
+++ b/machines/src/charm.py
@@ -347,15 +347,6 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         except MySQLGetMySQLVersionError:
             logger.debug("Fail to get MySQL version")
 
-        if not self.unit.is_leader():
-            # Wait to be joined and set flags
-            self.set_unit_status(WaitingStatus("Waiting to join the cluster"))
-            self.unit_peer_data["member-role"] = InstanceRole.SECONDARY.value
-            self.unit_peer_data["member-state"] = "waiting"
-            return
-
-        self._create_cluster()
-
     def _on_peer_relation_changed(self, event: RelationChangedEvent) -> None:
         """Handle the peer relation changed event."""
         # Only execute if peer relation data contains cluster config values
@@ -682,19 +673,6 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         """Returns whether the unit is the primary."""
         return self._mysql.get_primary_label() == self.unit_label
 
-    @property
-    def is_new_unit(self) -> bool:
-        """Return whether the unit is a clean state.
-
-        e.g. scaling from zero units
-        """
-        _default_unit_data_keys = {
-            "egress-subnets",
-            "ingress-address",
-            "private-address",
-        }
-        return self.unit_peer_data.keys() == _default_unit_data_keys
-
     def get_unit_hostname(self, unit_name: str | None = None) -> str:
         """Get the hostname of the unit."""
         if unit_name:
@@ -792,7 +770,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         if self._mysql.is_data_dir_initialised():
             logger.info("Data directory is already initialised, skipping configuration")
             self._mysql.start_mysqld()
-            if self.is_new_unit and self.unit.is_leader():
+            if not self.unit_initialized() and self.unit.is_leader():
                 # when unit is new and has data, it means the app is scaling out
                 # from zero units
                 logger.info("Scaling out from zero units")
@@ -840,6 +818,15 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
 
         self._mysql.wait_until_mysql_connection()
         self.unit_peer_data["instance-hostname"] = f"{instance_hostname()}:3306"
+
+        if not self.unit.is_leader():
+            # Wait to be joined and set flags
+            self.set_unit_status(WaitingStatus("Waiting to join the cluster"))
+            self.unit_peer_data["member-role"] = InstanceRole.SECONDARY.value
+            self.unit_peer_data["member-state"] = "waiting"
+            return
+
+        self._create_cluster()
 
     def get_unit_address(self, unit: Unit, relation_name: str) -> str:
         """Get the IP address of a specific unit."""

--- a/machines/src/charm.py
+++ b/machines/src/charm.py
@@ -769,6 +769,10 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         Create users and configuration to setup instance as an Group Replication node.
         Raised errors must be treated on handlers.
         """
+        if self._mysql.is_data_dir_initialised():
+            logger.info("Data directory is already initialised, skipping configuration")
+            return
+
         # ensure hostname can be resolved
         self.hostname_resolution.update_etc_hosts(None)
 

--- a/machines/src/mysql_vm_helpers.py
+++ b/machines/src/mysql_vm_helpers.py
@@ -766,24 +766,20 @@ class MySQL(MySQLBase):
 
             # minimal expected content for an integral mysqld data-dir
             expected_content = {
-                "mysql",
-                "public_key.pem",
-                "sys",
-                "ca.pem",
-                "client-key.pem",
-                "mysql.ibd",
                 "auto.cnf",
-                "server-cert.pem",
-                "ib_buffer_pool",
-                "server-key.pem",
-                "undo_002",
-                "#innodb_redo",
-                "undo_001",
-                "#innodb_temp",
-                "private_key.pem",
-                "client-cert.pem",
                 "ca-key.pem",
+                "ca.pem",
+                "client-cert.pem",
+                "client-key.pem",
+                "ib_buffer_pool",
+                "mysql",
+                "mysql.ibd",
                 "performance_schema",
+                "private_key.pem",
+                "public_key.pem",
+                "server-cert.pem",
+                "server-key.pem",
+                "sys",
             }
 
             return expected_content <= set(content)

--- a/machines/tests/integration/helpers_ha.py
+++ b/machines/tests/integration/helpers_ha.py
@@ -549,6 +549,7 @@ def verify_mysql_test_data(juju: Juju, app_name: str, table_name: str, value: st
             reraise=True,
             stop=stop_after_delay(5 * MINUTE_SECS),
             wait=wait_fixed(10),
+            before_sleep=before_sleep_log(logger, logging.WARNING),
         ):
             with attempt:
                 output = execute_queries_on_unit(

--- a/machines/tests/integration/integration/test_storage.py
+++ b/machines/tests/integration/integration/test_storage.py
@@ -38,7 +38,7 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
         DATABASE_APP_NAME,
         base="ubuntu@24.04",
         config={"profile": "testing"},
-        storage={"data": "5G"},  # Necessary to detach storage later
+        storage={"data": "1G", "logs": "1G"},  # Necessary to detach storage later
         num_units=1,
     )
 
@@ -129,6 +129,7 @@ def test_scale_up_from_zero_preserves_attached_storage(juju: Juju) -> None:
 
     storages = juju.status().storage.storage
     data_storage_id = next(storage_id for storage_id in storages if "data" in storage_id)
+    logs_storage_id = next(storage_id for storage_id in storages if "logs" in storage_id)
 
     logger.info("Scaling down to 0 units")
     juju.remove_unit(mysql_app_leader, destroy_storage=False)
@@ -139,7 +140,7 @@ def test_scale_up_from_zero_preserves_attached_storage(juju: Juju) -> None:
         timeout=TIMEOUT,
     )
 
-    juju.add_unit(DATABASE_APP_NAME, attach_storage=data_storage_id)
+    juju.add_unit(DATABASE_APP_NAME, attach_storage=[data_storage_id, logs_storage_id])
 
     juju.wait(
         ready=wait_for_apps_status(jubilant.all_active, DATABASE_APP_NAME),

--- a/machines/tests/integration/integration/test_storage.py
+++ b/machines/tests/integration/integration/test_storage.py
@@ -14,14 +14,20 @@ from constants import (
     MYSQL_TEMP_DIR,
 )
 
+from ..helpers import generate_random_string
 from ..helpers_ha import (
     MINUTE_SECS,
+    get_app_leader,
+    get_mysql_server_credentials,
+    insert_mysql_test_data,
+    verify_mysql_test_data,
     wait_for_apps_status,
 )
 
 logger = logging.getLogger(__name__)
 
 DATABASE_APP_NAME = "mysql"
+TABLE_NAME = "test-table"
 TIMEOUT = 15 * MINUTE_SECS
 
 
@@ -32,8 +38,8 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
         DATABASE_APP_NAME,
         base="ubuntu@24.04",
         config={"profile": "testing"},
+        storage={"data": "5G"},  # Necessary to detach storage later
         num_units=1,
-        trust=True,
     )
 
     juju.wait(
@@ -109,6 +115,46 @@ def test_logs_directory_has_only_expected_contents_after_initialization(juju: Ju
     )
 
     assert all(redolog_pattern.match(fname) for fname in actual_content)
+
+
+def test_scale_up_from_zero_preserves_attached_storage(juju: Juju) -> None:
+    """Ensure scaling down to zero and back up can reuse storage."""
+    logger.info("Creating test data")
+    test_data = generate_random_string(255)
+    insert_mysql_test_data(juju, DATABASE_APP_NAME, TABLE_NAME, test_data)
+    verify_mysql_test_data(juju, DATABASE_APP_NAME, TABLE_NAME, test_data)
+
+    mysql_app_leader = get_app_leader(juju, DATABASE_APP_NAME)
+    old_credentials = get_mysql_server_credentials(juju, mysql_app_leader)
+
+    storages = juju.status().storage.storage
+    data_storage_id = next(storage_id for storage_id in storages if "data" in storage_id)
+
+    logger.info("Scaling down to 0 units")
+    juju.remove_unit(mysql_app_leader, destroy_storage=False)
+
+    # Sometimes the app will arrive to an "unknown" state, we can't check for "active"
+    juju.wait(
+        ready=lambda status: len(status.apps[DATABASE_APP_NAME].units) == 0,
+        timeout=TIMEOUT,
+    )
+
+    juju.add_unit(DATABASE_APP_NAME, attach_storage=data_storage_id)
+
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, DATABASE_APP_NAME),
+        error=jubilant.any_error,
+        timeout=TIMEOUT,
+    )
+
+    # Check that credentials are the same
+    mysql_app_leader = get_app_leader(juju, DATABASE_APP_NAME)
+    new_credentials = get_mysql_server_credentials(juju, mysql_app_leader)
+
+    assert new_credentials == old_credentials
+
+    # Check that data is still there
+    verify_mysql_test_data(juju, DATABASE_APP_NAME, TABLE_NAME, test_data)
 
 
 def list_vm_files(

--- a/machines/tests/unit/test_charm.py
+++ b/machines/tests/unit/test_charm.py
@@ -116,12 +116,10 @@ class TestCharm(unittest.TestCase):
         self.assertIsNotNone(peer_relation_databag["cluster-name"])
 
     @patch("charm.MySQLOperatorCharm._can_start", return_value=True)
-    @patch("charm.MySQLOperatorCharm.create_cluster")
     @patch("charm.MySQLOperatorCharm.workload_initialise")
     def test_on_start(
         self,
         _workload_initialise,
-        _create_cluster,
         _can_start,
     ):
         # execute on_leader_elected and config_changed to populate the peer databag
@@ -130,16 +128,9 @@ class TestCharm(unittest.TestCase):
 
         self.charm.on.start.emit()
         _workload_initialise.assert_called_once()
-        _create_cluster.assert_called_once()
         _can_start.assert_called_once()
 
         self.assertTrue(isinstance(self.harness.model.unit.status, MaintenanceStatus))
-
-        self.harness.set_leader(False)
-        self.charm.on.start.emit()
-        self.assertTrue(isinstance(self.harness.model.unit.status, WaitingStatus))
-        self.assertEqual(self.charm.unit_peer_data["member-role"], "SECONDARY")
-        self.assertEqual(self.charm.unit_peer_data["member-state"], "waiting")
 
     @patch("charm.MySQLOperatorCharm._can_start", return_value=True)
     @patch("charm.MySQLOperatorCharm.create_cluster")


### PR DESCRIPTION
## Issue
fix gh-281

This makes the initialization code a bit closer to the Kubernetes counterpart, although there are still some structural differences I didn't want to tackle in this PR.

The new test roughly amounts to:

```
$ juju deploy --model testing ./mysql_ubuntu@24.04-amd64.charm mysql --base ubuntu@24.04 --config profile=testing --num-units 1 --storage data=1G --storage logs=1G
$ juju show-secret --reveal ...  # Take note of passwords
$ juju exec ...  # Write data
$ juju remove-unit mysql/0 --destroy-storage=false 
$ juju add-unit mysql --attach-storage data/1 --attach-storage logs/2
$ juju exec ...  # Verify the data is still there with the same credentials
```

I ported the same test to K8s, which trivially passed.

## Solution

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
