### PR TITLE
[MISC] 8.4 - Centralize relation-data test helper

### DIFF
--- a/kubernetes/tests/integration/helpers_ha.py
+++ b/kubernetes/tests/integration/helpers_ha.py
@@ -9,6 +9,7 @@ import uuid
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Any
 
 import jubilant
 import kubernetes
@@ -324,31 +325,30 @@ def get_unit_process_id(juju: Juju, unit_name: str, process_name: str) -> int | 
         return None
 
 
-def get_relation_data(juju: Juju, app_name: str, rel_name: str) -> list[dict]:
+def get_unit_relation_data(juju: Juju, unit_name: str, relation_name: str) -> dict[str, Any]:
     """Returns a list that contains the relation-data.
 
     Args:
         juju: The juju instance to use.
-        app_name: The name of the application
-        rel_name: name of the relation to get connection data from
+        unit_name: The name of the unit
+        relation_name: name of the relation to get data from
 
     Returns:
-        A list that contains the relation-data
+        A dictionary containing the relation data-bags
     """
-    app_leader = get_app_leader(juju, app_name)
-    app_leader_info = get_unit_info(juju, app_leader)
-    if not app_leader_info:
-        raise ValueError(f"No unit info could be grabbed for unit {app_leader}")
+    unit_info = get_unit_info(juju, unit_name)
+    if not unit_info:
+        raise ValueError(f"No unit info could be grabbed for unit {unit_name}")
 
     relation_data = [
         value
-        for value in app_leader_info[app_leader]["relation-info"]
-        if value["endpoint"] == rel_name
+        for value in unit_info[unit_name]["relation-info"]
+        if value["endpoint"] == relation_name
     ]
     if not relation_data:
-        raise ValueError(f"No relation data could be grabbed for relation {rel_name}")
+        raise ValueError(f"No relation data could be grabbed for relation {relation_name}")
 
-    return relation_data
+    return relation_data[0]
 
 
 @retry(stop=stop_after_attempt(30), wait=wait_fixed(5), reraise=True)

--- a/kubernetes/tests/integration/integration/relations/test_database.py
+++ b/kubernetes/tests/integration/integration/relations/test_database.py
@@ -11,7 +11,8 @@ from ... import architecture
 from ...helpers_ha import (
     CHARM_METADATA,
     MINUTE_SECS,
-    get_relation_data,
+    get_app_leader,
+    get_unit_relation_data,
     wait_for_apps_status,
 )
 
@@ -75,9 +76,11 @@ def test_relation_creation(juju: Juju):
         timeout=15 * MINUTE_SECS,
     )
 
-    relation_data = get_relation_data(juju, APPLICATION_APP_NAME, "database")
-    assert not {"password", "username"} <= set(relation_data[0]["application-data"])
-    assert "secret-user" in relation_data[0]["application-data"]
+    app_leader = get_app_leader(juju, APPLICATION_APP_NAME)
+    relation_data = get_unit_relation_data(juju, app_leader, "database")
+
+    assert not {"password", "username"} <= set(relation_data["application-data"])
+    assert "secret-user" in relation_data["application-data"]
 
 
 def test_relation_broken(juju: Juju):

--- a/kubernetes/tests/integration/integration/test_tls.py
+++ b/kubernetes/tests/integration/integration/test_tls.py
@@ -16,7 +16,7 @@ from ..helpers_ha import (
     get_app_units,
     get_mysql_server_credentials,
     get_unit_address,
-    get_unit_info,
+    get_unit_relation_data,
     wait_for_apps_status,
 )
 
@@ -124,8 +124,9 @@ def test_enable_tls(juju: Juju) -> None:
         )
 
     # test for ca presence in a given unit
-    logger.info("Assert TLS file exists")
-    assert get_tls_ca(juju, app_units[0]), "❌ No CA found after TLS relation"
+    logger.info("Assert TLS files exists")
+    assert get_unit_relation_data(juju, app_units[0], "client-certificates")
+    assert get_unit_relation_data(juju, app_units[0], "peer-certificates")
 
 
 def test_disable_tls(juju: Juju) -> None:
