### PR TITLE
[MISC] 8.0 - Centralize relation-data test helper

### DIFF
--- a/kubernetes/tests/integration/helpers_ha.py
+++ b/kubernetes/tests/integration/helpers_ha.py
@@ -7,6 +7,7 @@ import subprocess
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Any
 
 import jubilant_backports
 import kubernetes
@@ -341,31 +342,30 @@ def get_unit_process_id(juju: Juju, unit_name: str, process_name: str) -> int | 
         return None
 
 
-def get_relation_data(juju: Juju, app_name: str, rel_name: str) -> list[dict]:
+def get_unit_relation_data(juju: Juju, unit_name: str, relation_name: str) -> dict[str, Any]:
     """Returns a list that contains the relation-data.
 
     Args:
         juju: The juju instance to use.
-        app_name: The name of the application
-        rel_name: name of the relation to get connection data from
+        unit_name: The name of the unit
+        relation_name: name of the relation to get data from
 
     Returns:
-        A list that contains the relation-data
+        A dictionary containing the relation data-bags
     """
-    app_leader = get_app_leader(juju, app_name)
-    app_leader_info = get_unit_info(juju, app_leader)
-    if not app_leader_info:
-        raise ValueError(f"No unit info could be grabbed for unit {app_leader}")
+    unit_info = get_unit_info(juju, unit_name)
+    if not unit_info:
+        raise ValueError(f"No unit info could be grabbed for unit {unit_name}")
 
     relation_data = [
         value
-        for value in app_leader_info[app_leader]["relation-info"]
-        if value["endpoint"] == rel_name
+        for value in unit_info[unit_name]["relation-info"]
+        if value["endpoint"] == relation_name
     ]
     if not relation_data:
-        raise ValueError(f"No relation data could be grabbed for relation {rel_name}")
+        raise ValueError(f"No relation data could be grabbed for relation {relation_name}")
 
-    return relation_data
+    return relation_data[0]
 
 
 @retry(stop=stop_after_attempt(30), wait=wait_fixed(5), reraise=True)

--- a/kubernetes/tests/integration/integration/high_availability/test_upgrade.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_upgrade.py
@@ -21,8 +21,8 @@ from ...helpers_ha import (
     get_k8s_stateful_set_partitions,
     get_mysql_primary_unit,
     get_mysql_variable_value,
-    get_relation_data,
     get_unit_by_number,
+    get_unit_relation_data,
     load_mysql_test_data,
     wait_for_apps_status,
     wait_for_unit_message,
@@ -153,7 +153,7 @@ def test_fail_and_rollback(juju: Juju, charm: str, continuous_writes) -> None:
     shutil.copy(charm, tmp_folder_charm)
 
     logging.info("Inject dependency fault")
-    inject_dependency_fault(juju, MYSQL_APP_NAME, tmp_folder_charm)
+    inject_dependency_fault(juju, mysql_app_leader, tmp_folder_charm)
 
     logging.info("Refresh the charm")
     juju.refresh(app=MYSQL_APP_NAME, path=tmp_folder_charm)
@@ -202,16 +202,16 @@ def test_fail_and_rollback(juju: Juju, charm: str, continuous_writes) -> None:
     tmp_folder_charm.unlink()
 
 
-def inject_dependency_fault(juju: Juju, app_name: str, charm_file: str | Path) -> None:
+def inject_dependency_fault(juju: Juju, unit_name: str, charm_file: str | Path) -> None:
     """Inject a dependency fault into the mysql charm."""
     # Open dependency.json and load current charm version
     with open("src/dependency.json") as dependency_file:
         current_charm_version = json.load(dependency_file)["charm"]["version"]
 
     # Query running dependency to overwrite with incompatible version
-    relation_data = get_relation_data(juju, app_name, "upgrade")
+    relation_data = get_unit_relation_data(juju, unit_name, "upgrade")
 
-    loaded_dependency_dict = json.loads(relation_data[0]["application-data"]["dependencies"])
+    loaded_dependency_dict = json.loads(relation_data["application-data"]["dependencies"])
     loaded_dependency_dict["charm"]["upgrade_supported"] = f">{current_charm_version}"
     loaded_dependency_dict["charm"]["version"] = "999.999.999"
 

--- a/kubernetes/tests/integration/integration/relations/test_database.py
+++ b/kubernetes/tests/integration/integration/relations/test_database.py
@@ -12,7 +12,8 @@ from ...architecture import architecture
 from ...helpers_ha import (
     CHARM_METADATA,
     MINUTE_SECS,
-    get_relation_data,
+    get_app_leader,
+    get_unit_relation_data,
     wait_for_apps_status,
 )
 
@@ -77,8 +78,10 @@ def test_relation_creation_databag(juju: Juju):
         timeout=15 * MINUTE_SECS,
     )
 
