### PR TITLE
[MISC] More FQDN resolution fixes

### DIFF
--- a/kubernetes/src/utils.py
+++ b/kubernetes/src/utils.py
@@ -94,9 +94,18 @@ def dotappend(string: str) -> str:
 def get_k8s_fqdn(name: str, local_unit_label: str) -> str:
     """Resolve the canonical FQDN for a Kubernetes service or pod name.
 
+    Fully-qualified domain names always have a trailing dot
+    representing the root of the DNS hierarchy, as per RFC 1034.
+
     Args:
         name: The Kubernetes service or pod name to resolve.
         local_unit_label: The label of the local unit (e.g., "mysql-k8s-1")
+
+    Examples:
+        >>> get_k8s_fqdn("mysql-k8s-0.mysql-k8s-endpoints", local_unit_label="mysql-k8s-0")
+        'mysql-k8s-0.mysql-k8s-endpoints.jubilant-a65bb303.svc.cluster.local.'
+        >>> get_k8s_fqdn("mysql-k8s-1.mysql-k8s-endpoints", local_unit_label="mysql-k8s-0")
+        'mysql-k8s-1.mysql-k8s-endpoints.jubilant-a65bb303.svc.cluster.local.'
     """
 
     def _addrinfo(_name):
@@ -133,8 +142,9 @@ def get_k8s_fqdn(name: str, local_unit_label: str) -> str:
         )
         if canonname:
             if local_unit_label == name_prefix:
-                logger.debug("get_k8s_fqdn: local unit path -> returning canonname=%r", canonname)
-                return canonname
+                result = dotappend(canonname)
+                logger.debug("get_k8s_fqdn: local unit path -> returning result=%r", result)
+                return result
             else:
                 # for peer units, replace the local unit pod name in the fqdn (cannoname) with the
                 # peer unit pod name (name_prefix)
@@ -163,7 +173,8 @@ def get_k8s_fqdn(name: str, local_unit_label: str) -> str:
         canonname = entry[3]
         logger.debug("get_k8s_fqdn: DNS entry canonname=%r", canonname)
         if canonname:
-            logger.debug("get_k8s_fqdn: DNS fallback path -> returning canonname=%r", canonname)
-            return canonname
+            result = dotappend(canonname)
+            logger.debug("get_k8s_fqdn: DNS fallback path -> returning result=%r", result)
+            return result
 
     raise RuntimeError(f"Could not determine canonical for {name=}")

--- a/kubernetes/src/utils.py
+++ b/kubernetes/src/utils.py
@@ -3,12 +3,15 @@
 
 """A collection of utility functions that are used in the charm."""
 
+import logging
 import re
 import secrets
 import socket
 import string
 
 from tenacity import retry, stop_after_delay, wait_fixed
+
+logger = logging.getLogger(__name__)
 
 
 def generate_random_password(length: int) -> str:
@@ -111,11 +114,26 @@ def get_k8s_fqdn(name: str, local_unit_label: str) -> str:
 
     # fqdn resolve local in /etc/hosts
     name_prefix = name.split(".")[0]
+    logger.debug(
+        "get_k8s_fqdn: name=%r name_prefix=%r local_unit_label=%r",
+        name,
+        name_prefix,
+        local_unit_label,
+    )
     info = _addrinfo(local_unit_label)
+    logger.debug("get_k8s_fqdn: addrinfo(%r) returned %d entries", local_unit_label, len(info))
 
     for entry in info:
-        if canonname := entry[3]:
+        canonname = entry[3]
+        logger.debug(
+            "get_k8s_fqdn: entry canonname=%r (local_unit_label=%r, name_prefix=%r)",
+            canonname,
+            local_unit_label,
+            name_prefix,
+        )
+        if canonname:
             if local_unit_label == name_prefix:
+                logger.debug("get_k8s_fqdn: local unit path -> returning canonname=%r", canonname)
                 return canonname
             else:
                 # for peer units, replace the local unit pod name in the fqdn (cannoname) with the
@@ -126,12 +144,26 @@ def get_k8s_fqdn(name: str, local_unit_label: str) -> str:
                 # fqdn = mysql-k8s-1.mysql-k8s-endpoints.default.svc.cluster.local
                 fqdn = ".".join([name_prefix, *canonname.split(".")[1:]])
                 # dotappend other units as local unit is mapped without end dot in /etc/hosts