@@ -160,24 +161,20 @@ def test_disable_tls(juju: Juju) -> None:
         )
 
 
-def get_tls_ca(juju: Juju, unit_name: str) -> str:
+def get_unit_certificates_ca(juju: Juju, unit_name: str, relation_name: str) -> str:
     """Returns the TLS CA used by the unit.
 
     Args:
         juju: The Juju instance
         unit_name: The name of the unit
+        relation_name: name of the relation to get data from
 
     Returns:
         TLS CA or an empty string if there is no CA.
     """
-    unit_info = get_unit_info(juju, unit_name)
-    if not unit_info:
-        raise ValueError(f"no unit info could be grabbed for {unit_name}")
+    relation_data = get_unit_relation_data(juju, unit_name, relation_name)
+    relation_fields = json.loads(relation_data["application-data"]["certificates"])
+    if not relation_fields:
+        raise ValueError(f"No relation data could be grabbed for relation {relation_name}")
 
-    # Filter the data based on the relation name.
-    relation_data = [
-        v for v in unit_info[unit_name]["relation-info"] if v["endpoint"] == "client-certificates"
-    ]
-    if len(relation_data) == 0:
-        return ""
-    return json.loads(relation_data[0]["application-data"]["certificates"])[0].get("ca")
+    return relation_fields[0].get("ca", "")

--- a/machines/tests/integration/helpers_ha.py
+++ b/machines/tests/integration/helpers_ha.py
@@ -9,6 +9,7 @@ import uuid
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Any
 
 import jubilant
 import yaml
@@ -219,6 +220,32 @@ def get_unit_status_log(juju: Juju, unit_name: str, log_lines: int = 0) -> list[
     )
 
     return json.loads(output)
+
+
+def get_unit_relation_data(juju: Juju, unit_name: str, relation_name: str) -> dict[str, Any]:
+    """Returns a list that contains the relation-data.
+
+    Args:
+        juju: The juju instance to use.
+        unit_name: The name of the unit
+        relation_name: name of the relation to get data from
+
+    Returns:
+        A dictionary containing the relation data-bags
+    """
+    unit_info = get_unit_info(juju, unit_name)
+    if not unit_info:
+        raise ValueError(f"No unit info could be grabbed for unit {unit_name}")
+
+    relation_data = [
+        value
+        for value in unit_info[unit_name]["relation-info"]
+        if value["endpoint"] == relation_name
+    ]
+    if not relation_data:
+        raise ValueError(f"No relation data could be grabbed for relation {relation_name}")
+
+    return relation_data[0]
 
 
 @retry(stop=stop_after_attempt(30), wait=wait_fixed(5), reraise=True)

--- a/machines/tests/integration/integration/relations/test_database.py
+++ b/machines/tests/integration/integration/relations/test_database.py
@@ -18,8 +18,8 @@ from ...helpers_ha import (
     get_app_units,
     get_mysql_primary_unit,
     get_mysql_server_credentials,
-    get_unit_info,
     get_unit_ip,
+    get_unit_relation_data,
     remove_leader_unit,
     rotate_mysql_server_credentials,
     scale_app_units,
@@ -137,15 +137,18 @@ def test_relation_creation(juju: Juju):
         timeout=TIMEOUT,
     )
 
-    relation_data = get_relation_data(juju, APPLICATION_APP_NAME, DB_RELATION_NAME)
-    assert not {"password", "username"} <= set(relation_data[0]["application-data"])
-    assert "secret-user" in relation_data[0]["application-data"]
+    app_leader = get_app_leader(juju, APPLICATION_APP_NAME)
+    relation_data = get_unit_relation_data(juju, app_leader, DB_RELATION_NAME)
+
+    assert not {"password", "username"} <= set(relation_data["application-data"])
+    assert "secret-user" in relation_data["application-data"]
 
 
 def test_read_only_endpoints(juju: Juju):
     """Check read-only-endpoints are correctly updated."""