-    relation_data = get_relation_data(juju, APPLICATION_APP_NAME, "database")
-    assert {"password", "username"} <= set(relation_data[0]["application-data"])
+    app_leader = get_app_leader(juju, APPLICATION_APP_NAME)
+    relation_data = get_unit_relation_data(juju, app_leader, "database")
+
+    assert {"password", "username"} <= set(relation_data["application-data"])
 
 
 @markers.only_with_juju_secrets
@@ -89,9 +92,11 @@ def test_relation_creation(juju: Juju):
         timeout=15 * MINUTE_SECS,
     )
 
-    relation_data = get_relation_data(juju, APPLICATION_APP_NAME, "database")
-    assert not {"password", "username"} <= set(relation_data[0]["application-data"])
-    assert "secret-user" in relation_data[0]["application-data"]
+    app_leader = get_app_leader(juju, APPLICATION_APP_NAME)
+    relation_data = get_unit_relation_data(juju, app_leader, "database")
+
+    assert not {"password", "username"} <= set(relation_data["application-data"])
+    assert "secret-user" in relation_data["application-data"]
 
 
 def test_relation_broken(juju: Juju):

--- a/kubernetes/tests/integration/integration/test_tls.py
+++ b/kubernetes/tests/integration/integration/test_tls.py
@@ -20,7 +20,7 @@ from ..helpers_ha import (
     get_app_units,
     get_mysql_server_credentials,
     get_unit_address,
-    get_unit_info,
+    get_unit_relation_data,
     wait_for_apps_status,
 )
 
@@ -135,7 +135,7 @@ def test_enable_tls(juju: Juju) -> None:
 
     # test for ca presence in a given unit
     logger.info("Assert TLS file exists")
-    assert get_tls_ca(juju, app_units[0]), "❌ No CA found after TLS relation"
+    assert get_unit_certificates_ca(juju, app_units[0], "certificates")
 
 
 def test_rotate_tls_key(juju: Juju) -> None:
@@ -210,27 +210,23 @@ def test_disable_tls(juju: Juju) -> None:
         )
 
 
-def get_tls_ca(juju: Juju, unit_name: str) -> str:
+def get_unit_certificates_ca(juju: Juju, unit_name: str, relation_name: str) -> str:
     """Returns the TLS CA used by the unit.
 
     Args:
         juju: The Juju instance
         unit_name: The name of the unit
+        relation_name: name of the relation to get data from
 
     Returns:
         TLS CA or an empty string if there is no CA.
     """
-    unit_info = get_unit_info(juju, unit_name)
-    if not unit_info:
-        raise ValueError(f"no unit info could be grabbed for {unit_name}")
+    relation_data = get_unit_relation_data(juju, unit_name, relation_name)
+    relation_fields = json.loads(relation_data["application-data"]["certificates"])
+    if not relation_fields:
+        raise ValueError(f"No relation data could be grabbed for relation {relation_name}")
 
-    # Filter the data based on the relation name.
-    relation_data = [
-        v for v in unit_info[unit_name]["relation-info"] if v["endpoint"] == "certificates"
-    ]
-    if len(relation_data) == 0:
-        return ""
-    return json.loads(relation_data[0]["application-data"]["certificates"])[0].get("ca")
+    return relation_fields[0].get("ca", "")
 
 
 def unit_file_md5(juju: Juju, unit_name: str, file_path: str) -> str | None:

