### PR TITLE
[MISC] (8.0/edge) Improve logging of get-cluster-status

### DIFF
--- a/kubernetes/lib/charms/mysql/v0/mysql.py
+++ b/kubernetes/lib/charms/mysql/v0/mysql.py
@@ -1960,6 +1960,8 @@ class MySQLBase(ABC):
         """Get the cluster status dictionary."""
         if not from_instance:
             from_instance = self.instance_address
+        if extended is None:
+            extended = False
 
         client = MySQLClusterClient(
             executor=self._build_instance_tcp_executor(from_instance),

--- a/kubernetes/lib/charms/mysql/v0/mysql.py
+++ b/kubernetes/lib/charms/mysql/v0/mysql.py
@@ -1950,11 +1950,6 @@ class MySQLBase(ABC):
         else:
             return unit_label in labels
 
-    @retry(
-        wait=wait_fixed(2),
-        stop=stop_after_attempt(3),
-        retry=retry_if_exception_type(ExecutionError),
-    )
     def get_cluster_status(
         self, from_instance: str | None = None, extended: bool | None = False
     ) -> dict | None:

--- a/kubernetes/lib/charms/mysql/v0/mysql.py
+++ b/kubernetes/lib/charms/mysql/v0/mysql.py
@@ -78,6 +78,24 @@ from typing import (
 
 import ops
 from charms.data_platform_libs.v0.data_interfaces import DataPeerData, DataPeerUnitData
+from constants import (
+    BACKUPS_PASSWORD_KEY,
+    BACKUPS_USERNAME,
+    CHARMED_MYSQL_PITR_HELPER,
+    CLUSTER_ADMIN_PASSWORD_KEY,
+    CLUSTER_ADMIN_USERNAME,
+    COS_AGENT_RELATION_NAME,
+    GR_MAX_MEMBERS,
+    MONITORING_PASSWORD_KEY,
+    MONITORING_USERNAME,
+    PASSWORD_LENGTH,
+    PEER,
+    ROOT_PASSWORD_KEY,
+    ROOT_USERNAME,
+    SECRET_KEY_FALLBACKS,
+    SERVER_CONFIG_PASSWORD_KEY,
+    SERVER_CONFIG_USERNAME,
+)
 from mysql_shell.builders import (
     CharmAuthorizationQueryBuilder,
     CharmLockingQueryBuilder,
@@ -104,25 +122,6 @@ from tenacity import (
     stop_after_attempt,
     wait_fixed,
     wait_random,
-)
-
-from constants import (
-    BACKUPS_PASSWORD_KEY,
-    BACKUPS_USERNAME,
-    CHARMED_MYSQL_PITR_HELPER,
-    CLUSTER_ADMIN_PASSWORD_KEY,
-    CLUSTER_ADMIN_USERNAME,
-    COS_AGENT_RELATION_NAME,
-    GR_MAX_MEMBERS,
-    MONITORING_PASSWORD_KEY,
-    MONITORING_USERNAME,
-    PASSWORD_LENGTH,
-    PEER,
-    ROOT_PASSWORD_KEY,
-    ROOT_USERNAME,
-    SECRET_KEY_FALLBACKS,
-    SERVER_CONFIG_PASSWORD_KEY,
-    SERVER_CONFIG_USERNAME,
 )
 from utils import generate_random_password
 

--- a/kubernetes/lib/charms/mysql/v0/mysql.py
+++ b/kubernetes/lib/charms/mysql/v0/mysql.py
@@ -1950,13 +1950,11 @@ class MySQLBase(ABC):
             return unit_label in labels
 
     def get_cluster_status(
-        self, from_instance: str | None = None, extended: bool | None = False
+        self, from_instance: str | None = None, extended: bool = False
     ) -> dict | None:
         """Get the cluster status dictionary."""
         if not from_instance:
             from_instance = self.instance_address
-        if extended is None:
-            extended = False
 
         client = MySQLClusterClient(
             executor=self._build_instance_tcp_executor(from_instance),

--- a/kubernetes/lib/charms/mysql/v0/mysql.py
+++ b/kubernetes/lib/charms/mysql/v0/mysql.py
@@ -78,24 +78,6 @@ from typing import (
 
 import ops
 from charms.data_platform_libs.v0.data_interfaces import DataPeerData, DataPeerUnitData
-from constants import (
-    BACKUPS_PASSWORD_KEY,
-    BACKUPS_USERNAME,
-    CHARMED_MYSQL_PITR_HELPER,
-    CLUSTER_ADMIN_PASSWORD_KEY,
-    CLUSTER_ADMIN_USERNAME,
-    COS_AGENT_RELATION_NAME,
-    GR_MAX_MEMBERS,
-    MONITORING_PASSWORD_KEY,
-    MONITORING_USERNAME,
-    PASSWORD_LENGTH,
-    PEER,
-    ROOT_PASSWORD_KEY,
-    ROOT_USERNAME,
-    SECRET_KEY_FALLBACKS,
-    SERVER_CONFIG_PASSWORD_KEY,
-    SERVER_CONFIG_USERNAME,
-)
 from mysql_shell.builders import (
     CharmAuthorizationQueryBuilder,
     CharmLockingQueryBuilder,
@@ -122,6 +104,25 @@ from tenacity import (
     stop_after_attempt,
     wait_fixed,
     wait_random,
+)
+
+from constants import (
+    BACKUPS_PASSWORD_KEY,
+    BACKUPS_USERNAME,
+    CHARMED_MYSQL_PITR_HELPER,
+    CLUSTER_ADMIN_PASSWORD_KEY,
+    CLUSTER_ADMIN_USERNAME,
+    COS_AGENT_RELATION_NAME,
+    GR_MAX_MEMBERS,
+    MONITORING_PASSWORD_KEY,
+    MONITORING_USERNAME,
+    PASSWORD_LENGTH,
+    PEER,
+    ROOT_PASSWORD_KEY,
+    ROOT_USERNAME,
+    SECRET_KEY_FALLBACKS,
+    SERVER_CONFIG_PASSWORD_KEY,
+    SERVER_CONFIG_USERNAME,
 )
 from utils import generate_random_password
 

--- a/kubernetes/lib/charms/mysql/v0/mysql.py
+++ b/kubernetes/lib/charms/mysql/v0/mysql.py
@@ -1965,7 +1965,8 @@ class MySQLBase(ABC):
 
         try:
             status = client.fetch_cluster_status(self.cluster_name, extended)
-        except ExecutionError:
+        except ExecutionError as exc:
+            logger.debug(f"Failed when fetching cluster status: {exc}")
             return None
         else:
             return status

--- a/kubernetes/lib/charms/mysql/v0/mysql.py
+++ b/kubernetes/lib/charms/mysql/v0/mysql.py
@@ -1981,7 +1981,8 @@ class MySQLBase(ABC):
 
         try:
             status = client.fetch_cluster_set_status(bool(extended))
-        except ExecutionError:
+        except ExecutionError as exc:
+            logger.debug(f"Failed when fetching cluster set status: {exc}")
             return None
         else:
             return status

--- a/kubernetes/lib/pyproject.toml
+++ b/kubernetes/lib/pyproject.toml
@@ -1,0 +1,31 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Linting tools configuration
+[tool.ruff]
+# preview and explicit preview are enabled for CPY001
+preview = true
+target-version = "py310"
+src = [".."]
+line-length = 99
+
+[tool.ruff.lint]
+explicit-preview-rules = true
+select = ["A", "E", "W", "F", "C", "N", "D", "I", "B", "CPY001", "RUF", "S", "SIM", "UP", "TC"]
+ignore = [
+  "D107", # Ignore D107 Missing docstring in __init__
+  "E501", # Ignore E501 Line too long
+
+]
+
+[tool.ruff.lint.flake8-copyright]
+# Check for properly formatted copyright header in each file
+author = "Canonical Ltd."
+notice-rgx = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+"
+min-file-size = 1
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"

--- a/kubernetes/src/mysql_k8s_executor.py
+++ b/kubernetes/src/mysql_k8s_executor.py
@@ -45,13 +45,16 @@ class ContainerExecutor(BaseExecutor):
                 f"--user={self._conn_details.username}",
             ]
 
-    def _parse_error(self, output: str) -> dict:
+    def _parse_exception(self, exc: ops.pebble.ExecError) -> str:
         """Parse the execution error."""
-        error = next(self._iter_output(output, "error"), None)
+        error = next(self._iter_output(exc.stdout or "", "error"), None)
         if not error:
-            error = {}
+            error = exc.stderr
 
-        return error
+        if isinstance(error, dict):
+            error = error.get("message")
+
+        return str(error)
 
     def _parse_output_py(self, output: str) -> str:
         """Parse the Python execution output."""
@@ -117,7 +120,7 @@ class ContainerExecutor(BaseExecutor):
             )
             process.wait_output()
         except ops.pebble.ExecError as exc:
-            err = self._parse_error(exc.stdout)
+            err = self._parse_exception(exc)
             raise ExecutionError(err) from exc
         except ops.pebble.TimeoutError as exc:
             raise ExecutionError() from exc
@@ -153,7 +156,7 @@ class ContainerExecutor(BaseExecutor):
             )
             stdout, _ = process.wait_output()
         except ops.pebble.ExecError as exc:
-            err = self._parse_error(exc.stdout)
+            err = self._parse_exception(exc)
             raise ExecutionError(err) from exc
         except ops.pebble.TimeoutError as exc:
             raise ExecutionError() from exc
@@ -186,7 +189,7 @@ class ContainerExecutor(BaseExecutor):
             )
             stdout, _ = process.wait_output()
         except ops.pebble.ExecError as exc:
-            err = self._parse_error(exc.stdout)
+            err = self._parse_exception(exc)
             exc = self._strip_password(exc)
             raise ExecutionError(err) from exc
         except ops.pebble.TimeoutError as exc:

--- a/machines/lib/charms/mysql/v0/mysql.py
+++ b/machines/lib/charms/mysql/v0/mysql.py
@@ -1949,11 +1949,6 @@ class MySQLBase(ABC):
         else:
             return unit_label in labels
 
-    @retry(
-        wait=wait_fixed(2),
-        stop=stop_after_attempt(3),
-        retry=retry_if_exception_type(ExecutionError),
-    )
     def get_cluster_status(
         self, from_instance: str | None = None, extended: bool | None = False
     ) -> dict | None:

--- a/machines/lib/charms/mysql/v0/mysql.py
+++ b/machines/lib/charms/mysql/v0/mysql.py
@@ -1950,7 +1950,7 @@ class MySQLBase(ABC):
             return unit_label in labels
 
     def get_cluster_status(
-        self, from_instance: str | None = None, extended: bool | None = False
+        self, from_instance: str | None = None, extended: bool = False
     ) -> dict | None:
         """Get the cluster status dictionary."""
         if not from_instance:

--- a/machines/lib/charms/mysql/v0/mysql.py
+++ b/machines/lib/charms/mysql/v0/mysql.py
@@ -1962,7 +1962,8 @@ class MySQLBase(ABC):
 
         try:
             status = client.fetch_cluster_status(self.cluster_name, extended)
-        except ExecutionError:
+        except ExecutionError as exc:
+            logger.debug(f"Failed when fetching cluster status: {exc}")
             return None
         else:
             return status

--- a/machines/lib/charms/mysql/v0/mysql.py
+++ b/machines/lib/charms/mysql/v0/mysql.py
@@ -1981,7 +1981,8 @@ class MySQLBase(ABC):
 
         try:
             status = client.fetch_cluster_set_status(bool(extended))
-        except ExecutionError:
+        except ExecutionError as exc:
+            logger.debug(f"Failed when fetching cluster set status: {exc}")
             return None
         else:
             return status


### PR DESCRIPTION
## Issue

This is a critical operation needed for troubleshooting that had obscure failure modes. In this PR I deleted some dead code and improved the logging so that, on DEBUG level, we can know immediately what went wrong.

Example logs:

```
unit-mysql-k8s-0: 21:04:49.208 DEBUG unit.mysql-k8s/0.juju-log Failed when fetching cluster status: Cannot set LC_ALL to locale en_US.UTF-8: No such file or directory
MySQL Error 2003 (HY000): Can't connect to MySQL server on 'mysql-k8s-0.mysql-k8s-endpoints.testing.svc.cluster.local.:33062' (111)                                                                                  
...
unit-mysql-k8s-0: 21:04:59.578 DEBUG unit.mysql-k8s/0.juju-log Failed when fetching cluster status: Shell Error (51314): Dba.get_cluster: This function is not available through a session to an InnoDB Cluster that belongs to an InnoDB ClusterSet but is not ONLINE
```

## Solution

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