-                return dotappend(fqdn)
+                result = dotappend(fqdn)
+                logger.debug(
+                    "get_k8s_fqdn: peer unit path -> canonname=%r fqdn=%r result=%r",
+                    canonname,
+                    fqdn,
+                    result,
+                )
+                return result
 
     # fallback to DNS
+    logger.debug(
+        "get_k8s_fqdn: no canonname from local lookup, falling back to DNS for name=%r", name
+    )
     info = _addrinfo(name)
+    logger.debug("get_k8s_fqdn: DNS addrinfo(%r) returned %d entries", name, len(info))
     for entry in info:
-        if canonname := entry[3]:
+        canonname = entry[3]
+        logger.debug("get_k8s_fqdn: DNS entry canonname=%r", canonname)
+        if canonname:
+            logger.debug("get_k8s_fqdn: DNS fallback path -> returning canonname=%r", canonname)
             return canonname
 
     raise RuntimeError(f"Could not determine canonical for {name=}")

--- a/kubernetes/src/utils.py
+++ b/kubernetes/src/utils.py
@@ -130,21 +130,12 @@ def get_k8s_fqdn(name: str, local_unit_label: str) -> str:
         local_unit_label,
     )
     info = _addrinfo(local_unit_label)
-    logger.debug("get_k8s_fqdn: addrinfo(%r) returned %d entries", local_unit_label, len(info))
 
     for entry in info:
-        canonname = entry[3]
-        logger.debug(
-            "get_k8s_fqdn: entry canonname=%r (local_unit_label=%r, name_prefix=%r)",
-            canonname,
-            local_unit_label,
-            name_prefix,
-        )
-        if canonname:
+        if canonname := entry[3]:
             if local_unit_label == name_prefix:
-                result = dotappend(canonname)
-                logger.debug("get_k8s_fqdn: local unit path -> returning result=%r", result)
-                return result
+                logger.debug("get_k8s_fqdn: local unit path -> canonname=%r", canonname)
+                return dotappend(canonname)
             else:
                 # for peer units, replace the local unit pod name in the fqdn (cannoname) with the
                 # peer unit pod name (name_prefix)
@@ -153,28 +144,22 @@ def get_k8s_fqdn(name: str, local_unit_label: str) -> str:
                 # name_prefix: mysql-k8s-1
                 # fqdn = mysql-k8s-1.mysql-k8s-endpoints.default.svc.cluster.local
                 fqdn = ".".join([name_prefix, *canonname.split(".")[1:]])
-                # dotappend other units as local unit is mapped without end dot in /etc/hosts
-                result = dotappend(fqdn)
                 logger.debug(
-                    "get_k8s_fqdn: peer unit path -> canonname=%r fqdn=%r result=%r",
+                    "get_k8s_fqdn: peer unit path -> canonname=%r fqdn=%r",
                     canonname,
                     fqdn,
-                    result,
                 )
-                return result
+                # dotappend other units as local unit is mapped without end dot in /etc/hosts
+                return dotappend(fqdn)
 
     # fallback to DNS
     logger.debug(
         "get_k8s_fqdn: no canonname from local lookup, falling back to DNS for name=%r", name
     )
     info = _addrinfo(name)
-    logger.debug("get_k8s_fqdn: DNS addrinfo(%r) returned %d entries", name, len(info))
     for entry in info:
-        canonname = entry[3]
-        logger.debug("get_k8s_fqdn: DNS entry canonname=%r", canonname)
-        if canonname:
-            result = dotappend(canonname)
-            logger.debug("get_k8s_fqdn: DNS fallback path -> returning result=%r", result)
-            return result
+        if canonname := entry[3]:
+            logger.debug("get_k8s_fqdn: DNS entry canonname=%r", canonname)
+            return dotappend(canonname)
 
     raise RuntimeError(f"Could not determine canonical for {name=}")

--- a/kubernetes/tests/integration/conftest.py
+++ b/kubernetes/tests/integration/conftest.py
@@ -25,6 +25,17 @@ def pytest_configure(config):
     config.option.log_date_format = "%b %d %H:%M:%S"
 
 