--- a/machines/tests/integration/helpers_ha.py
+++ b/machines/tests/integration/helpers_ha.py
@@ -7,6 +7,7 @@ import subprocess
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Any
 
 import jubilant_backports
 import yaml
@@ -216,31 +217,30 @@ def get_unit_status_log(juju: Juju, unit_name: str, log_lines: int = 0) -> list[
     return json.loads(output)
 
 
-def get_relation_data(juju: Juju, app_name: str, rel_name: str) -> list[dict]:
+def get_unit_relation_data(juju: Juju, unit_name: str, relation_name: str) -> dict[str, Any]:
     """Returns a list that contains the relation-data.
 
     Args:
         juju: The juju instance to use.
-        app_name: The name of the application
-        rel_name: name of the relation to get connection data from
+        unit_name: The name of the unit
+        relation_name: name of the relation to get data from
 
     Returns:
-        A list that contains the relation-data
+        A dictionary containing the relation data-bags
     """
-    app_leader = get_app_leader(juju, app_name)
-    app_leader_info = get_unit_info(juju, app_leader)
-    if not app_leader_info:
-        raise ValueError(f"No unit info could be grabbed for unit {app_leader}")
+    unit_info = get_unit_info(juju, unit_name)
+    if not unit_info:
+        raise ValueError(f"No unit info could be grabbed for unit {unit_name}")
 
     relation_data = [
         value
-        for value in app_leader_info[app_leader]["relation-info"]
-        if value["endpoint"] == rel_name
+        for value in unit_info[unit_name]["relation-info"]
+        if value["endpoint"] == relation_name
     ]
     if not relation_data:
-        raise ValueError(f"No relation data could be grabbed for relation {rel_name}")
+        raise ValueError(f"No relation data could be grabbed for relation {relation_name}")
 
-    return relation_data
+    return relation_data[0]
 
 
 @retry(stop=stop_after_attempt(30), wait=wait_fixed(5), reraise=True)

--- a/machines/tests/integration/integration/high_availability/test_upgrade.py
+++ b/machines/tests/integration/integration/high_availability/test_upgrade.py
@@ -17,7 +17,7 @@ from ...helpers_ha import (
     get_app_units,
     get_mysql_primary_unit,
     get_mysql_variable_value,
-    get_relation_data,
+    get_unit_relation_data,
     load_mysql_test_data,
     wait_for_apps_status,
 )
@@ -122,7 +122,7 @@ def test_fail_and_rollback(juju: Juju, charm: str, continuous_writes) -> None:
     shutil.copy(charm, tmp_folder_charm)
 
     logging.info("Inject dependency fault")
-    inject_dependency_fault(juju, MYSQL_APP_NAME, tmp_folder_charm)
+    inject_dependency_fault(juju, mysql_app_leader, tmp_folder_charm)
 
     logging.info("Refresh the charm")
     juju.refresh(app=MYSQL_APP_NAME, path=tmp_folder_charm)
@@ -161,16 +161,16 @@ def test_fail_and_rollback(juju: Juju, charm: str, continuous_writes) -> None:
     tmp_folder_charm.unlink()
 
 
-def inject_dependency_fault(juju: Juju, app_name: str, charm_file: str | Path) -> None:
+def inject_dependency_fault(juju: Juju, unit_name: str, charm_file: str | Path) -> None:
     """Inject a dependency fault into the mysql charm."""
     # Open dependency.json and load current charm version
     with open("src/dependency.json") as dependency_file:
         current_charm_version = json.load(dependency_file)["charm"]["version"]
 
     # Query running dependency to overwrite with incompatible version
-    relation_data = get_relation_data(juju, app_name, "upgrade")
+    relation_data = get_unit_relation_data(juju, unit_name, "upgrade")
 
-    loaded_dependency_dict = json.loads(relation_data[0]["application-data"]["dependencies"])
+    loaded_dependency_dict = json.loads(relation_data["application-data"]["dependencies"])
     loaded_dependency_dict["charm"]["upgrade_supported"] = f">{current_charm_version}"
     loaded_dependency_dict["charm"]["version"] = f"{int(current_charm_version) + 1}"
 

--- a/machines/tests/integration/integration/relations/test_database.py
+++ b/machines/tests/integration/integration/relations/test_database.py
@@ -15,11 +15,12 @@ from ... import markers
 from ...helpers import execute_queries_on_unit
 from ...helpers_ha import (
     MINUTE_SECS,
+    get_app_leader,
     get_app_units,
     get_mysql_primary_unit,
     get_mysql_server_credentials,
-    get_relation_data,
     get_unit_ip,
+    get_unit_relation_data,
     remove_leader_unit,
     scale_app_units,
     wait_for_apps_status,
@@ -143,8 +144,10 @@ def test_relation_creation_databag(juju: Juju):
         timeout=TIMEOUT,
     )
 
-    relation_data = get_relation_data(juju, APPLICATION_APP_NAME, DB_RELATION_NAME)
-    assert {"password", "username"} <= set(relation_data[0]["application-data"])
+    app_leader = get_app_leader(juju, APPLICATION_APP_NAME)
+    relation_data = get_unit_relation_data(juju, app_leader, DB_RELATION_NAME)
+
+    assert {"password", "username"} <= set(relation_data["application-data"])
 
 
 @markers.only_with_juju_secrets
@@ -157,15 +160,17 @@ def test_relation_creation(juju: Juju):
         timeout=TIMEOUT,
     )
 
