### PR TITLE
[MISC] Fix condition for publishing Allure results

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -156,7 +156,7 @@ jobs:
         # Only upload results from one spread system & one spread variant
         # Allure can only process one result per pytest test ID. If parameterization is done via
         # spread instead of pytest, there will be overlapping pytest test IDs.
-        if: ${{ (success() || (failure() && steps.spread.outcome == 'failure')) && startsWith(matrix.job.spread_job, 'github-ci:ubuntu-24.04:') && endsWith(matrix.job.spread_job, ':juju36') && github.event_name == 'workflow_dispatch' && github.run_attempt == '1' }}
+        if: ${{ (success() || (failure() && steps.spread.outcome == 'failure')) && startsWith(matrix.job.spread_job, 'github-ci:ubuntu-22.04:') && endsWith(matrix.job.spread_job, ':juju36') && github.event_name == 'workflow_dispatch' && github.run_attempt == '1' }}
         uses: actions/upload-artifact@v7
         with:
           name: allure-results-integration-test-${{ inputs.path-to-charm-directory }}-${{ matrix.job.name_in_artifact }}


### PR DESCRIPTION
## Issue
Didn't remember that https://github.com/canonical/mysql-operators/pull/199 got backported to 8.0/edge, and as such this condition had to change.

## Solution

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