+def pytest_addoption(parser):
+    """Adds command line parameter ``--model`` (see help for details)."""
+    parser.addoption(
+        "--model",
+        action="store",
+        default="testing",
+        help="model name or ':auto:' for temporary model, default to 'testing'",
+        required=False,
+    )
+
+
 @pytest.fixture(scope="session")
 def charm():
     # Return str instead of pathlib.Path since python-libjuju's model.deploy(), juju deploy, and
@@ -64,5 +75,12 @@ def cloud_configs_gcp() -> tuple[dict[str, str], dict[str, str]]:
 
 
 @pytest.fixture(scope="module")
-def juju() -> jubilant_backports.Juju:
-    return jubilant_backports.Juju(model="testing")
+def juju(request: pytest.FixtureRequest):
+    """Pytest fixture that yields a new :meth:`jubilant.Juju` object."""
+    model = request.config.getoption("--model")
+
+    if model == ":auto:":
+        with jubilant_backports.temp_model() as juju:
+            yield juju
+    else:
+        yield jubilant_backports.Juju(model=model)

--- a/machines/tests/integration/conftest.py
+++ b/machines/tests/integration/conftest.py
@@ -25,6 +25,17 @@ def pytest_configure(config):
     config.option.log_date_format = "%b %d %H:%M:%S"
 
 
+def pytest_addoption(parser):
+    """Adds command line parameter ``--model`` (see help for details)."""
+    parser.addoption(
+        "--model",
+        action="store",
+        default="testing",
+        help="model name or ':auto:' for temporary model, default to 'testing'",
+        required=False,
+    )
+
+
 @pytest.fixture(scope="session")
 def charm():
     # Return str instead of pathlib.Path since python-libjuju's model.deploy(), juju deploy, and
@@ -64,5 +75,12 @@ def cloud_configs_gcp() -> tuple[dict[str, str], dict[str, str]]:
 
 
 @pytest.fixture(scope="module")
-def juju() -> jubilant_backports.Juju:
-    return jubilant_backports.Juju(model="testing")
+def juju(request: pytest.FixtureRequest):
+    """Pytest fixture that yields a new :meth:`jubilant.Juju` object."""
+    model = request.config.getoption("--model")
+
+    if model == ":auto:":
+        with jubilant_backports.temp_model() as juju:
+            yield juju
+    else:
+        yield jubilant_backports.Juju(model=model)


### PR DESCRIPTION
## Issue
We observed that `test_predefined_roles_refresh.py` had been consistently failing for some time, see for example https://github.com/canonical/mysql-operators/actions/runs/25294722798/job/74152259227#step:13:25

Turns out there was an inconsistency between what `@@report_host` was reporting and the actual InnoDB Cluster metadata. Performing a cluster `rescan()` mid-test showed the difference and unblocked it:

```
$ # dba.get_cluster().rescan({"addInstances": "auto", "removeInstances": "auto"})
...
The instance 'mysql-k8s-0.mysql-k8s-endpoints.testing.svc.cluster.local:3306' is part of the cluster but its reported address has changed. Old address: mysql-k8s-0.mysql-k8s-endpoints.testing.svc.cluster.local.:3306. Current address: mysql-k8s-0.mysql-k8s-endpoints.testing.svc.cluster.local:3306.
The instance 'mysql-k8s-0.mysql-k8s-endpoints.testing.svc.cluster.local:3306' is part of the Cluster but the reported X plugin port has changed. Old xport: mysql-k8s-0.mysql-k8s-endpoints.testing.svc.cluster.local.:33060. Current xport: mysql-k8s-0.mysql-k8s-endpoints.testing.svc.cluster.local:33060.
Updating instance metadata...
```

I fixed this locally by making `get_k8s_fqdn` _always_ return a FQDN, that is: with a trailing dot.

Additionally, I added some extra debug logging. @paulomach has been wrestling with this issue the longest, so maybe he has opinions on what would have been useful to know.

I also acknowledge that this has been a thorny issue over the past few months that we only managed to detect through real world testing, so it would be nice if we could have some extra validation before merging, assuming the current approach is blessed.

This PR also backports https://github.com/canonical/mysql-operators/pull/238.

## Solution

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