-    relation_data = get_relation_data(juju, APPLICATION_APP_NAME, DB_RELATION_NAME)
-    assert not {"password", "username"} <= set(relation_data[0]["application-data"])
-    assert "secret-user" in relation_data[0]["application-data"]
+    app_leader = get_app_leader(juju, APPLICATION_APP_NAME)
+    relation_data = get_unit_relation_data(juju, app_leader, DB_RELATION_NAME)
+
+    assert not {"password", "username"} <= set(relation_data["application-data"])
+    assert "secret-user" in relation_data["application-data"]
 
 
 def test_read_only_endpoints(juju: Juju):
     """Check read-only-endpoints are correctly updated."""
-    relation_data = get_relation_data(juju, DATABASE_APP_NAME, DB_RELATION_NAME)
-    assert len(relation_data) == 1
+    relation_data = get_unit_relation_data(juju, DATABASE_APP_NAME, DB_RELATION_NAME)
+    assert relation_data
 
     check_read_only_endpoints(juju, app_name=DATABASE_APP_NAME, relation_name=DB_RELATION_NAME)
 
@@ -221,19 +226,23 @@ def check_read_only_endpoints(juju: Juju, app_name: str, relation_name: str) -> 
         app_name: The name of the application
         relation_name: The name of the relation
     """
-    relation_data = get_relation_data(juju=juju, app_name=app_name, rel_name=relation_name)
+    app_leader = get_app_leader(juju, app_name)
+    relation_data = get_unit_relation_data(juju, app_leader, relation_name)
     read_only_endpoint_ips = get_read_only_endpoint_ips(relation_data)
+
     # check that the number of read-only-endpoints is correct
     if len(get_app_units(juju, app_name)) - 1 != len(read_only_endpoint_ips):
         return False
+
     unit_ips = [
         get_unit_ip(juju, app_name, unit_name) for unit_name in get_app_units(juju, app_name)
     ]
+
     # check that endpoints are the one of the application
     return all(read_endpoint_ip in unit_ips for read_endpoint_ip in read_only_endpoint_ips)
 
 
-def get_read_only_endpoints(relation_data: list) -> set[str]:
+def get_read_only_endpoints(relation_data: dict) -> set[str]:
     """Returns the read-only-endpoints from the relation data.
 
     Args:
