### PR TITLE
[DPE-10193] 8.0 - Fix Terraform expose block

### DIFF
--- a/kubernetes/terraform/main.tf
+++ b/kubernetes/terraform/main.tf
@@ -27,7 +27,7 @@ resource "juju_application" "mysql_server" {
     content {
       endpoints = lookup(expose.value, "endpoints", null)
       spaces    = lookup(expose.value, "spaces", null)
-      cidrs     = lookup(expose.value, "cirds", null)
+      cidrs     = lookup(expose.value, "cidrs", null)
     }
   }
 }

--- a/kubernetes/terraform/main.tf
+++ b/kubernetes/terraform/main.tf
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 resource "juju_application" "mysql_server" {
   model_uuid = var.model
   name       = var.app_name
@@ -18,7 +21,13 @@ resource "juju_application" "mysql_server" {
   constraints = var.constraints
   units       = var.units
 
-  expose {
-    endpoints = "database"
+  dynamic "expose" {
+    for_each = var.expose != null ? [var.expose] : []
+
+    content {
+      endpoints = lookup(expose.value, "endpoints", null)
+      spaces    = lookup(expose.value, "spaces", null)
+      cidrs     = lookup(expose.value, "cirds", null)
+    }
   }
 }

--- a/kubernetes/terraform/outputs.tf
+++ b/kubernetes/terraform/outputs.tf
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 output "app_name" {
   description = "Name of the MySQL Server K8s application"
   value       = juju_application.mysql_server.name

--- a/kubernetes/terraform/variables.tf
+++ b/kubernetes/terraform/variables.tf
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 variable "model" {
   description = "UUID of the juju model to deploy to"
   type        = string
@@ -18,7 +21,7 @@ variable "base" {
 variable "config" {
   description = "Application configuration. Details at https://charmhub.io/mysql-k8s/configurations"
   type        = map(string)
-  default     = {}
+  default     = null
 }
 
 variable "constraints" {
@@ -49,4 +52,10 @@ variable "storage_size" {
   description = "Storage size"
   type        = string
   default     = "10G"
+}
+
+variable "expose" {
+  description = "Exposed network access"
+  type        = map(string)
+  default     = null
 }

--- a/kubernetes/terraform/versions.tf
+++ b/kubernetes/terraform/versions.tf
@@ -1,10 +1,13 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 terraform {
   required_version = ">= 1.6.6"
 
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 1.0.0"
+      version = "~> 1.0"
     }
   }
 }

--- a/machines/terraform/main.tf
+++ b/machines/terraform/main.tf
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 resource "juju_application" "mysql_server" {
   model_uuid = var.model
   name       = var.app_name
@@ -18,7 +21,13 @@ resource "juju_application" "mysql_server" {
   endpoint_bindings = var.endpoint_bindings
   units             = var.units
 
-  expose {
-    endpoints = "database"
+  dynamic "expose" {
+    for_each = var.expose != null ? [var.expose] : []
+
+    content {
+      endpoints = lookup(expose.value, "endpoints", null)
+      spaces    = lookup(expose.value, "spaces", null)
+      cidrs     = lookup(expose.value, "cirds", null)
+    }
   }
 }

--- a/machines/terraform/main.tf
+++ b/machines/terraform/main.tf
@@ -27,7 +27,7 @@ resource "juju_application" "mysql_server" {
     content {
       endpoints = lookup(expose.value, "endpoints", null)
       spaces    = lookup(expose.value, "spaces", null)
-      cidrs     = lookup(expose.value, "cirds", null)
+      cidrs     = lookup(expose.value, "cidrs", null)
     }
   }
 }

--- a/machines/terraform/outputs.tf
+++ b/machines/terraform/outputs.tf
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 output "app_name" {
   description = "Name of the MySQL Server VM application"
   value       = juju_application.mysql_server.name

--- a/machines/terraform/variables.tf
+++ b/machines/terraform/variables.tf
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 variable "model" {
   description = "UUID of the juju model to deploy to"
   type        = string
@@ -18,7 +21,7 @@ variable "base" {
 variable "config" {
   description = "Application configuration. Details at https://charmhub.io/mysql/configurations"
   type        = map(string)
-  default     = {}
+  default     = null
 }
 
 variable "constraints" {
@@ -49,6 +52,12 @@ variable "storage_size" {
   description = "Storage size"
   type        = string
   default     = "10G"
+}
+
+variable "expose" {
+  description = "Exposed network access"
+  type        = map(string)
+  default     = null
 }
 
 variable "endpoint_bindings" {

--- a/machines/terraform/versions.tf
+++ b/machines/terraform/versions.tf
@@ -1,10 +1,13 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 terraform {
   required_version = ">= 1.6.6"
 
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 1.0.0"
+      version = "~> 1.0"
     }
   }
 }


### PR DESCRIPTION
This PR fixes the hard-coding of the `expose` block done in PR https://github.com/canonical/mysql-operators/pull/200, by making it optional.

The current Terraform definition was flawed, as exposing an endpoint / space / CIDR trigger different actions depending on the substrate: for VM it just requires to open certain ports, but for Kubernetes it requires the creation of an Ingress resource, which needs to be configured by passing the `juju-external-hostname` config.

### Additional changes
- Added missing LICENSE headers to all the Terraform files.
- Limited Juju provider version to be `1.X.Y`, now that version `2.0.0` is in release candidate phase.