### PR TITLE
[MISC] 8.4 - Consolidate experimental configs

### DIFF
--- a/kubernetes/config.yaml
+++ b/kubernetes/config.yaml
@@ -10,6 +10,12 @@ options:
       Optional - Name for async replication cluster set, set once at deployment.
       On `recreate-clster` action call, the cluster set name will be re-generated automatically.
     type: string
+  max-connections:
+    type: int
+    description: |
+      Maximum number of connections allowed to the MySQL server.
+      When set max-connections value take precedence over the memory utilization
+      against innodb_buffer_pool_size.
   profile:
     description: |
       Profile representing the scope of deployment, and used to be able to enable high-level
@@ -57,11 +63,3 @@ options:
       Allowed values: "all", "first", "none"
     type: string
     default: first
-  # Experimental features
-  experimental-max-connections:
-    type: int
-    description: |
-      Maximum number of connections allowed to the MySQL server.
-      When set max-connections value take precedence over the memory utilizations
-      againts innodb_buffer_pool_size.
-      This is an experimental feature and may be removed in future releases.

--- a/kubernetes/lib/charms/mysql/v0/mysql.py
+++ b/kubernetes/lib/charms/mysql/v0/mysql.py
@@ -1105,11 +1105,10 @@ class MySQLBase(ABC):
         audit_log_strategy: str,
         audit_log_policy: str,
         memory_limit: int | None = None,
-        experimental_max_connections: int | None = None,
+        max_connections: int | None = None,
         binlog_retention_days: int,
     ) -> tuple[str, dict]:
         """Render mysqld ini configuration file."""
-        max_connections = None
         performance_schema_instrument = ""
         if profile == "testing":
             innodb_buffer_pool_size = 20 * BYTES_1MiB
@@ -1124,12 +1123,9 @@ class MySQLBase(ABC):
                 # between the available memory and the limit
                 available_memory = min(available_memory, memory_limit)
 
-            if experimental_max_connections:
-                # when set, we use the experimental max connections
-                # and it takes precedence over buffers usage
-                max_connections = experimental_max_connections
-                # we reserve 200MiB for memory buffers
-                # even when there's some overcommittment
+            if max_connections:
+                # when set, we use the max connections as it precedence over buffers usage.
+                # we reserve 200MiB for memory buffers even when there's some overcommitment
                 available_memory = max(
                     available_memory - max_connections * 12 * BYTES_1MiB,
                     200 * BYTES_1MiB,

--- a/kubernetes/src/charm.py
+++ b/kubernetes/src/charm.py
@@ -702,7 +702,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             audit_log_strategy=self.config.plugin_audit_strategy,
             audit_log_policy=self.config.logs_audit_policy,
             memory_limit=memory_limit_bytes,
-            experimental_max_connections=self.config.experimental_max_connections,
+            max_connections=self.config.max_connections,
             binlog_retention_days=self.config.binlog_retention_days,
         )
         self._mysql.write_content_to_file(path=MYSQLD_CONFIG_FILE, content=new_config_content)

--- a/kubernetes/src/config.py
+++ b/kubernetes/src/config.py
@@ -53,8 +53,8 @@ class CharmConfig(BaseConfigModel):
     profile: str
     cluster_name: str | None = Field(default=None)
     cluster_set_name: str | None = Field(default=None)
+    max_connections: int | None = Field(default=None)
     profile_limit_memory: int | None = Field(default=None)
-    experimental_max_connections: int | None = Field(default=None)
     binlog_retention_days: int
     plugin_audit_enabled: bool
     plugin_audit_strategy: str
@@ -104,14 +104,13 @@ class CharmConfig(BaseConfigModel):
 
         return value
 
-    @field_validator("experimental_max_connections")
+    @field_validator("max_connections")
     @classmethod
-    def experimental_max_connections_validator(cls, value: int) -> int | None:
-        """Check experimental max connections."""
+    def max_connections_validator(cls, value: int) -> int | None:
+        """Check max connections."""
         if value < MAX_CONNECTIONS_FLOOR:
             raise ValueError(
-                f"experimental-max-connections ({value=}) must be equal or greater "
-                + f" than {MAX_CONNECTIONS_FLOOR}"
+                f"max-connections ({value=}) must be equal or greater than {MAX_CONNECTIONS_FLOOR}"
             )
 
         return value

--- a/kubernetes/tests/integration/integration/test_saturate_max_connections.py
+++ b/kubernetes/tests/integration/integration/test_saturate_max_connections.py
@@ -24,7 +24,7 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     juju.deploy(
         charm,
         MYSQL_APP_NAME,
-        config={"profile-limit-memory": "2000", "experimental-max-connections": CONNECTIONS},
+        config={"profile-limit-memory": "2000", "max-connections": CONNECTIONS},
         num_units=1,
         base="ubuntu@24.04",
         resources={"mysql-image": CHARM_METADATA["resources"]["mysql-image"]["upstream-source"]},

--- a/machines/config.yaml
+++ b/machines/config.yaml
@@ -10,6 +10,12 @@ options:
       Optional - Name for async replication cluster set, set once at deployment.
       On `recreate-clster` action call, the cluster set name will be re-generated automatically.
     type: string
+  max-connections:
+    type: int
+    description: |
+      Maximum number of connections allowed to the MySQL server.
+      When set max-connections value take precedence over the memory utilization
+      against innodb_buffer_pool_size.
   profile:
     description: |
       profile representing the scope of deployment, and used to be able to enable high-level
@@ -56,11 +62,3 @@ options:
       Allowed values: "all", "first", "none"
     type: string
     default: first
-  # Experimental features
-  experimental-max-connections:
-    type: int
-    description: |
-      Maximum number of connections allowed to the MySQL server.
-      When set max-connections value take precedence over the memory utilizations
-      againts innodb_buffer_pool_size.
-      This is an experimental feature and may be removed in future releases.

--- a/machines/lib/charms/mysql/v0/mysql.py
+++ b/machines/lib/charms/mysql/v0/mysql.py
@@ -1105,11 +1105,10 @@ class MySQLBase(ABC):
         audit_log_strategy: str,
         audit_log_policy: str,
         memory_limit: int | None = None,
-        experimental_max_connections: int | None = None,
+        max_connections: int | None = None,
         binlog_retention_days: int,
     ) -> tuple[str, dict]:
         """Render mysqld ini configuration file."""