-    relation_data = get_relation_data(juju, DATABASE_APP_NAME, DB_RELATION_NAME)
-    assert len(relation_data) == 1
+    app_leader = get_app_leader(juju, APPLICATION_APP_NAME)
+    relation_data = get_unit_relation_data(juju, app_leader, DB_RELATION_NAME)
+    assert relation_data
 
     check_read_only_endpoints(juju, app_name=DATABASE_APP_NAME, relation_name=DB_RELATION_NAME)
 
@@ -201,19 +204,23 @@ def check_read_only_endpoints(juju: Juju, app_name: str, relation_name: str) -> 
         app_name: The name of the application
         relation_name: The name of the relation
     """
-    relation_data = get_relation_data(juju=juju, app_name=app_name, relation_name=relation_name)
+    app_leader = get_app_leader(juju, app_name)
+    relation_data = get_unit_relation_data(juju, app_leader, relation_name)
     read_only_endpoint_ips = get_read_only_endpoint_ips(relation_data)
+
     # check that the number of read-only-endpoints is correct
     if len(get_app_units(juju, app_name)) - 1 != len(read_only_endpoint_ips):
         return False
+
     unit_ips = [
         get_unit_ip(juju, app_name, unit_name) for unit_name in get_app_units(juju, app_name)
     ]
+
     # check that endpoints are the one of the application
     return all(read_endpoint_ip in unit_ips for read_endpoint_ip in read_only_endpoint_ips)
 
 
-def get_read_only_endpoints(relation_data: list) -> set[str]:
+def get_read_only_endpoints(relation_data: dict) -> set[str]:
     """Returns the read-only-endpoints from the relation data.
 
     Args:
@@ -221,7 +228,7 @@ def get_read_only_endpoints(relation_data: list) -> set[str]:
     Returns:
         a set that contains the read-only-endpoints
     """
-    related_units = relation_data[0]["related-units"]
+    related_units = relation_data["related-units"]
     read_only_endpoints = set()
     for _, relation_data in related_units.items():
         assert "data" in relation_data
@@ -241,7 +248,7 @@ def get_read_only_endpoints(relation_data: list) -> set[str]:
     return read_only_endpoints
 
 
-def get_read_only_endpoint_ips(relation_data: list) -> list[str]:
+def get_read_only_endpoint_ips(relation_data: dict) -> list[str]:
     """Returns the read-only-endpoint hostnames from the relation data.
 
     Args:
@@ -259,30 +266,3 @@ def get_read_only_endpoint_ips(relation_data: list) -> list[str]:
             raise ValueError("Malformed endpoint")
 
     return read_only_endpoint_hostnames
-
-
-def get_relation_data(juju: Juju, app_name: str, relation_name: str) -> list[dict]:
-    """Returns a list that contains the relation-data.
-
-    Args:
-        juju: The juju instance to use.
-        app_name: The name of the application
-        relation_name: name of the relation to get connection data from
-
-    Returns:
-        A list that contains the relation-data
-    """
-    app_leader = get_app_leader(juju, app_name)
-    app_leader_info = get_unit_info(juju, app_leader)
-    if not app_leader_info:
-        raise ValueError(f"No unit info could be grabbed for unit {app_leader}")
-
-    relation_data = [
-        value
-        for value in app_leader_info[app_leader]["relation-info"]
-        if value["endpoint"] == relation_name
-    ]
-    if not relation_data:
-        raise ValueError(f"No relation data could be grabbed for relation {relation_name}")
-
-    return relation_data

--- a/machines/tests/integration/integration/spaces/test_spaced_db.py
+++ b/machines/tests/integration/integration/spaces/test_spaced_db.py
@@ -49,7 +49,7 @@ def test_build_and_deploy(juju: Juju, lxd_spaces, charm) -> None:
         timeout=TIMEOUT,
     )
     juju.wait(
-        ready=wait_for_apps_status(jubilant.all_waiting, APPLICATION_APP_NAME),
+        ready=wait_for_apps_status(jubilant.all_blocked, APPLICATION_APP_NAME),
         timeout=TIMEOUT,
     )
 