@@ -241,7 +250,7 @@ def get_read_only_endpoints(relation_data: list) -> set[str]:
     Returns:
         a set that contains the read-only-endpoints
     """
-    related_units = relation_data[0]["related-units"]
+    related_units = relation_data["related-units"]
     read_only_endpoints = set()
     for _, relation_data in related_units.items():
         assert "data" in relation_data
@@ -261,7 +270,7 @@ def get_read_only_endpoints(relation_data: list) -> set[str]:
     return read_only_endpoints
 
 
-def get_read_only_endpoint_ips(relation_data: list) -> list[str]:
+def get_read_only_endpoint_ips(relation_data: dict) -> list[str]:
     """Returns the read-only-endpoint hostnames from the relation data.
 
     Args:

--- a/machines/tests/integration/integration/test_tls.py
+++ b/machines/tests/integration/integration/test_tls.py
@@ -18,8 +18,8 @@ from ..helpers_ha import (
     MINUTE_SECS,
     get_app_units,
     get_mysql_server_credentials,
-    get_unit_info,
     get_unit_ip,
+    get_unit_relation_data,
     wait_for_apps_status,
 )
 
@@ -138,8 +138,8 @@ def test_enable_tls(juju: Juju) -> None:
         )
 
     # test for ca presence in a given unit
-    logger.info("Assert TLS file exists")
-    assert get_tls_ca(juju, app_units[0]), "❌ No CA found after TLS relation"
+    logger.info("Assert TLS files exists")
+    assert get_unit_certificates_ca(juju, app_units[0], "certificates")
 
 
 def test_rotate_tls_key(juju: Juju) -> None:
@@ -219,27 +219,23 @@ def test_disable_tls(juju: Juju) -> None:
         )
 
 
-def get_tls_ca(juju: Juju, unit_name: str) -> str:
+def get_unit_certificates_ca(juju: Juju, unit_name: str, relation_name: str) -> str:
     """Returns the TLS CA used by the unit.
 
     Args:
         juju: The Juju instance
         unit_name: The name of the unit
+        relation_name: name of the relation to get data from
 
     Returns:
         TLS CA or an empty string if there is no CA.
     """
-    unit_info = get_unit_info(juju, unit_name)
-    if not unit_info:
-        raise ValueError(f"no unit info could be grabbed for {unit_name}")
+    relation_data = get_unit_relation_data(juju, unit_name, relation_name)
+    relation_fields = json.loads(relation_data["application-data"]["certificates"])
+    if not relation_fields:
+        raise ValueError(f"No relation data could be grabbed for relation {relation_name}")
 
-    # Filter the data based on the relation name.
-    relation_data = [
-        v for v in unit_info[unit_name]["relation-info"] if v["endpoint"] == "certificates"
-    ]
-    if len(relation_data) == 0:
-        return ""
-    return json.loads(relation_data[0]["application-data"]["certificates"])[0].get("ca")
+    return relation_fields[0].get("ca", "")
 
 
 def unit_file_md5(juju: Juju, unit_name: str, file_path: str) -> str | None:


### PR DESCRIPTION
This PR proposes a simplification regarding how the integration tests get relation data. This logic is duplicated across:

- Kubernetes:
  - `helpers.py` module (see [code](https://github.com/canonical/mysql-operators/blob/b505a21ed84ffb3673e788fd5de8cfa87bcc3779/kubernetes/tests/integration/helpers_ha.py#L344-L368)).
  - `test_tls.py` module (see [code](https://github.com/canonical/mysql-operators/blob/b505a21ed84ffb3673e788fd5de8cfa87bcc3779/kubernetes/tests/integration/integration/test_tls.py#L213-L233)).
- Machines:
  - `helpers.py` module (see [code](https://github.com/canonical/mysql-operators/blob/b505a21ed84ffb3673e788fd5de8cfa87bcc3779/machines/tests/integration/helpers_ha.py#L219-L243)).
  - `test_tls.py` module (see [code](https://github.com/canonical/mysql-operators/blob/b505a21ed84ffb3673e788fd5de8cfa87bcc3779/machines/tests/integration/integration/test_tls.py#L222-L242)).