-        max_connections = None
         performance_schema_instrument = ""
         if profile == "testing":
             innodb_buffer_pool_size = 20 * BYTES_1MiB
@@ -1124,12 +1123,9 @@ class MySQLBase(ABC):
                 # between the available memory and the limit
                 available_memory = min(available_memory, memory_limit)
 
-            if experimental_max_connections:
-                # when set, we use the experimental max connections
-                # and it takes precedence over buffers usage
-                max_connections = experimental_max_connections
-                # we reserve 200MiB for memory buffers
-                # even when there's some overcommittment
+            if max_connections:
+                # when set, we use the max connections as it takes precedence over buffers usage.
+                # we reserve 200MiB for memory buffers even when there's some overcommitment
                 available_memory = max(
                     available_memory - max_connections * 12 * BYTES_1MiB,
                     200 * BYTES_1MiB,

--- a/machines/src/config.py
+++ b/machines/src/config.py
@@ -53,8 +53,8 @@ class CharmConfig(BaseConfigModel):
     profile: str
     cluster_name: str | None = Field(default=None)
     cluster_set_name: str | None = Field(default=None)
+    max_connections: int | None = Field(default=None)
     profile_limit_memory: int | None = Field(default=None)
-    experimental_max_connections: int | None = Field(default=None)
     binlog_retention_days: int
     plugin_audit_enabled: bool
     plugin_audit_strategy: str
@@ -104,14 +104,13 @@ class CharmConfig(BaseConfigModel):
 
         return value
 
-    @field_validator("experimental_max_connections")
+    @field_validator("max_connections")
     @classmethod
-    def experimental_max_connections_validator(cls, value: int) -> int | None:
-        """Check experimental max connections."""
+    def max_connections_validator(cls, value: int) -> int | None:
+        """Check max connections."""
         if value < MAX_CONNECTIONS_FLOOR:
             raise ValueError(
-                f"experimental-max-connections ({value=}) must be equal or greater "
-                + f" than {MAX_CONNECTIONS_FLOOR}"
+                f"max-connections ({value=}) must be equal or greater than {MAX_CONNECTIONS_FLOOR}"
             )
 
         return value

--- a/machines/src/mysql_vm_helpers.py
+++ b/machines/src/mysql_vm_helpers.py
@@ -261,7 +261,7 @@ class MySQL(MySQLBase):
                 audit_log_policy=self.charm.config.logs_audit_policy,
                 memory_limit=memory_limit,
                 binlog_retention_days=self.charm.config.binlog_retention_days,
-                experimental_max_connections=self.charm.config.experimental_max_connections,
+                max_connections=self.charm.config.max_connections,
             )
         except (MySQLGetAvailableMemoryError, MySQLGetAutoTuningParametersError) as e:
             logger.exception("Failed to get available memory or auto tuning parameters")

--- a/machines/tests/integration/integration/test_saturate_max_connections.py
+++ b/machines/tests/integration/integration/test_saturate_max_connections.py
@@ -23,7 +23,7 @@ def test_build_and_deploy(juju: Juju, charm) -> None:
     juju.deploy(
         charm,
         MYSQL_APP_NAME,
-        config={"profile-limit-memory": "2000", "experimental-max-connections": CONNECTIONS},
+        config={"profile-limit-memory": "2000", "max-connections": CONNECTIONS},
         num_units=1,
         base="ubuntu@24.04",
         trust=True,

--- a/machines/tests/unit/test_mysql.py
+++ b/machines/tests/unit/test_mysql.py
@@ -1806,7 +1806,7 @@ class TestMySQLBase(unittest.TestCase):
             audit_log_enabled=True,
             audit_log_strategy="async",
             audit_log_policy="LOGINS",
-            experimental_max_connections=500,
+            max_connections=500,
             memory_limit=memory_limit,
         )
 
@@ -1819,7 +1819,7 @@ class TestMySQLBase(unittest.TestCase):
             audit_log_enabled=True,
             audit_log_strategy="async",
             audit_log_policy="LOGINS",
-            experimental_max_connections=800,
+            max_connections=800,
             memory_limit=memory_limit,
         )
 

--- a/machines/tests/unit/test_mysqlsh_helpers.py
+++ b/machines/tests/unit/test_mysqlsh_helpers.py
@@ -35,10 +35,10 @@ from mysql_vm_helpers import (
 
 class StubConfig:
     def __init__(self):
+        self.max_connections = None
         self.plugin_audit_enabled = True
         self.profile = "production"
         self.profile_limit_memory = None
-        self.experimental_max_connections = None
         self.plugin_audit_strategy = "async"
         self.binlog_retention_days = 7
         self.logs_audit_policy = "logins"


### PR DESCRIPTION
This PR consolidates the `max-connections` config option after our conversation with Managed Solutions. This setting is heavily used by SunBeam folks, and we should make it official.
