### PR TITLE
[MISC] Revert "Run integration tests on GitHub-hosted runners with Ubuntu 22.04"

### DIFF
--- a/.github/workflows/check_libs.yaml
+++ b/.github/workflows/check_libs.yaml
@@ -42,6 +42,4 @@ jobs:
           credentials: ""  # `charmcraft fetch-lib` no longer requires authentication; but action still requires input
           github-token: "${{ secrets.GITHUB_TOKEN }}"
     permissions:
-      contents: read
-      pull-requests: read
-      issues: write
+      pull-requests: write

--- a/.github/workflows/check_libs.yaml
+++ b/.github/workflows/check_libs.yaml
@@ -39,5 +39,5 @@ jobs:
         uses: canonical/charming-actions/check-libraries@2.7.0
         with:
           charm-path: ${{ matrix.path }}
-          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          credentials: ""  # `charmcraft fetch-lib` no longer requires authentication; but action still requires input
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/check_libs.yaml
+++ b/.github/workflows/check_libs.yaml
@@ -44,3 +44,4 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      issues: write

--- a/.github/workflows/check_libs.yaml
+++ b/.github/workflows/check_libs.yaml
@@ -41,3 +41,6 @@ jobs:
           charm-path: ${{ matrix.path }}
           credentials: ""  # `charmcraft fetch-lib` no longer requires authentication; but action still requires input
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+    permissions:
+      contents: read
+      pull-requests: read

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -114,10 +114,6 @@ jobs:
       - name: Checkout
         timeout-minutes: 3
         uses: actions/checkout@v6
-      - name: Install Python for tests
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
       - name: Set up environment
         timeout-minutes: 10
         run: |

--- a/kubernetes/spread.yaml
+++ b/kubernetes/spread.yaml
@@ -81,8 +81,6 @@ backends:
 
       sudo passwd --delete "$USER"
 
-      sudo systemctl reload ssh || sudo systemctl restart ssh
-
       ADDRESS localhost
     # HACK: spread does not pass environment variables set on runner
     # Manually pass specific environment variables
@@ -93,12 +91,10 @@ backends:
       AWS_SECRET_KEY: '$(HOST: echo $AWS_SECRET_KEY)'
       GCP_ACCESS_KEY: '$(HOST: echo $GCP_ACCESS_KEY)'
       GCP_SECRET_KEY: '$(HOST: echo $GCP_SECRET_KEY)'
-      LD_LIBRARY_PATH: '$(HOST: echo $LD_LIBRARY_PATH)'
-      PKG_CONFIG_PATH: '$(HOST: echo $PKG_CONFIG_PATH)'
     systems:
-      - ubuntu-22.04:
+      - ubuntu-24.04:
           username: runner
-      - ubuntu-22.04-arm:
+      - ubuntu-24.04-arm:
           username: runner
 
 suites:
@@ -113,7 +109,6 @@ kill-timeout: 3h
 environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
   CONCIERGE_JUJU_CHANNEL/juju36: 3.6/stable
-  pythonLocation: '$(HOST: echo $pythonLocation)'
 prepare: |
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"
@@ -124,7 +119,6 @@ prepare: |
   concierge prepare --trace
 
   pipx install tox poetry
-  poetry env use $pythonLocation/bin/python
 prepare-each: |
   cd "$SPREAD_PATH"
   concierge prepare --trace
@@ -132,5 +126,3 @@ prepare-each: |
   # Unable to set constraint on all models because of Juju bug:
   # https://bugs.launchpad.net/juju/+bug/2065050
   juju set-model-constraints arch="$(dpkg --print-architecture)"
-
-  poetry env use $pythonLocation/bin/python

--- a/machines/spread.yaml
+++ b/machines/spread.yaml
@@ -81,8 +81,6 @@ backends:
 
       sudo passwd --delete "$USER"
 
-      sudo systemctl reload ssh || sudo systemctl restart ssh
-
       ADDRESS localhost
     # HACK: spread does not pass environment variables set on runner
     # Manually pass specific environment variables
@@ -96,12 +94,10 @@ backends:
       UBUNTU_PRO_TOKEN: '$(HOST: echo $UBUNTU_PRO_TOKEN)'
       LANDSCAPE_ACCOUNT_NAME: '$(HOST: echo $LANDSCAPE_ACCOUNT_NAME)'
       LANDSCAPE_REGISTRATION_KEY: '$(HOST: echo $LANDSCAPE_REGISTRATION_KEY)'
-      LD_LIBRARY_PATH: '$(HOST: echo $LD_LIBRARY_PATH)'
-      PKG_CONFIG_PATH: '$(HOST: echo $PKG_CONFIG_PATH)'
     systems:
-      - ubuntu-22.04:
+      - ubuntu-24.04:
           username: runner
-      - ubuntu-22.04-arm:
+      - ubuntu-24.04-arm:
           username: runner
 
 suites:
@@ -116,7 +112,6 @@ kill-timeout: 3h
 environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
   CONCIERGE_JUJU_CHANNEL/juju36: 3.6/stable
-  pythonLocation: '$(HOST: echo $pythonLocation)'
 prepare: |
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"
@@ -127,7 +122,6 @@ prepare: |
   concierge prepare --trace
 
   pipx install tox poetry
-  poetry env use $pythonLocation/bin/python
 prepare-each: |
   cd "$SPREAD_PATH"
   concierge prepare --trace
@@ -135,5 +129,3 @@ prepare-each: |
   # Unable to set constraint on all models because of Juju bug:
   # https://bugs.launchpad.net/juju/+bug/2065050
   juju set-model-constraints arch="$(dpkg --print-architecture)"
-
-  poetry env use $pythonLocation/bin/python


### PR DESCRIPTION
Agent-Logs-Url: https://github.com/canonical/mysql-operators/sessions/0d8a02dc-32d0-4147-a2ce-5530bf0403d1

(But I have the suspicion Copilot-led PRs lack the necessary permissions)

## Issue

## Solution

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