@@ -96,7 +96,7 @@ def test_integrate_with_isolated_space(juju: Juju):
         channel="latest/edge",
     )
     juju.wait(
-        ready=wait_for_apps_status(jubilant.all_waiting, isolated_app_name),
+        ready=wait_for_apps_status(jubilant.all_blocked, isolated_app_name),
         timeout=TIMEOUT,
     )
 

--- a/machines/tests/integration/integration/test_tls.py
+++ b/machines/tests/integration/integration/test_tls.py
@@ -16,8 +16,8 @@ from ..helpers_ha import (
     MINUTE_SECS,
     get_app_units,
     get_mysql_server_credentials,
-    get_unit_info,
     get_unit_ip,
+    get_unit_relation_data,
     wait_for_apps_status,
 )
 
@@ -123,8 +123,9 @@ def test_enable_tls(juju: Juju) -> None:
         )
 
     # test for ca presence in a given unit
-    logger.info("Assert TLS file exists")
-    assert get_tls_ca(juju, app_units[0]), "❌ No CA found after TLS relation"
+    logger.info("Assert TLS files exists")
+    assert get_unit_certificates_ca(juju, app_units[0], "client-certificates")
+    assert get_unit_certificates_ca(juju, app_units[0], "peer-certificates")
 
 
 def test_disable_tls(juju: Juju) -> None:
@@ -159,24 +160,20 @@ def test_disable_tls(juju: Juju) -> None:
         )
 
 
-def get_tls_ca(juju: Juju, unit_name: str) -> str:
+def get_unit_certificates_ca(juju: Juju, unit_name: str, relation_name: str) -> str:
     """Returns the TLS CA used by the unit.
 
     Args:
         juju: The Juju instance
         unit_name: The name of the unit
+        relation_name: name of the relation to get data from
 
     Returns:
         TLS CA or an empty string if there is no CA.
     """
-    unit_info = get_unit_info(juju, unit_name)
-    if not unit_info:
-        raise ValueError(f"no unit info could be grabbed for {unit_name}")
+    relation_data = get_unit_relation_data(juju, unit_name, relation_name)
+    relation_fields = json.loads(relation_data["application-data"]["certificates"])
+    if not relation_fields:
+        raise ValueError(f"No relation data could be grabbed for relation {relation_name}")
 
-    # Filter the data based on the relation name.
-    relation_data = [
-        v for v in unit_info[unit_name]["relation-info"] if v["endpoint"] == "client-certificates"
-    ]
-    if len(relation_data) == 0:
-        return ""
-    return json.loads(relation_data[0]["application-data"]["certificates"])[0].get("ca")
+    return relation_fields[0].get("ca", "")


### PR DESCRIPTION
This PR proposes a simplification regarding how the integration tests get relation data. This logic is duplicated across:

- Kubernetes:
  - `helpers.py` module (see [code](https://github.com/canonical/mysql-operators/blob/d9cfafa737a9502ef49417b51cf72d82f4d24fd4/kubernetes/tests/integration/helpers_ha.py#L327-L351)).
  - `test_tls.py` module (see [code](https://github.com/canonical/mysql-operators/blob/d9cfafa737a9502ef49417b51cf72d82f4d24fd4/kubernetes/tests/integration/integration/test_tls.py#L163-L183)).
- Machines:
  - `test_database.py` module (see [code](https://github.com/canonical/mysql-operators/blob/d9cfafa737a9502ef49417b51cf72d82f4d24fd4/machines/tests/integration/integration/relations/test_database.py#L269-L293)).
  - `test_tls.py` module (see [code](https://github.com/canonical/mysql-operators/blob/d9cfafa737a9502ef49417b51cf72d82f4d24fd4/machines/tests/integration/integration/test_tls.py#L162-L182)).

### Additional changes

- Fixed MySQL Test app status refactor leftover in the `test_spaced_db.py` module.
- Checked whether the CA files are present, for both TLS certificates relations.

