### PR TITLE
[DPE-7899] 8.4 - Migrate to TLS v4 (III)

### DIFF
--- a/docs/how-to/tls/disable-tls.md
+++ b/docs/how-to/tls/disable-tls.md
@@ -19,8 +19,9 @@ remove the relation between Charmed MySQL and the TLS provider.
 
     > Integration provider                   Requirer                   Interface         Type     Message
     > mysql:database-peers                   mysql:database-peers       mysql_peers       peer
-    > mysql:restart                          mysql:restart              rolling_op        peer
+    > mysql:rolling-ops                      mysql:rolling-ops          rolling_op        peer
     > self-signed-certificates:certificates  mysql:client-certificates  tls-certificates  regular
+    > self-signed-certificates:certificates  mysql:peer-certificates    tls-certificates  regular
 ```
 
 ```{tab-item} K8s
@@ -30,8 +31,9 @@ remove the relation between Charmed MySQL and the TLS provider.
 
     > Integration provider                   Requirer                      Interface         Type     Message
     > mysql-k8s:database-peers               mysql-k8s:database-peers      mysql_peers       peer
-    > mysql-k8s:restart                      mysql-k8s:restart             rolling_op        peer
+    > mysql-k8s:rolling-ops                  mysql-k8s:rolling-ops         rolling_op        peer
     > self-signed-certificates:certificates  mysql-k8s:client-certificates tls-certificates  regular
+    > self-signed-certificates:certificates  mysql-k8s:peer-certificates   tls-certificates  regular
 ```
 ````
 

--- a/docs/how-to/tls/index.md
+++ b/docs/how-to/tls/index.md
@@ -16,4 +16,5 @@ preventing unauthorized access and ensuring confidentiality.
 
 Enable TLS <enable-tls>
 Disable TLS <disable-tls>
+Manage private keys <manage-private-keys>
 ```

--- a/docs/how-to/tls/manage-private-keys.md
+++ b/docs/how-to/tls/manage-private-keys.md
@@ -1,0 +1,59 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to manage TLS private keys for Charmed MySQL using the self-signed-certificates operator."
+---
+
+# How to manage private keys
+
+You can manage private keys used by the charm to generate the certificate signing requests (CSR) by storing the private key in a [juju secret](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/secret/) and then referencing the secret in the [charm configuration](https://canonical-juju.readthedocs-hosted.com/en/latest/user/howto/manage-applications/#configure-an-application). The keys need to be PEM formatted, base64 encoded and at least 2048 bits long.
+
+## Store the private key in a Juju secret
+
+To store the private key in a juju secret, run the following command:
+
+```shell
+juju add-secret tls-client-private-key private-key=$(base64 -w0 private-key.key)
+juju add-secret tls-peer-private-key private-key=$(base64 -w0 private-key.key)
+```
+
+## Reference the secret in the charm configuration
+
+You can use the secret ID from the output to reference the secret in the charm configuration.
+Now that the secret is stored, you can grant the secret to the application using the following commands:
+
+````{tab-set}
+```{tab-item} VM
+:sync: vm
+
+    juju grant-secret tls-client-private-key mysql
+    juju config mysql tls-client-private-key=<SECRET_ID>
+```
+
+```{tab-item} K8s
+:sync: k8s
+
+    juju grant-secret tls-client-private-key mysql-k8s
+    juju config mysql-k8s tls-client-private-key=<SECRET_ID>
+```
+````
+
+Setting the private key for the peer-to-peer communication is similar to the client-to-server communication:
+
+````{tab-set}
+```{tab-item} VM
+:sync: vm
+
+    juju grant-secret tls-peer-private-key mysql
+    juju config mysql tls-peer-private-key=<SECRET_ID>
+```
+
+```{tab-item} K8s
+:sync: k8s
+
+    juju grant-secret tls-peer-private-key mysql-k8s
+    juju config mysql-k8s tls-peer-private-key=<SECRET_ID>
+```
+````
+
+Once the configuration is set, the charm will use the private key stored in the secret to generate new certificate signing requests (CSR) to acquire new certificates from the TLS provider.

--- a/kubernetes/config.yaml
+++ b/kubernetes/config.yaml
@@ -57,6 +57,16 @@ options:
       Allowed values: "all", "first", "none"
     type: string
     default: first
+  tls-client-private-key:
+    type: secret
+    description: |
+      A Juju secret URI of a secret containing the private key for client-to-server TLS certificates.
+      The private key must be PEM formatted, base64 encoded and at least 2048 bits long.
+  tls-peer-private-key:
+    type: secret
+    description: |
+      A Juju secret URI of a secret containing the private key for peer-to-peer TLS certificates.
+      The private key must be PEM formatted, base64 encoded and at least 2048 bits long.
   # Experimental features
   experimental-max-connections:
     type: int

--- a/kubernetes/poetry.lock
+++ b/kubernetes/poetry.lock
@@ -87,7 +87,7 @@ version = "23.2.0"
 description = "Classes Without Boilerplate"
 optional = false
 python-versions = ">=3.7"
-groups = ["charm-libs", "integration"]
+groups = ["integration"]
 files = [
     {file = "attrs-23.2.0-py3-none-any.whl", hash = "sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1"},
     {file = "attrs-23.2.0.tar.gz", hash = "sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30"},
@@ -212,7 +212,7 @@ version = "2.0.0"
 description = "Foreign Function Interface for Python calling C code."
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "charm-libs", "integration"]
+groups = ["main", "integration"]
 files = [
     {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
     {file = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"},
@@ -299,7 +299,7 @@ files = [
     {file = "cffi-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9"},
     {file = "cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529"},
 ]
-markers = {main = "platform_python_implementation != \"PyPy\"", charm-libs = "platform_python_implementation != \"PyPy\""}
+markers = {main = "platform_python_implementation != \"PyPy\""}
 
 [package.dependencies]
 pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
@@ -403,14 +403,14 @@ ops = ">=2.19,<4"
 
 [[package]]
 name = "charmlibs-rollingops"
-version = "1.0.0"
+version = "1.1.0"
 description = "The charmlibs.rollingops package."
 optional = false
 python-versions = ">=3.12"
 groups = ["main"]
 files = [
-    {file = "charmlibs_rollingops-1.0.0-py3-none-any.whl", hash = "sha256:39bcbc0d0705eb1d940296a5cede848d069fd4f20aa77b682d0876271cbe1a2e"},
-    {file = "charmlibs_rollingops-1.0.0.tar.gz", hash = "sha256:a88654f5d048e90a1acc394885e911611d997582d5029ab3506097a820edd5ba"},
+    {file = "charmlibs_rollingops-1.1.0-py3-none-any.whl", hash = "sha256:543e436fa6ebcefc290d1832182f19a5873910b3e48edc8fb028d0eadc83e493"},
+    {file = "charmlibs_rollingops-1.1.0.tar.gz", hash = "sha256:7ff6420943fdf6a953e60ff2a78e641741aba8f6f77efe0121457a37036f1bee"},
 ]
 
 [package.dependencies]
@@ -644,7 +644,7 @@ version = "47.0.0"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = "!=3.9.0,!=3.9.1,>=3.8"
-groups = ["main", "charm-libs", "integration"]
+groups = ["main", "integration"]
 files = [
     {file = "cryptography-47.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:160ad728f128972d362e714054f6ba0067cab7fb350c5202a9ae8ae4ce3ef1a0"},
     {file = "cryptography-47.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b9a8943e359b7615db1a3ba587994618e094ff3d6fa5a390c73d079ce18b3973"},
@@ -949,43 +949,6 @@ files = [
     {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
     {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
 ]
-
-[[package]]
-name = "jsonschema"
-version = "4.22.0"
-description = "An implementation of JSON Schema validation for Python"
-optional = false
-python-versions = ">=3.8"
-groups = ["charm-libs"]
-files = [
-    {file = "jsonschema-4.22.0-py3-none-any.whl", hash = "sha256:ff4cfd6b1367a40e7bc6411caec72effadd3db0bbe5017de188f2d6108335802"},
-    {file = "jsonschema-4.22.0.tar.gz", hash = "sha256:5b22d434a45935119af990552c862e5d6d564e8f6601206b305a61fdf661a2b7"},
-]
-
-[package.dependencies]
-attrs = ">=22.2.0"
-jsonschema-specifications = ">=2023.03.6"
-referencing = ">=0.28.4"
-rpds-py = ">=0.7.1"
-
-[package.extras]
-format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3987", "uri-template", "webcolors (>=1.11)"]
-format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "uri-template", "webcolors (>=1.11)"]
-
-[[package]]
-name = "jsonschema-specifications"
-version = "2023.12.1"
-description = "The JSON Schema meta-schemas and vocabularies, exposed as a Registry"
-optional = false
-python-versions = ">=3.8"
-groups = ["charm-libs"]
-files = [
-    {file = "jsonschema_specifications-2023.12.1-py3-none-any.whl", hash = "sha256:87e4fdf3a94858b8a2ba2778d9ba57d8a9cafca7c7489c46ba0d30a8bc6a9c3c"},
-    {file = "jsonschema_specifications-2023.12.1.tar.gz", hash = "sha256:48a76787b3e70f5ed53f1160d2b81f586e4ca6d1548c5de7085d1682674764cc"},
-]
-
-[package.dependencies]
-referencing = ">=0.31.0"
 
 [[package]]
 name = "jubilant"
@@ -1505,12 +1468,12 @@ version = "2.22"
 description = "C parser in Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "charm-libs", "integration"]
+groups = ["main", "integration"]
 files = [
     {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
     {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
 ]
-markers = {main = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\"", charm-libs = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\"", integration = "implementation_name != \"PyPy\""}
+markers = {main = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\"", integration = "implementation_name != \"PyPy\""}
 
 [[package]]
 name = "pydantic"
@@ -1871,22 +1834,6 @@ files = [
 ]
 
 [[package]]
-name = "referencing"
-version = "0.35.1"
-description = "JSON Referencing + Python"
-optional = false
-python-versions = ">=3.8"
-groups = ["charm-libs"]
-files = [
-    {file = "referencing-0.35.1-py3-none-any.whl", hash = "sha256:eda6d3234d62814d1c64e305c1331c9a3a6132da475ab6382eaa997b21ee75de"},
-    {file = "referencing-0.35.1.tar.gz", hash = "sha256:25b42124a6c8b632a425174f24087783efb348a6f1e0008e63cd4466fedf703c"},
-]
-
-[package.dependencies]
-attrs = ">=22.2.0"
-rpds-py = ">=0.7.0"
-
-[[package]]
 name = "requests"
 version = "2.32.3"
 description = "Python HTTP for Humans."
@@ -1926,119 +1873,6 @@ requests = ">=2.0.0"
 
 [package.extras]
 rsa = ["oauthlib[signedtoken] (>=3.0.0)"]
-
-[[package]]
-name = "rpds-py"
-version = "0.20.1"
-description = "Python bindings to Rust's persistent data structures (rpds)"
-optional = false
-python-versions = ">=3.8"
-groups = ["charm-libs"]
-files = [
-    {file = "rpds_py-0.20.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a649dfd735fff086e8a9d0503a9f0c7d01b7912a333c7ae77e1515c08c146dad"},
-    {file = "rpds_py-0.20.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f16bc1334853e91ddaaa1217045dd7be166170beec337576818461268a3de67f"},
-    {file = "rpds_py-0.20.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14511a539afee6f9ab492b543060c7491c99924314977a55c98bfa2ee29ce78c"},
-    {file = "rpds_py-0.20.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3ccb8ac2d3c71cda472b75af42818981bdacf48d2e21c36331b50b4f16930163"},
-    {file = "rpds_py-0.20.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c142b88039b92e7e0cb2552e8967077e3179b22359e945574f5e2764c3953dcf"},
-    {file = "rpds_py-0.20.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f19169781dddae7478a32301b499b2858bc52fc45a112955e798ee307e294977"},
-    {file = "rpds_py-0.20.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13c56de6518e14b9bf6edde23c4c39dac5b48dcf04160ea7bce8fca8397cdf86"},
-    {file = "rpds_py-0.20.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:925d176a549f4832c6f69fa6026071294ab5910e82a0fe6c6228fce17b0706bd"},
-    {file = "rpds_py-0.20.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:78f0b6877bfce7a3d1ff150391354a410c55d3cdce386f862926a4958ad5ab7e"},
-    {file = "rpds_py-0.20.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:3dd645e2b0dcb0fd05bf58e2e54c13875847687d0b71941ad2e757e5d89d4356"},
-    {file = "rpds_py-0.20.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:4f676e21db2f8c72ff0936f895271e7a700aa1f8d31b40e4e43442ba94973899"},
-    {file = "rpds_py-0.20.1-cp310-none-win32.whl", hash = "sha256:648386ddd1e19b4a6abab69139b002bc49ebf065b596119f8f37c38e9ecee8ff"},
-    {file = "rpds_py-0.20.1-cp310-none-win_amd64.whl", hash = "sha256:d9ecb51120de61e4604650666d1f2b68444d46ae18fd492245a08f53ad2b7711"},
-    {file = "rpds_py-0.20.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:762703bdd2b30983c1d9e62b4c88664df4a8a4d5ec0e9253b0231171f18f6d75"},
-    {file = "rpds_py-0.20.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0b581f47257a9fce535c4567782a8976002d6b8afa2c39ff616edf87cbeff712"},
-    {file = "rpds_py-0.20.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:842c19a6ce894493563c3bd00d81d5100e8e57d70209e84d5491940fdb8b9e3a"},
-    {file = "rpds_py-0.20.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:42cbde7789f5c0bcd6816cb29808e36c01b960fb5d29f11e052215aa85497c93"},
-    {file = "rpds_py-0.20.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6c8e9340ce5a52f95fa7d3b552b35c7e8f3874d74a03a8a69279fd5fca5dc751"},
-    {file = "rpds_py-0.20.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8ba6f89cac95c0900d932c9efb7f0fb6ca47f6687feec41abcb1bd5e2bd45535"},
-    {file = "rpds_py-0.20.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a916087371afd9648e1962e67403c53f9c49ca47b9680adbeef79da3a7811b0"},
-    {file = "rpds_py-0.20.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:200a23239781f46149e6a415f1e870c5ef1e712939fe8fa63035cd053ac2638e"},
-    {file = "rpds_py-0.20.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:58b1d5dd591973d426cbb2da5e27ba0339209832b2f3315928c9790e13f159e8"},
-    {file = "rpds_py-0.20.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:6b73c67850ca7cae0f6c56f71e356d7e9fa25958d3e18a64927c2d930859b8e4"},
-    {file = "rpds_py-0.20.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d8761c3c891cc51e90bc9926d6d2f59b27beaf86c74622c8979380a29cc23ac3"},
-    {file = "rpds_py-0.20.1-cp311-none-win32.whl", hash = "sha256:cd945871335a639275eee904caef90041568ce3b42f402c6959b460d25ae8732"},
-    {file = "rpds_py-0.20.1-cp311-none-win_amd64.whl", hash = "sha256:7e21b7031e17c6b0e445f42ccc77f79a97e2687023c5746bfb7a9e45e0921b84"},
-    {file = "rpds_py-0.20.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:36785be22066966a27348444b40389f8444671630063edfb1a2eb04318721e17"},
-    {file = "rpds_py-0.20.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:142c0a5124d9bd0e2976089484af5c74f47bd3298f2ed651ef54ea728d2ea42c"},
-    {file = "rpds_py-0.20.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dbddc10776ca7ebf2a299c41a4dde8ea0d8e3547bfd731cb87af2e8f5bf8962d"},
-    {file = "rpds_py-0.20.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:15a842bb369e00295392e7ce192de9dcbf136954614124a667f9f9f17d6a216f"},
-    {file = "rpds_py-0.20.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be5ef2f1fc586a7372bfc355986226484e06d1dc4f9402539872c8bb99e34b01"},
-    {file = "rpds_py-0.20.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbcf360c9e3399b056a238523146ea77eeb2a596ce263b8814c900263e46031a"},
-    {file = "rpds_py-0.20.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecd27a66740ffd621d20b9a2f2b5ee4129a56e27bfb9458a3bcc2e45794c96cb"},
-    {file = "rpds_py-0.20.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0b937b2a1988f184a3e9e577adaa8aede21ec0b38320d6009e02bd026db04fa"},
-    {file = "rpds_py-0.20.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6889469bfdc1eddf489729b471303739bf04555bb151fe8875931f8564309afc"},
-    {file = "rpds_py-0.20.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:19b73643c802f4eaf13d97f7855d0fb527fbc92ab7013c4ad0e13a6ae0ed23bd"},
-    {file = "rpds_py-0.20.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3c6afcf2338e7f374e8edc765c79fbcb4061d02b15dd5f8f314a4af2bdc7feb5"},
-    {file = "rpds_py-0.20.1-cp312-none-win32.whl", hash = "sha256:dc73505153798c6f74854aba69cc75953888cf9866465196889c7cdd351e720c"},
-    {file = "rpds_py-0.20.1-cp312-none-win_amd64.whl", hash = "sha256:8bbe951244a838a51289ee53a6bae3a07f26d4e179b96fc7ddd3301caf0518eb"},
-    {file = "rpds_py-0.20.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:6ca91093a4a8da4afae7fe6a222c3b53ee4eef433ebfee4d54978a103435159e"},
-    {file = "rpds_py-0.20.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b9c2fe36d1f758b28121bef29ed1dee9b7a2453e997528e7d1ac99b94892527c"},
-    {file = "rpds_py-0.20.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f009c69bc8c53db5dfab72ac760895dc1f2bc1b62ab7408b253c8d1ec52459fc"},
-    {file = "rpds_py-0.20.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6740a3e8d43a32629bb9b009017ea5b9e713b7210ba48ac8d4cb6d99d86c8ee8"},
-    {file = "rpds_py-0.20.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:32b922e13d4c0080d03e7b62991ad7f5007d9cd74e239c4b16bc85ae8b70252d"},
-    {file = "rpds_py-0.20.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fe00a9057d100e69b4ae4a094203a708d65b0f345ed546fdef86498bf5390982"},
-    {file = "rpds_py-0.20.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49fe9b04b6fa685bd39237d45fad89ba19e9163a1ccaa16611a812e682913496"},
-    {file = "rpds_py-0.20.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:aa7ac11e294304e615b43f8c441fee5d40094275ed7311f3420d805fde9b07b4"},
-    {file = "rpds_py-0.20.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6aa97af1558a9bef4025f8f5d8c60d712e0a3b13a2fe875511defc6ee77a1ab7"},
-    {file = "rpds_py-0.20.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:483b29f6f7ffa6af845107d4efe2e3fa8fb2693de8657bc1849f674296ff6a5a"},
-    {file = "rpds_py-0.20.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:37fe0f12aebb6a0e3e17bb4cd356b1286d2d18d2e93b2d39fe647138458b4bcb"},
-    {file = "rpds_py-0.20.1-cp313-none-win32.whl", hash = "sha256:a624cc00ef2158e04188df5e3016385b9353638139a06fb77057b3498f794782"},
-    {file = "rpds_py-0.20.1-cp313-none-win_amd64.whl", hash = "sha256:b71b8666eeea69d6363248822078c075bac6ed135faa9216aa85f295ff009b1e"},
-    {file = "rpds_py-0.20.1-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:5b48e790e0355865197ad0aca8cde3d8ede347831e1959e158369eb3493d2191"},
-    {file = "rpds_py-0.20.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:3e310838a5801795207c66c73ea903deda321e6146d6f282e85fa7e3e4854804"},
-    {file = "rpds_py-0.20.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249280b870e6a42c0d972339e9cc22ee98730a99cd7f2f727549af80dd5a963"},
-    {file = "rpds_py-0.20.1-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e79059d67bea28b53d255c1437b25391653263f0e69cd7dec170d778fdbca95e"},
-    {file = "rpds_py-0.20.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2b431c777c9653e569986ecf69ff4a5dba281cded16043d348bf9ba505486f36"},
-    {file = "rpds_py-0.20.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:da584ff96ec95e97925174eb8237e32f626e7a1a97888cdd27ee2f1f24dd0ad8"},
-    {file = "rpds_py-0.20.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:02a0629ec053fc013808a85178524e3cb63a61dbc35b22499870194a63578fb9"},
-    {file = "rpds_py-0.20.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fbf15aff64a163db29a91ed0868af181d6f68ec1a3a7d5afcfe4501252840bad"},
-    {file = "rpds_py-0.20.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:07924c1b938798797d60c6308fa8ad3b3f0201802f82e4a2c41bb3fafb44cc28"},
-    {file = "rpds_py-0.20.1-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:4a5a844f68776a7715ecb30843b453f07ac89bad393431efbf7accca3ef599c1"},
-    {file = "rpds_py-0.20.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:518d2ca43c358929bf08f9079b617f1c2ca6e8848f83c1225c88caeac46e6cbc"},
-    {file = "rpds_py-0.20.1-cp38-none-win32.whl", hash = "sha256:3aea7eed3e55119635a74bbeb80b35e776bafccb70d97e8ff838816c124539f1"},
-    {file = "rpds_py-0.20.1-cp38-none-win_amd64.whl", hash = "sha256:7dca7081e9a0c3b6490a145593f6fe3173a94197f2cb9891183ef75e9d64c425"},
-    {file = "rpds_py-0.20.1-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:b41b6321805c472f66990c2849e152aff7bc359eb92f781e3f606609eac877ad"},
-    {file = "rpds_py-0.20.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:0a90c373ea2975519b58dece25853dbcb9779b05cc46b4819cb1917e3b3215b6"},
-    {file = "rpds_py-0.20.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:16d4477bcb9fbbd7b5b0e4a5d9b493e42026c0bf1f06f723a9353f5153e75d30"},
-    {file = "rpds_py-0.20.1-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:84b8382a90539910b53a6307f7c35697bc7e6ffb25d9c1d4e998a13e842a5e83"},
-    {file = "rpds_py-0.20.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4888e117dd41b9d34194d9e31631af70d3d526efc363085e3089ab1a62c32ed1"},
-    {file = "rpds_py-0.20.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5265505b3d61a0f56618c9b941dc54dc334dc6e660f1592d112cd103d914a6db"},
-    {file = "rpds_py-0.20.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e75ba609dba23f2c95b776efb9dd3f0b78a76a151e96f96cc5b6b1b0004de66f"},
-    {file = "rpds_py-0.20.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1791ff70bc975b098fe6ecf04356a10e9e2bd7dc21fa7351c1742fdeb9b4966f"},
-    {file = "rpds_py-0.20.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:d126b52e4a473d40232ec2052a8b232270ed1f8c9571aaf33f73a14cc298c24f"},
-    {file = "rpds_py-0.20.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:c14937af98c4cc362a1d4374806204dd51b1e12dded1ae30645c298e5a5c4cb1"},
-    {file = "rpds_py-0.20.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:3d089d0b88996df627693639d123c8158cff41c0651f646cd8fd292c7da90eaf"},
-    {file = "rpds_py-0.20.1-cp39-none-win32.whl", hash = "sha256:653647b8838cf83b2e7e6a0364f49af96deec64d2a6578324db58380cff82aca"},
-    {file = "rpds_py-0.20.1-cp39-none-win_amd64.whl", hash = "sha256:fa41a64ac5b08b292906e248549ab48b69c5428f3987b09689ab2441f267d04d"},
-    {file = "rpds_py-0.20.1-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:7a07ced2b22f0cf0b55a6a510078174c31b6d8544f3bc00c2bcee52b3d613f74"},
-    {file = "rpds_py-0.20.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:68cb0a499f2c4a088fd2f521453e22ed3527154136a855c62e148b7883b99f9a"},
-    {file = "rpds_py-0.20.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fa3060d885657abc549b2a0f8e1b79699290e5d83845141717c6c90c2df38311"},
-    {file = "rpds_py-0.20.1-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:95f3b65d2392e1c5cec27cff08fdc0080270d5a1a4b2ea1d51d5f4a2620ff08d"},
-    {file = "rpds_py-0.20.1-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2cc3712a4b0b76a1d45a9302dd2f53ff339614b1c29603a911318f2357b04dd2"},
-    {file = "rpds_py-0.20.1-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5d4eea0761e37485c9b81400437adb11c40e13ef513375bbd6973e34100aeb06"},
-    {file = "rpds_py-0.20.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f5179583d7a6cdb981151dd349786cbc318bab54963a192692d945dd3f6435d"},
-    {file = "rpds_py-0.20.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2fbb0ffc754490aff6dabbf28064be47f0f9ca0b9755976f945214965b3ace7e"},
-    {file = "rpds_py-0.20.1-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:a94e52537a0e0a85429eda9e49f272ada715506d3b2431f64b8a3e34eb5f3e75"},
-    {file = "rpds_py-0.20.1-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:92b68b79c0da2a980b1c4197e56ac3dd0c8a149b4603747c4378914a68706979"},
-    {file = "rpds_py-0.20.1-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:93da1d3db08a827eda74356f9f58884adb254e59b6664f64cc04cdff2cc19b0d"},
-    {file = "rpds_py-0.20.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:754bbed1a4ca48479e9d4182a561d001bbf81543876cdded6f695ec3d465846b"},
-    {file = "rpds_py-0.20.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:ca449520e7484534a2a44faf629362cae62b660601432d04c482283c47eaebab"},
-    {file = "rpds_py-0.20.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:9c4cb04a16b0f199a8c9bf807269b2f63b7b5b11425e4a6bd44bd6961d28282c"},
-    {file = "rpds_py-0.20.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb63804105143c7e24cee7db89e37cb3f3941f8e80c4379a0b355c52a52b6780"},
-    {file = "rpds_py-0.20.1-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:55cd1fa4ecfa6d9f14fbd97ac24803e6f73e897c738f771a9fe038f2f11ff07c"},
-    {file = "rpds_py-0.20.1-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0f8f741b6292c86059ed175d80eefa80997125b7c478fb8769fd9ac8943a16c0"},
-    {file = "rpds_py-0.20.1-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0fc212779bf8411667234b3cdd34d53de6c2b8b8b958e1e12cb473a5f367c338"},
-    {file = "rpds_py-0.20.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0ad56edabcdb428c2e33bbf24f255fe2b43253b7d13a2cdbf05de955217313e6"},
-    {file = "rpds_py-0.20.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0a3a1e9ee9728b2c1734f65d6a1d376c6f2f6fdcc13bb007a08cc4b1ff576dc5"},
-    {file = "rpds_py-0.20.1-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:e13de156137b7095442b288e72f33503a469aa1980ed856b43c353ac86390519"},
-    {file = "rpds_py-0.20.1-pp39-pypy39_pp73-musllinux_1_2_i686.whl", hash = "sha256:07f59760ef99f31422c49038964b31c4dfcfeb5d2384ebfc71058a7c9adae2d2"},
-    {file = "rpds_py-0.20.1-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:59240685e7da61fb78f65a9f07f8108e36a83317c53f7b276b4175dc44151684"},
-    {file = "rpds_py-0.20.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:83cba698cfb3c2c5a7c3c6bac12fe6c6a51aae69513726be6411076185a8b24a"},
-    {file = "rpds_py-0.20.1.tar.gz", hash = "sha256:e1791c4aabd117653530dccd24108fa03cc6baf21f58b950d0a73c3b3b29a350"},
-]
 
 [[package]]
 name = "rsa"

--- a/kubernetes/pyproject.toml
+++ b/kubernetes/pyproject.toml
@@ -6,7 +6,7 @@ main = [
     "boto3~=1.28",
     "charm-refresh~=3.1.1",
     "charmlibs-interfaces-tls-certificates~=1.0",
-    "charmlibs-rollingops~=1.0",
+    "charmlibs-rollingops~=1.1",
     "jinja2~=3.1",
     "lightkube~=0.19.0",
     "object-storage-charmlib~=1.0.0",
@@ -22,10 +22,6 @@ charm-libs = [
     # mysql/v0/*.py"
     "charm-refresh~=3.1.1",
     "mysql_shell_client[contrib]~=1.0",
-    # tls_certificates_interface/v1/tls_certificates.py
-    # tls_certificates lib uses a feature only available in cryptography >=42.0.5
-    "cryptography>=42.0.5",
-    "jsonschema",
     # loki_k8s/v0/loki_push_api.py and prometheus_k8s/v0/prometheus_scrape.py
     "cosl>=0.0.50",
 ]
@@ -56,6 +52,7 @@ integration = [
     "kubernetes~=27.2.0",
     "allure-pytest~=2.13",
     "allure-pytest-default-results~=0.1.2",
+    "cryptography~=47.0",
     "jubilant~=1.4.0",
     "tomli~=2.3",
     "tomli-w~=1.2",

--- a/kubernetes/src/charm.py
+++ b/kubernetes/src/charm.py
@@ -10,7 +10,6 @@ from ops.main import main
 if is_wrong_architecture() and __name__ == "__main__":
     main(WrongArchitectureWarningCharm)
 
-import json
 import logging
 import random
 from time import sleep
@@ -565,8 +564,10 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             logger.info("Skipping group replication restart")
             return OperationResult.RETRY_RELEASE
 
-        ongoing_ops = [relation.data[unit].get("operations", "[]") for unit in self.peers.units]
-        ongoing_ops = [json.loads(op) for op in ongoing_ops]
+        ongoing_ops = [
+            self.rolling_ops.is_waiting_callback("replication", unit.name)
+            for unit in self.peers.units
+        ]
 
         if self.is_unit_primary and any(ongoing_ops):
             logger.info("Skipping group replication restart")
@@ -665,7 +666,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         self.unit_peer_data.setdefault("member-role", "UNKNOWN")
         self.unit_peer_data.setdefault("member-state", "waiting")
 
-    def _on_config_changed(self, _: EventBase) -> None:
+    def _on_config_changed(self, _: EventBase) -> None:  # noqa: C901
         """Handle the config changed event."""
         container = self.unit.get_container(CONTAINER_NAME)
         if not container.can_connect():
@@ -693,6 +694,12 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
 
         # Override log rotation
         self.log_rotate_setup.setup()
+
+        # Rotate TLS keys
+        if self.config.tls_client_private_key:
+            self.tls.client_certificates_refresh_event.emit()
+        if self.config.tls_peer_private_key:
+            self.tls.peer_certificates_refresh_event.emit()
 
         if (
             self.mysql_config.keys_requires_restart(changed_config)

--- a/kubernetes/src/charm.py
+++ b/kubernetes/src/charm.py
@@ -660,13 +660,31 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         self.current_event = event
         self._reconcile_pebble_layer(container)
 
+    def _rotate_private_keys(self) -> None:
+        """Rotates either of the TLS private keys if the config values are new."""
+        new_client_private_key = self.config.tls_client_private_key
+        old_client_private_key = self.app_peer_data.get("client-private-key", None)
+
+        if new_client_private_key != old_client_private_key:
+            self.tls.client_certificates_refresh_event.emit()
+            if self.unit.is_leader():
+                self.app_peer_data["client-private-key"] = new_client_private_key
+
+        new_peer_private_key = self.config.tls_peer_private_key
+        old_peer_private_key = self.app_peer_data.get("peer-private-key", None)
+
+        if new_peer_private_key != old_peer_private_key:
+            self.tls.peer_certificates_refresh_event.emit()
+            if self.unit.is_leader():
+                self.app_peer_data["peer-private-key"] = new_peer_private_key
+
     def _on_peer_relation_joined(self, _) -> None:
         """Handle the peer relation joined event."""
         # set some initial unit data
         self.unit_peer_data.setdefault("member-role", "UNKNOWN")
         self.unit_peer_data.setdefault("member-state", "waiting")
 
-    def _on_config_changed(self, _: EventBase) -> None:  # noqa: C901
+    def _on_config_changed(self, _: EventBase) -> None:
         """Handle the config changed event."""
         container = self.unit.get_container(CONTAINER_NAME)
         if not container.can_connect():
@@ -696,10 +714,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         self.log_rotate_setup.setup()
 
         # Rotate TLS keys
-        if self.config.tls_client_private_key:
-            self.tls.client_certificates_refresh_event.emit()
-        if self.config.tls_peer_private_key:
-            self.tls.peer_certificates_refresh_event.emit()
+        self._rotate_private_keys()
 
         if (
             self.mysql_config.keys_requires_restart(changed_config)

--- a/kubernetes/src/config.py
+++ b/kubernetes/src/config.py
@@ -61,6 +61,8 @@ class CharmConfig(BaseConfigModel):
     logs_audit_policy: str
     logs_retention_period: str
     pause_after_unit_refresh: str
+    tls_client_private_key: str | None = Field(default=None)
+    tls_peer_private_key: str | None = Field(default=None)
 
     @field_validator("profile")
     @classmethod

--- a/kubernetes/src/relations/tls.py
+++ b/kubernetes/src/relations/tls.py
@@ -4,6 +4,7 @@
 """TLS Handler."""
 
 import base64
+import binascii
 import logging
 import re
 import socket
@@ -208,7 +209,7 @@ class TLS(Object):
 
         try:
             private_key = base64.b64decode(private_key).decode("utf-8").strip()
-        except UnicodeDecodeError as e:
+        except (UnicodeDecodeError, binascii.Error) as e:
             logger.error(e)
             return None
 
@@ -305,6 +306,9 @@ class TLS(Object):
             self.charm.unit.status = BlockedStatus("Failed to disable client TLS.")
             return
 
+        if self.charm.unit.is_leader():
+            del self.charm.app_peer_data["client-private-key"]
+
         self.charm.unit.status = self.charm.build_unit_workload_status()
 
     def _on_peer_relation_broken(self, _: EventBase) -> None:
@@ -322,6 +326,9 @@ class TLS(Object):
             logger.error(f"Failed to disable peer TLS: {e}")
             self.charm.unit.status = BlockedStatus("Failed to disable peer TLS.")
             return
+
+        if self.charm.unit.is_leader():
+            del self.charm.app_peer_data["peer-private-key"]
 
     def _push_tls_files_to_workload(self) -> None:
         """Push TLS files to unit."""

--- a/kubernetes/src/relations/tls.py
+++ b/kubernetes/src/relations/tls.py
@@ -3,12 +3,15 @@
 
 """TLS Handler."""
 
+import base64
 import logging
+import re
 import socket
 from typing import TYPE_CHECKING
 
 from charmlibs.interfaces.tls_certificates import (
     CertificateRequestAttributes,
+    PrivateKey,
     TLSCertificatesRequiresV4,
 )
 from charms.mysql.v0.async_replication import (
@@ -18,7 +21,7 @@ from charms.mysql.v0.async_replication import (
 from charms.mysql.v0.mysql import MySQLTLSSetupError
 from mysql_shell.models import InstanceState
 from ops.framework import EventBase, EventSource, Object
-from ops.model import BlockedStatus, MaintenanceStatus
+from ops.model import BlockedStatus, MaintenanceStatus, SecretNotFoundError
 from ops.pebble import ConnectionError as PebbleConnectionError
 from ops.pebble import PathError, ProtocolError
 
@@ -46,7 +49,8 @@ class RefreshTLSCertificatesEvent(EventBase):
 class TLS(Object):
     """In this class we manage certificates relation."""
 
-    refresh_tls_certificates_event = EventSource(RefreshTLSCertificatesEvent)
+    client_certificates_refresh_event = EventSource(RefreshTLSCertificatesEvent)
+    peer_certificates_refresh_event = EventSource(RefreshTLSCertificatesEvent)
 
     def __init__(self, charm: "MySQLOperatorCharm"):
         super().__init__(charm, "certificates")
@@ -73,7 +77,8 @@ class TLS(Object):
                     },
                 ),
             ],
-            refresh_events=[self.refresh_tls_certificates_event],
+            private_key=self._parse_client_private_key(),
+            refresh_events=[self.client_certificates_refresh_event],
         )
         self.peer_certificate = TLSCertificatesRequiresV4(
             self.charm,
@@ -87,7 +92,8 @@ class TLS(Object):
                     },
                 ),
             ],
-            refresh_events=[self.refresh_tls_certificates_event],
+            private_key=self._parse_peer_private_key(),
+            refresh_events=[self.peer_certificates_refresh_event],
         )
 
         self.framework.observe(
@@ -179,6 +185,47 @@ class TLS(Object):
             ca_file = str(certs[0].ca)
 
         return key_file, ca_file, cert_file
+
+    def _parse_private_key(self, secret_id: str | None) -> PrivateKey | None:
+        """Parse the received private key."""
+        if not secret_id:
+            return None
+
+        try:
+            secret_content = self.charm.model.get_secret(id=secret_id).get_content(refresh=True)
+        except SecretNotFoundError as e:
+            logger.error(e)
+            return None
+
+        private_key = secret_content.get("private-key")
+        if private_key is None:
+            logger.error(f"Secret {secret_id} does not contain a private key.")
+            return None
+
+        if re.match(r"(-+(BEGIN|END) [A-Z ]+-+)", private_key):
+            logger.error(f"Secret {secret_id} must be base64 encoded.")
+            return None
+
+        try:
+            private_key = base64.b64decode(private_key).decode("utf-8").strip()
+        except UnicodeDecodeError as e:
+            logger.error(e)
+            return None
+
+        private_key = PrivateKey(raw=private_key)
+        if not private_key.is_valid():
+            logger.error("Invalid private key format.")
+            return None
+
+        return private_key
+
+    def _parse_client_private_key(self) -> PrivateKey | None:
+        """Parse the client private key from the config."""
+        return self._parse_private_key(self.charm.config.tls_client_private_key)
+
+    def _parse_peer_private_key(self) -> PrivateKey | None:
+        """Parse the peer private key from the config."""
+        return self._parse_private_key(self.charm.config.tls_peer_private_key)
 
     def _on_client_certificate_available(self, event: EventBase) -> None:
         """Handler for the certificate available event."""

--- a/kubernetes/tests/integration/integration/test_tls_private_key.py
+++ b/kubernetes/tests/integration/integration/test_tls_private_key.py
@@ -111,8 +111,8 @@ def test_set_private_key(juju: Juju) -> None:
         "password": credentials["password"],
     }
 
-    current_client_certs = get_unit_certificates_cert(juju, leader_unit, TLS_CLIENT_RELATION)
-    current_peer_certs = get_unit_certificates_cert(juju, leader_unit, TLS_PEER_RELATION)
+    first_client_certs = get_unit_certificates_cert(juju, leader_unit, TLS_CLIENT_RELATION)
+    first_peer_certs = get_unit_certificates_cert(juju, leader_unit, TLS_PEER_RELATION)
 
     logger.info("Generating new private key")
     private_key = create_private_key()
@@ -127,10 +127,10 @@ def test_set_private_key(juju: Juju) -> None:
         timeout=TIMEOUT,
     )
 
-    new_client_certs = get_unit_certificates_cert(juju, leader_unit, TLS_CLIENT_RELATION)
-    new_peer_certs = get_unit_certificates_cert(juju, leader_unit, TLS_PEER_RELATION)
-    assert current_client_certs != new_client_certs
-    assert current_peer_certs == new_peer_certs
+    second_client_certs = get_unit_certificates_cert(juju, leader_unit, TLS_CLIENT_RELATION)
+    second_peer_certs = get_unit_certificates_cert(juju, leader_unit, TLS_PEER_RELATION)
+    assert first_client_certs != second_client_certs
+    assert first_peer_certs == second_peer_certs
 
     logger.info("Configuring the application with the new peer private key")
     juju.config(app=APP_NAME, values={"tls-peer-private-key": secret_uri})
@@ -139,10 +139,10 @@ def test_set_private_key(juju: Juju) -> None:
         timeout=TIMEOUT,
     )
 
-    new_client_certs = get_unit_certificates_cert(juju, leader_unit, TLS_CLIENT_RELATION)
-    new_peer_certs = get_unit_certificates_cert(juju, leader_unit, TLS_PEER_RELATION)
-    assert current_client_certs != new_client_certs
-    assert current_peer_certs != new_peer_certs
+    third_client_certs = get_unit_certificates_cert(juju, leader_unit, TLS_CLIENT_RELATION)
+    third_peer_certs = get_unit_certificates_cert(juju, leader_unit, TLS_PEER_RELATION)
+    assert second_client_certs == third_client_certs
+    assert second_peer_certs != third_peer_certs
 
     logger.info("Verifying cluster accessibility after client key rotation")
     for unit_name in get_app_units(juju, APP_NAME):

--- a/kubernetes/tests/integration/integration/test_tls_private_key.py
+++ b/kubernetes/tests/integration/integration/test_tls_private_key.py
@@ -150,6 +150,37 @@ def test_set_private_key(juju: Juju) -> None:
         assert is_connection_possible(config, **{"ssl_disabled": False})
 
 
+def test_disable_tls(juju: Juju) -> None:
+    """Verify TLS is disabled and the cluster is accessible."""
+    leader_unit = get_app_leader(juju, APP_NAME)
+    credentials = get_mysql_server_credentials(juju, leader_unit)
+
+    config = {
+        "username": credentials["username"],
+        "password": credentials["password"],
+    }
+
+    logger.info("Removing relation")
+    juju.remove_relation(f"{APP_NAME}:client-certificates", f"{TLS_APP_NAME}:certificates")
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, APP_NAME, TLS_APP_NAME),
+        timeout=TIMEOUT,
+        delay=5,
+    )
+
+    juju.remove_relation(f"{APP_NAME}:peer-certificates", f"{TLS_APP_NAME}:certificates")
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, APP_NAME, TLS_APP_NAME),
+        timeout=TIMEOUT,
+        delay=5,
+    )
+
+    for unit_name in get_app_units(juju, APP_NAME):
+        config["host"] = get_unit_address(juju, APP_NAME, unit_name)
+        assert is_connection_possible(config, **{"ssl_disabled": False})
+        assert is_connection_possible(config, **{"ssl_disabled": True})
+
+
 def create_private_key() -> str:
     """Generates a private key using the PEM format (valid for certificates)."""
     private_key = generate_private_key(

--- a/kubernetes/tests/integration/integration/test_tls_private_key.py
+++ b/kubernetes/tests/integration/integration/test_tls_private_key.py
@@ -1,0 +1,184 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import base64
+import json
+import logging
+
+import jubilant
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.rsa import generate_private_key
+from jubilant import Juju
+
+from constants import (
+    TLS_CLIENT_RELATION,
+    TLS_PEER_RELATION,
+)
+
+from ..helpers import is_connection_possible
+from ..helpers_ha import (
+    CHARM_METADATA,
+    MINUTE_SECS,
+    create_app_secret,
+    get_app_leader,
+    get_app_units,
+    get_mysql_server_credentials,
+    get_unit_address,
+    get_unit_relation_data,
+    wait_for_apps_status,
+)
+
+logger = logging.getLogger(__name__)
+
+APP_NAME = CHARM_METADATA["name"]
+TLS_APP_NAME = "self-signed-certificates"
+CLUSTER_NAME = "test_cluster"
+TIMEOUT = 15 * MINUTE_SECS
+
+
+def test_build_and_deploy(juju: Juju, charm) -> None:
+    """Build the charm and deploy with TLS enabled."""
+    juju.deploy(
+        charm,
+        APP_NAME,
+        resources={"mysql-image": CHARM_METADATA["resources"]["mysql-image"]["upstream-source"]},
+        base="ubuntu@24.04",
+        config={"cluster-name": CLUSTER_NAME, "profile": "testing"},
+        num_units=3,
+        trust=True,
+    )
+
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, APP_NAME),
+        timeout=TIMEOUT,
+    )
+
+
+def test_tls_enabled(juju: Juju) -> None:
+    """Verify TLS is enabled and the cluster is accessible."""
+    app_units = get_app_units(juju, APP_NAME)
+
+    logger.info("Deploy TLS operator")
+    juju.deploy(
+        TLS_APP_NAME,
+        channel="1/stable",
+        config={"ca-common-name": "Test CA"},
+        base="ubuntu@24.04",
+    )
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, TLS_APP_NAME),
+        timeout=TIMEOUT,
+    )
+
+    logger.info("Relate to TLS operator")
+    juju.integrate(f"{APP_NAME}:{TLS_CLIENT_RELATION}", f"{TLS_APP_NAME}:certificates")
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, APP_NAME, TLS_APP_NAME),
+        timeout=TIMEOUT,
+        delay=5,
+    )
+
+    juju.integrate(f"{APP_NAME}:{TLS_PEER_RELATION}", f"{TLS_APP_NAME}:certificates")
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, APP_NAME, TLS_APP_NAME),
+        timeout=TIMEOUT,
+        delay=5,
+    )
+
+    credentials = get_mysql_server_credentials(juju, app_units[0])
+    config = {
+        "username": credentials["username"],
+        "password": credentials["password"],
+    }
+
+    logger.info("Asserting connections after relation")
+    for unit_name in app_units:
+        config["host"] = get_unit_address(juju, APP_NAME, unit_name)
+        assert is_connection_possible(config, **{"ssl_disabled": False})
+
+    logger.info("Asserting TLS relation data exists")
+    assert get_unit_relation_data(juju, app_units[0], TLS_CLIENT_RELATION)
+    assert get_unit_relation_data(juju, app_units[0], TLS_PEER_RELATION)
+
+
+def test_set_private_key(juju: Juju) -> None:
+    """Set a new private key and verify the cluster remains accessible."""
+    leader_unit = get_app_leader(juju, APP_NAME)
+    credentials = get_mysql_server_credentials(juju, leader_unit)
+
+    config = {
+        "username": credentials["username"],
+        "password": credentials["password"],
+    }
+
+    current_client_certs = get_unit_certificates_cert(juju, leader_unit, TLS_CLIENT_RELATION)
+    current_peer_certs = get_unit_certificates_cert(juju, leader_unit, TLS_PEER_RELATION)
+
+    logger.info("Generating new private key")
+    private_key = create_private_key()
+
+    logger.info("Creating secret with the new private key")
+    secret_uri = create_app_secret(juju, APP_NAME, {"private-key": private_key})
+
+    logger.info("Configuring the application with the new client private key")
+    juju.config(app=APP_NAME, values={"tls-client-private-key": secret_uri})
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, APP_NAME, TLS_APP_NAME),
+        timeout=TIMEOUT,
+    )
+
+    new_client_certs = get_unit_certificates_cert(juju, leader_unit, TLS_CLIENT_RELATION)
+    new_peer_certs = get_unit_certificates_cert(juju, leader_unit, TLS_PEER_RELATION)
+    assert current_client_certs != new_client_certs
+    assert current_peer_certs == new_peer_certs
+
+    logger.info("Configuring the application with the new peer private key")
+    juju.config(app=APP_NAME, values={"tls-peer-private-key": secret_uri})
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, APP_NAME, TLS_APP_NAME),
+        timeout=TIMEOUT,
+    )
+
+    new_client_certs = get_unit_certificates_cert(juju, leader_unit, TLS_CLIENT_RELATION)
+    new_peer_certs = get_unit_certificates_cert(juju, leader_unit, TLS_PEER_RELATION)
+    assert current_client_certs != new_client_certs
+    assert current_peer_certs != new_peer_certs
+
+    logger.info("Verifying cluster accessibility after client key rotation")
+    for unit_name in get_app_units(juju, APP_NAME):
+        config["host"] = get_unit_address(juju, APP_NAME, unit_name)
+        assert is_connection_possible(config, **{"ssl_disabled": False})
+
+
+def create_private_key() -> str:
+    """Generates a private key using the PEM format (valid for certificates)."""
+    private_key = generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+    )
+    private_key = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+    return base64.b64encode(private_key).decode()
+
+
+def get_unit_certificates_cert(juju: Juju, unit_name: str, relation_name: str) -> str:
+    """Returns the TLS Certificate used by the unit.
+
+    Args:
+        juju: The Juju instance
+        unit_name: The name of the unit
+        relation_name: name of the relation to get data from
+
+    Returns:
+        TLS Certificate or an empty string if there is no Certificate.
+    """
+    relation_data = get_unit_relation_data(juju, unit_name, relation_name)
+    relation_fields = json.loads(relation_data["application-data"]["certificates"])
+    if not relation_fields:
+        raise ValueError(f"No relation data could be grabbed for relation {relation_name}")
+
+    return relation_fields[0].get("certificate", "")

--- a/kubernetes/tests/spread/integration/test_tls_private_key.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_tls_private_key.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_tls_private_key.py
+environment:
+  TEST_MODULE: test_tls_private_key.py
+execute: |
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/machines/config.yaml
+++ b/machines/config.yaml
@@ -56,6 +56,16 @@ options:
       Allowed values: "all", "first", "none"
     type: string
     default: first
+  tls-client-private-key:
+    type: secret
+    description: |
+      A Juju secret URI of a secret containing the private key for client-to-server TLS certificates.
+      The private key must be PEM formatted, base64 encoded and at least 2048 bits long.
+  tls-peer-private-key:
+    type: secret
+    description: |
+      A Juju secret URI of a secret containing the private key for peer-to-peer TLS certificates.
+      The private key must be PEM formatted, base64 encoded and at least 2048 bits long.
   # Experimental features
   experimental-max-connections:
     type: int

--- a/machines/poetry.lock
+++ b/machines/poetry.lock
@@ -88,7 +88,7 @@ version = "23.1.0"
 description = "Classes Without Boilerplate"
 optional = false
 python-versions = ">=3.7"
-groups = ["charm-libs", "integration"]
+groups = ["integration"]
 files = [
     {file = "attrs-23.1.0-py3-none-any.whl", hash = "sha256:1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04"},
     {file = "attrs-23.1.0.tar.gz", hash = "sha256:6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"},
@@ -206,7 +206,7 @@ version = "2.0.0"
 description = "Foreign Function Interface for Python calling C code."
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "charm-libs", "integration"]
+groups = ["main", "integration"]
 files = [
     {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
     {file = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"},
@@ -293,7 +293,7 @@ files = [
     {file = "cffi-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9"},
     {file = "cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529"},
 ]
-markers = {main = "platform_python_implementation != \"PyPy\"", charm-libs = "platform_python_implementation != \"PyPy\""}
+markers = {main = "platform_python_implementation != \"PyPy\""}
 
 [package.dependencies]
 pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
@@ -397,14 +397,14 @@ ops = ">=2.19,<4"
 
 [[package]]
 name = "charmlibs-rollingops"
-version = "1.0.0"
+version = "1.1.0"
 description = "The charmlibs.rollingops package."
 optional = false
 python-versions = ">=3.12"
 groups = ["main"]
 files = [
-    {file = "charmlibs_rollingops-1.0.0-py3-none-any.whl", hash = "sha256:39bcbc0d0705eb1d940296a5cede848d069fd4f20aa77b682d0876271cbe1a2e"},
-    {file = "charmlibs_rollingops-1.0.0.tar.gz", hash = "sha256:a88654f5d048e90a1acc394885e911611d997582d5029ab3506097a820edd5ba"},
+    {file = "charmlibs_rollingops-1.1.0-py3-none-any.whl", hash = "sha256:543e436fa6ebcefc290d1832182f19a5873910b3e48edc8fb028d0eadc83e493"},
+    {file = "charmlibs_rollingops-1.1.0.tar.gz", hash = "sha256:7ff6420943fdf6a953e60ff2a78e641741aba8f6f77efe0121457a37036f1bee"},
 ]
 
 [package.dependencies]
@@ -631,7 +631,7 @@ version = "47.0.0"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = "!=3.9.0,!=3.9.1,>=3.8"
-groups = ["main", "charm-libs", "integration"]
+groups = ["main", "integration"]
 files = [
     {file = "cryptography-47.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:160ad728f128972d362e714054f6ba0067cab7fb350c5202a9ae8ae4ce3ef1a0"},
     {file = "cryptography-47.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b9a8943e359b7615db1a3ba587994618e094ff3d6fa5a390c73d079ce18b3973"},
@@ -912,43 +912,6 @@ files = [
     {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
     {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
 ]
-
-[[package]]
-name = "jsonschema"
-version = "4.19.0"
-description = "An implementation of JSON Schema validation for Python"
-optional = false
-python-versions = ">=3.8"
-groups = ["charm-libs"]
-files = [
-    {file = "jsonschema-4.19.0-py3-none-any.whl", hash = "sha256:043dc26a3845ff09d20e4420d6012a9c91c9aa8999fa184e7efcfeccb41e32cb"},
-    {file = "jsonschema-4.19.0.tar.gz", hash = "sha256:6e1e7569ac13be8139b2dd2c21a55d350066ee3f80df06c608b398cdc6f30e8f"},
-]
-
-[package.dependencies]
-attrs = ">=22.2.0"
-jsonschema-specifications = ">=2023.03.6"
-referencing = ">=0.28.4"
-rpds-py = ">=0.7.1"
-
-[package.extras]
-format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3987", "uri-template", "webcolors (>=1.11)"]
-format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "uri-template", "webcolors (>=1.11)"]
-
-[[package]]
-name = "jsonschema-specifications"
-version = "2023.7.1"
-description = "The JSON Schema meta-schemas and vocabularies, exposed as a Registry"
-optional = false
-python-versions = ">=3.8"
-groups = ["charm-libs"]
-files = [
-    {file = "jsonschema_specifications-2023.7.1-py3-none-any.whl", hash = "sha256:05adf340b659828a004220a9613be00fa3f223f2b82002e273dee62fd50524b1"},
-    {file = "jsonschema_specifications-2023.7.1.tar.gz", hash = "sha256:c91a50404e88a1f6ba40636778e2ee08f6e24c5613fe4c53ac24578a5a7f72bb"},
-]
-
-[package.dependencies]
-referencing = ">=0.28.0"
 
 [[package]]
 name = "jubilant"
@@ -1466,12 +1429,12 @@ version = "2.21"
 description = "C parser in Python"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-groups = ["main", "charm-libs", "integration"]
+groups = ["main", "integration"]
 files = [
     {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
     {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
 ]
-markers = {main = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\"", charm-libs = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\"", integration = "implementation_name != \"PyPy\""}
+markers = {main = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\"", integration = "implementation_name != \"PyPy\""}
 
 [[package]]
 name = "pydantic"
@@ -1856,22 +1819,6 @@ files = [
 ]
 
 [[package]]
-name = "referencing"
-version = "0.30.0"
-description = "JSON Referencing + Python"
-optional = false
-python-versions = ">=3.8"
-groups = ["charm-libs"]
-files = [
-    {file = "referencing-0.30.0-py3-none-any.whl", hash = "sha256:c257b08a399b6c2f5a3510a50d28ab5dbc7bbde049bcaf954d43c446f83ab548"},
-    {file = "referencing-0.30.0.tar.gz", hash = "sha256:47237742e990457f7512c7d27486394a9aadaf876cbfaa4be65b27b4f4d47c6b"},
-]
-
-[package.dependencies]
-attrs = ">=22.2.0"
-rpds-py = ">=0.7.0"
-
-[[package]]
 name = "requests"
 version = "2.31.0"
 description = "Python HTTP for Humans."
@@ -1911,113 +1858,6 @@ requests = ">=2.0.0"
 
 [package.extras]
 rsa = ["oauthlib[signedtoken] (>=3.0.0)"]
-
-[[package]]
-name = "rpds-py"
-version = "0.9.2"
-description = "Python bindings to Rust's persistent data structures (rpds)"
-optional = false
-python-versions = ">=3.8"
-groups = ["charm-libs"]
-files = [
-    {file = "rpds_py-0.9.2-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:ab6919a09c055c9b092798ce18c6c4adf49d24d4d9e43a92b257e3f2548231e7"},
-    {file = "rpds_py-0.9.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d55777a80f78dd09410bd84ff8c95ee05519f41113b2df90a69622f5540c4f8b"},
-    {file = "rpds_py-0.9.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a216b26e5af0a8e265d4efd65d3bcec5fba6b26909014effe20cd302fd1138fa"},
-    {file = "rpds_py-0.9.2-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29cd8bfb2d716366a035913ced99188a79b623a3512292963d84d3e06e63b496"},
-    {file = "rpds_py-0.9.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:44659b1f326214950a8204a248ca6199535e73a694be8d3e0e869f820767f12f"},
-    {file = "rpds_py-0.9.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:745f5a43fdd7d6d25a53ab1a99979e7f8ea419dfefebcab0a5a1e9095490ee5e"},
-    {file = "rpds_py-0.9.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a987578ac5214f18b99d1f2a3851cba5b09f4a689818a106c23dbad0dfeb760f"},
-    {file = "rpds_py-0.9.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:bf4151acb541b6e895354f6ff9ac06995ad9e4175cbc6d30aaed08856558201f"},
-    {file = "rpds_py-0.9.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:03421628f0dc10a4119d714a17f646e2837126a25ac7a256bdf7c3943400f67f"},
-    {file = "rpds_py-0.9.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:13b602dc3e8dff3063734f02dcf05111e887f301fdda74151a93dbbc249930fe"},
-    {file = "rpds_py-0.9.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:fae5cb554b604b3f9e2c608241b5d8d303e410d7dfb6d397c335f983495ce7f6"},
-    {file = "rpds_py-0.9.2-cp310-none-win32.whl", hash = "sha256:47c5f58a8e0c2c920cc7783113df2fc4ff12bf3a411d985012f145e9242a2764"},
-    {file = "rpds_py-0.9.2-cp310-none-win_amd64.whl", hash = "sha256:4ea6b73c22d8182dff91155af018b11aac9ff7eca085750455c5990cb1cfae6e"},
-    {file = "rpds_py-0.9.2-cp311-cp311-macosx_10_7_x86_64.whl", hash = "sha256:e564d2238512c5ef5e9d79338ab77f1cbbda6c2d541ad41b2af445fb200385e3"},
-    {file = "rpds_py-0.9.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f411330a6376fb50e5b7a3e66894e4a39e60ca2e17dce258d53768fea06a37bd"},
-    {file = "rpds_py-0.9.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0e7521f5af0233e89939ad626b15278c71b69dc1dfccaa7b97bd4cdf96536bb7"},
-    {file = "rpds_py-0.9.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8d3335c03100a073883857e91db9f2e0ef8a1cf42dc0369cbb9151c149dbbc1b"},
-    {file = "rpds_py-0.9.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d25b1c1096ef0447355f7293fbe9ad740f7c47ae032c2884113f8e87660d8f6e"},
-    {file = "rpds_py-0.9.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6a5d3fbd02efd9cf6a8ffc2f17b53a33542f6b154e88dd7b42ef4a4c0700fdad"},
-    {file = "rpds_py-0.9.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c5934e2833afeaf36bd1eadb57256239785f5af0220ed8d21c2896ec4d3a765f"},
-    {file = "rpds_py-0.9.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:095b460e117685867d45548fbd8598a8d9999227e9061ee7f012d9d264e6048d"},
-    {file = "rpds_py-0.9.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:91378d9f4151adc223d584489591dbb79f78814c0734a7c3bfa9c9e09978121c"},
-    {file = "rpds_py-0.9.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:24a81c177379300220e907e9b864107614b144f6c2a15ed5c3450e19cf536fae"},
-    {file = "rpds_py-0.9.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:de0b6eceb46141984671802d412568d22c6bacc9b230174f9e55fc72ef4f57de"},
-    {file = "rpds_py-0.9.2-cp311-none-win32.whl", hash = "sha256:700375326ed641f3d9d32060a91513ad668bcb7e2cffb18415c399acb25de2ab"},
-    {file = "rpds_py-0.9.2-cp311-none-win_amd64.whl", hash = "sha256:0766babfcf941db8607bdaf82569ec38107dbb03c7f0b72604a0b346b6eb3298"},
-    {file = "rpds_py-0.9.2-cp312-cp312-macosx_10_7_x86_64.whl", hash = "sha256:b1440c291db3f98a914e1afd9d6541e8fc60b4c3aab1a9008d03da4651e67386"},
-    {file = "rpds_py-0.9.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0f2996fbac8e0b77fd67102becb9229986396e051f33dbceada3debaacc7033f"},
-    {file = "rpds_py-0.9.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9f30d205755566a25f2ae0382944fcae2f350500ae4df4e795efa9e850821d82"},
-    {file = "rpds_py-0.9.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:159fba751a1e6b1c69244e23ba6c28f879a8758a3e992ed056d86d74a194a0f3"},
-    {file = "rpds_py-0.9.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a1f044792e1adcea82468a72310c66a7f08728d72a244730d14880cd1dabe36b"},
-    {file = "rpds_py-0.9.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9251eb8aa82e6cf88510530b29eef4fac825a2b709baf5b94a6094894f252387"},
-    {file = "rpds_py-0.9.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:01899794b654e616c8625b194ddd1e5b51ef5b60ed61baa7a2d9c2ad7b2a4238"},
-    {file = "rpds_py-0.9.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b0c43f8ae8f6be1d605b0465671124aa8d6a0e40f1fb81dcea28b7e3d87ca1e1"},
-    {file = "rpds_py-0.9.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:207f57c402d1f8712618f737356e4b6f35253b6d20a324d9a47cb9f38ee43a6b"},
-    {file = "rpds_py-0.9.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:b52e7c5ae35b00566d244ffefba0f46bb6bec749a50412acf42b1c3f402e2c90"},
-    {file = "rpds_py-0.9.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:978fa96dbb005d599ec4fd9ed301b1cc45f1a8f7982d4793faf20b404b56677d"},
-    {file = "rpds_py-0.9.2-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:6aa8326a4a608e1c28da191edd7c924dff445251b94653988efb059b16577a4d"},
-    {file = "rpds_py-0.9.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:aad51239bee6bff6823bbbdc8ad85136c6125542bbc609e035ab98ca1e32a192"},
-    {file = "rpds_py-0.9.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4bd4dc3602370679c2dfb818d9c97b1137d4dd412230cfecd3c66a1bf388a196"},
-    {file = "rpds_py-0.9.2-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:dd9da77c6ec1f258387957b754f0df60766ac23ed698b61941ba9acccd3284d1"},
-    {file = "rpds_py-0.9.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:190ca6f55042ea4649ed19c9093a9be9d63cd8a97880106747d7147f88a49d18"},
-    {file = "rpds_py-0.9.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:876bf9ed62323bc7dcfc261dbc5572c996ef26fe6406b0ff985cbcf460fc8a4c"},
-    {file = "rpds_py-0.9.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa2818759aba55df50592ecbc95ebcdc99917fa7b55cc6796235b04193eb3c55"},
-    {file = "rpds_py-0.9.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9ea4d00850ef1e917815e59b078ecb338f6a8efda23369677c54a5825dbebb55"},
-    {file = "rpds_py-0.9.2-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:5855c85eb8b8a968a74dc7fb014c9166a05e7e7a8377fb91d78512900aadd13d"},
-    {file = "rpds_py-0.9.2-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:14c408e9d1a80dcb45c05a5149e5961aadb912fff42ca1dd9b68c0044904eb32"},
-    {file = "rpds_py-0.9.2-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:65a0583c43d9f22cb2130c7b110e695fff834fd5e832a776a107197e59a1898e"},
-    {file = "rpds_py-0.9.2-cp38-none-win32.whl", hash = "sha256:71f2f7715935a61fa3e4ae91d91b67e571aeb5cb5d10331ab681256bda2ad920"},
-    {file = "rpds_py-0.9.2-cp38-none-win_amd64.whl", hash = "sha256:674c704605092e3ebbbd13687b09c9f78c362a4bc710343efe37a91457123044"},
-    {file = "rpds_py-0.9.2-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:07e2c54bef6838fa44c48dfbc8234e8e2466d851124b551fc4e07a1cfeb37260"},
-    {file = "rpds_py-0.9.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f7fdf55283ad38c33e35e2855565361f4bf0abd02470b8ab28d499c663bc5d7c"},
-    {file = "rpds_py-0.9.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:890ba852c16ace6ed9f90e8670f2c1c178d96510a21b06d2fa12d8783a905193"},
-    {file = "rpds_py-0.9.2-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:50025635ba8b629a86d9d5474e650da304cb46bbb4d18690532dd79341467846"},
-    {file = "rpds_py-0.9.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:517cbf6e67ae3623c5127206489d69eb2bdb27239a3c3cc559350ef52a3bbf0b"},
-    {file = "rpds_py-0.9.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0836d71ca19071090d524739420a61580f3f894618d10b666cf3d9a1688355b1"},
-    {file = "rpds_py-0.9.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c439fd54b2b9053717cca3de9583be6584b384d88d045f97d409f0ca867d80f"},
-    {file = "rpds_py-0.9.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f68996a3b3dc9335037f82754f9cdbe3a95db42bde571d8c3be26cc6245f2324"},
-    {file = "rpds_py-0.9.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:7d68dc8acded354c972116f59b5eb2e5864432948e098c19fe6994926d8e15c3"},
-    {file = "rpds_py-0.9.2-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:f963c6b1218b96db85fc37a9f0851eaf8b9040aa46dec112611697a7023da535"},
-    {file = "rpds_py-0.9.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:5a46859d7f947061b4010e554ccd1791467d1b1759f2dc2ec9055fa239f1bc26"},
-    {file = "rpds_py-0.9.2-cp39-none-win32.whl", hash = "sha256:e07e5dbf8a83c66783a9fe2d4566968ea8c161199680e8ad38d53e075df5f0d0"},
-    {file = "rpds_py-0.9.2-cp39-none-win_amd64.whl", hash = "sha256:682726178138ea45a0766907957b60f3a1bf3acdf212436be9733f28b6c5af3c"},
-    {file = "rpds_py-0.9.2-pp310-pypy310_pp73-macosx_10_7_x86_64.whl", hash = "sha256:196cb208825a8b9c8fc360dc0f87993b8b260038615230242bf18ec84447c08d"},
-    {file = "rpds_py-0.9.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:c7671d45530fcb6d5e22fd40c97e1e1e01965fc298cbda523bb640f3d923b387"},
-    {file = "rpds_py-0.9.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83b32f0940adec65099f3b1c215ef7f1d025d13ff947975a055989cb7fd019a4"},
-    {file = "rpds_py-0.9.2-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7f67da97f5b9eac838b6980fc6da268622e91f8960e083a34533ca710bec8611"},
-    {file = "rpds_py-0.9.2-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:03975db5f103997904c37e804e5f340c8fdabbb5883f26ee50a255d664eed58c"},
-    {file = "rpds_py-0.9.2-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:987b06d1cdb28f88a42e4fb8a87f094e43f3c435ed8e486533aea0bf2e53d931"},
-    {file = "rpds_py-0.9.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c861a7e4aef15ff91233751619ce3a3d2b9e5877e0fcd76f9ea4f6847183aa16"},
-    {file = "rpds_py-0.9.2-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:02938432352359805b6da099c9c95c8a0547fe4b274ce8f1a91677401bb9a45f"},
-    {file = "rpds_py-0.9.2-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:ef1f08f2a924837e112cba2953e15aacfccbbfcd773b4b9b4723f8f2ddded08e"},
-    {file = "rpds_py-0.9.2-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:35da5cc5cb37c04c4ee03128ad59b8c3941a1e5cd398d78c37f716f32a9b7f67"},
-    {file = "rpds_py-0.9.2-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:141acb9d4ccc04e704e5992d35472f78c35af047fa0cfae2923835d153f091be"},
-    {file = "rpds_py-0.9.2-pp38-pypy38_pp73-macosx_10_7_x86_64.whl", hash = "sha256:79f594919d2c1a0cc17d1988a6adaf9a2f000d2e1048f71f298b056b1018e872"},
-    {file = "rpds_py-0.9.2-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:a06418fe1155e72e16dddc68bb3780ae44cebb2912fbd8bb6ff9161de56e1798"},
-    {file = "rpds_py-0.9.2-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b2eb034c94b0b96d5eddb290b7b5198460e2d5d0c421751713953a9c4e47d10"},
-    {file = "rpds_py-0.9.2-pp38-pypy38_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8b08605d248b974eb02f40bdcd1a35d3924c83a2a5e8f5d0fa5af852c4d960af"},
-    {file = "rpds_py-0.9.2-pp38-pypy38_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a0805911caedfe2736935250be5008b261f10a729a303f676d3d5fea6900c96a"},
-    {file = "rpds_py-0.9.2-pp38-pypy38_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ab2299e3f92aa5417d5e16bb45bb4586171c1327568f638e8453c9f8d9e0f020"},
-    {file = "rpds_py-0.9.2-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c8d7594e38cf98d8a7df25b440f684b510cf4627fe038c297a87496d10a174f"},
-    {file = "rpds_py-0.9.2-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8b9ec12ad5f0a4625db34db7e0005be2632c1013b253a4a60e8302ad4d462afd"},
-    {file = "rpds_py-0.9.2-pp38-pypy38_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:1fcdee18fea97238ed17ab6478c66b2095e4ae7177e35fb71fbe561a27adf620"},
-    {file = "rpds_py-0.9.2-pp38-pypy38_pp73-musllinux_1_2_i686.whl", hash = "sha256:933a7d5cd4b84f959aedeb84f2030f0a01d63ae6cf256629af3081cf3e3426e8"},
-    {file = "rpds_py-0.9.2-pp38-pypy38_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:686ba516e02db6d6f8c279d1641f7067ebb5dc58b1d0536c4aaebb7bf01cdc5d"},
-    {file = "rpds_py-0.9.2-pp39-pypy39_pp73-macosx_10_7_x86_64.whl", hash = "sha256:0173c0444bec0a3d7d848eaeca2d8bd32a1b43f3d3fde6617aac3731fa4be05f"},
-    {file = "rpds_py-0.9.2-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:d576c3ef8c7b2d560e301eb33891d1944d965a4d7a2eacb6332eee8a71827db6"},
-    {file = "rpds_py-0.9.2-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed89861ee8c8c47d6beb742a602f912b1bb64f598b1e2f3d758948721d44d468"},
-    {file = "rpds_py-0.9.2-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1054a08e818f8e18910f1bee731583fe8f899b0a0a5044c6e680ceea34f93876"},
-    {file = "rpds_py-0.9.2-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:99e7c4bb27ff1aab90dcc3e9d37ee5af0231ed98d99cb6f5250de28889a3d502"},
-    {file = "rpds_py-0.9.2-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c545d9d14d47be716495076b659db179206e3fd997769bc01e2d550eeb685596"},
-    {file = "rpds_py-0.9.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9039a11bca3c41be5a58282ed81ae422fa680409022b996032a43badef2a3752"},
-    {file = "rpds_py-0.9.2-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fb39aca7a64ad0c9490adfa719dbeeb87d13be137ca189d2564e596f8ba32c07"},
-    {file = "rpds_py-0.9.2-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:2d8b3b3a2ce0eaa00c5bbbb60b6713e94e7e0becab7b3db6c5c77f979e8ed1f1"},
-    {file = "rpds_py-0.9.2-pp39-pypy39_pp73-musllinux_1_2_i686.whl", hash = "sha256:99b1c16f732b3a9971406fbfe18468592c5a3529585a45a35adbc1389a529a03"},
-    {file = "rpds_py-0.9.2-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:c27ee01a6c3223025f4badd533bea5e87c988cb0ba2811b690395dfe16088cfe"},
-    {file = "rpds_py-0.9.2.tar.gz", hash = "sha256:8d70e8f14900f2657c249ea4def963bed86a29b81f81f5b76b5a9215680de945"},
-]
 
 [[package]]
 name = "rsa"

--- a/machines/pyproject.toml
+++ b/machines/pyproject.toml
@@ -6,7 +6,7 @@ main = [
     "boto3~=1.28",
     "charm-refresh~=3.1.1",
     "charmlibs-interfaces-tls-certificates~=1.0",
-    "charmlibs-rollingops~=1.0",
+    "charmlibs-rollingops~=1.1",
     "jinja2~=3.1",
     "object-storage-charmlib~=1.0.0",
     "ops[tracing]~=3.5",
@@ -26,9 +26,6 @@ charm-libs = [
     # mysql/v0/*.py"
     "charm-refresh~=3.1.1",
     "mysql_shell_client[contrib]~=1.0",
-    # tls_certificates_interface/v2/tls_certificates.py
-    "cryptography>=42.0.5",
-    "jsonschema",
 ]
 format = [
     "ruff~=0.12",
@@ -54,6 +51,7 @@ integration = [
     "urllib3~=2.0",
     "allure-pytest~=2.13",
     "allure-pytest-default-results~=0.1.2",
+    "cryptography~=47.0",
     "jubilant~=1.4.0",
     "tomli~=2.3",
     "tomli-w~=1.2",

--- a/machines/src/charm.py
+++ b/machines/src/charm.py
@@ -273,7 +273,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         """Handle the leader settings changed event."""
         self.unit_peer_data.update({"leader": "false"})
 
-    def _on_config_changed(self, _) -> None:  # noqa: C901
+    def _on_config_changed(self, _) -> None:
         """Handle the config changed event."""
         if not self._is_peer_data_set:
             # skip when not initialized
@@ -298,10 +298,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         self.log_rotation_setup.setup()
 
         # Rotate TLS keys
-        if self.config.tls_client_private_key:
-            self.tls.client_certificates_refresh_event.emit()
-        if self.config.tls_peer_private_key:
-            self.tls.peer_certificates_refresh_event.emit()
+        self._rotate_private_keys()
 
         if (
             self.mysql_config.keys_requires_restart(changed_config)
@@ -1111,6 +1108,24 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
 
         self._on_update_status(None)
         return OperationResult.RELEASE
+
+    def _rotate_private_keys(self) -> None:
+        """Rotates either of the TLS private keys if the config values are new."""
+        new_client_private_key = self.config.tls_client_private_key
+        old_client_private_key = self.app_peer_data.get("client-private-key", None)
+
+        if new_client_private_key != old_client_private_key:
+            self.tls.client_certificates_refresh_event.emit()
+            if self.unit.is_leader():
+                self.app_peer_data["client-private-key"] = new_client_private_key
+
+        new_peer_private_key = self.config.tls_peer_private_key
+        old_peer_private_key = self.app_peer_data.get("peer-private-key", None)
+
+        if new_peer_private_key != old_peer_private_key:
+            self.tls.peer_certificates_refresh_event.emit()
+            if self.unit.is_leader():
+                self.app_peer_data["peer-private-key"] = new_peer_private_key
 
 
 if __name__ == "__main__":

--- a/machines/src/charm.py
+++ b/machines/src/charm.py
@@ -10,7 +10,6 @@ from ops.main import main
 if is_wrong_architecture() and __name__ == "__main__":
     main(WrongArchitectureWarningCharm)
 
-import json
 import logging
 import random
 import socket
@@ -274,7 +273,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         """Handle the leader settings changed event."""
         self.unit_peer_data.update({"leader": "false"})
 
-    def _on_config_changed(self, _) -> None:
+    def _on_config_changed(self, _) -> None:  # noqa: C901
         """Handle the config changed event."""
         if not self._is_peer_data_set:
             # skip when not initialized
@@ -297,6 +296,12 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
 
         # Override log rotation
         self.log_rotation_setup.setup()
+
+        # Rotate TLS keys
+        if self.config.tls_client_private_key:
+            self.tls.client_certificates_refresh_event.emit()
+        if self.config.tls_peer_private_key:
+            self.tls.peer_certificates_refresh_event.emit()
 
         if (
             self.mysql_config.keys_requires_restart(changed_config)
@@ -1049,8 +1054,10 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             logger.info("Skipping group replication restart")
             return OperationResult.RETRY_RELEASE
 
-        ongoing_ops = [relation.data[unit].get("operations", "[]") for unit in self.peers.units]
-        ongoing_ops = [json.loads(op) for op in ongoing_ops]
+        ongoing_ops = [
+            self.rolling_ops.is_waiting_callback("replication", unit.name)
+            for unit in self.peers.units
+        ]
 
         if self.is_unit_primary() and any(ongoing_ops):
             logger.info("Skipping group replication restart")

--- a/machines/src/config.py
+++ b/machines/src/config.py
@@ -61,6 +61,8 @@ class CharmConfig(BaseConfigModel):
     logs_audit_policy: str
     logs_retention_period: str
     pause_after_unit_refresh: str
+    tls_client_private_key: str | None = Field(default=None)
+    tls_peer_private_key: str | None = Field(default=None)
 
     @field_validator("profile")
     @classmethod

--- a/machines/src/relations/tls.py
+++ b/machines/src/relations/tls.py
@@ -4,6 +4,7 @@
 """TLS Handler."""
 
 import base64
+import binascii
 import logging
 import re
 import socket
@@ -199,7 +200,7 @@ class TLS(Object):
 
         try:
             private_key = base64.b64decode(private_key).decode("utf-8").strip()
-        except UnicodeDecodeError as e:
+        except (UnicodeDecodeError, binascii.Error) as e:
             logger.error(e)
             return None
 
@@ -296,6 +297,9 @@ class TLS(Object):
             self.charm.unit.status = BlockedStatus("Failed to disable client TLS.")
             return
 
+        if self.charm.unit.is_leader():
+            del self.charm.app_peer_data["client-private-key"]
+
         self.charm.unit.status = self.charm.build_unit_workload_status()
 
     def _on_peer_relation_broken(self, _: EventBase) -> None:
@@ -313,6 +317,9 @@ class TLS(Object):
             logger.error(f"Failed to disable peer TLS: {e}")
             self.charm.unit.status = BlockedStatus("Failed to disable peer TLS.")
             return
+
+        if self.charm.unit.is_leader():
+            del self.charm.app_peer_data["peer-private-key"]
 
     def _push_tls_files_to_workload(self) -> None:
         """Push TLS files to unit."""

--- a/machines/src/relations/tls.py
+++ b/machines/src/relations/tls.py
@@ -3,12 +3,15 @@
 
 """TLS Handler."""
 
+import base64
 import logging
+import re
 import socket
 from typing import TYPE_CHECKING
 
 from charmlibs.interfaces.tls_certificates import (
     CertificateRequestAttributes,
+    PrivateKey,
     TLSCertificatesRequiresV4,
 )
 from charms.mysql.v0.async_replication import (
@@ -18,7 +21,7 @@ from charms.mysql.v0.async_replication import (
 from charms.mysql.v0.mysql import MySQLTLSSetupError
 from mysql_shell.models import InstanceState
 from ops.framework import EventBase, EventSource, Object
-from ops.model import BlockedStatus, MaintenanceStatus
+from ops.model import BlockedStatus, MaintenanceStatus, SecretNotFoundError
 from ops.pebble import ConnectionError as PebbleConnectionError
 from ops.pebble import PathError, ProtocolError
 
@@ -46,7 +49,8 @@ class RefreshTLSCertificatesEvent(EventBase):
 class TLS(Object):
     """In this class we manage certificates relation."""
 
-    refresh_tls_certificates_event = EventSource(RefreshTLSCertificatesEvent)
+    client_certificates_refresh_event = EventSource(RefreshTLSCertificatesEvent)
+    peer_certificates_refresh_event = EventSource(RefreshTLSCertificatesEvent)
 
     def __init__(self, charm: "MySQLOperatorCharm"):
         super().__init__(charm, "certificates")
@@ -71,7 +75,8 @@ class TLS(Object):
                     },
                 ),
             ],
-            refresh_events=[self.refresh_tls_certificates_event],
+            private_key=self._parse_client_private_key(),
+            refresh_events=[self.client_certificates_refresh_event],
         )
         self.peer_certificate = TLSCertificatesRequiresV4(
             self.charm,
@@ -85,7 +90,8 @@ class TLS(Object):
                     },
                 ),
             ],
-            refresh_events=[self.refresh_tls_certificates_event],
+            private_key=self._parse_peer_private_key(),
+            refresh_events=[self.peer_certificates_refresh_event],
         )
 
         self.framework.observe(
@@ -170,6 +176,47 @@ class TLS(Object):
             ca_file = str(certs[0].ca)
 
         return key_file, ca_file, cert_file
+
+    def _parse_private_key(self, secret_id: str | None) -> PrivateKey | None:
+        """Parse the received private key."""
+        if not secret_id:
+            return None
+
+        try:
+            secret_content = self.charm.model.get_secret(id=secret_id).get_content(refresh=True)
+        except SecretNotFoundError as e:
+            logger.error(e)
+            return None
+
+        private_key = secret_content.get("private-key")
+        if private_key is None:
+            logger.error(f"Secret {secret_id} does not contain a private key.")
+            return None
+
+        if re.match(r"(-+(BEGIN|END) [A-Z ]+-+)", private_key):
+            logger.error(f"Secret {secret_id} must be base64 encoded.")
+            return None
+
+        try:
+            private_key = base64.b64decode(private_key).decode("utf-8").strip()
+        except UnicodeDecodeError as e:
+            logger.error(e)
+            return None
+
+        private_key = PrivateKey(raw=private_key)
+        if not private_key.is_valid():
+            logger.error("Invalid private key format.")
+            return None
+
+        return private_key
+
+    def _parse_client_private_key(self) -> PrivateKey | None:
+        """Parse the client private key from the config."""
+        return self._parse_private_key(self.charm.config.tls_client_private_key)
+
+    def _parse_peer_private_key(self) -> PrivateKey | None:
+        """Parse the peer private key from the config."""
+        return self._parse_private_key(self.charm.config.tls_peer_private_key)
 
     def _on_client_certificate_available(self, event: EventBase) -> None:
         """Handler for the certificate available event."""

--- a/machines/tests/integration/integration/test_tls_private_key.py
+++ b/machines/tests/integration/integration/test_tls_private_key.py
@@ -109,8 +109,8 @@ def test_set_private_key(juju: Juju) -> None:
         "password": credentials["password"],
     }
 
-    current_client_certs = get_unit_certificates_cert(juju, leader_unit, TLS_CLIENT_RELATION)
-    current_peer_certs = get_unit_certificates_cert(juju, leader_unit, TLS_PEER_RELATION)
+    first_client_certs = get_unit_certificates_cert(juju, leader_unit, TLS_CLIENT_RELATION)
+    first_peer_certs = get_unit_certificates_cert(juju, leader_unit, TLS_PEER_RELATION)
 
     logger.info("Generating new private key")
     private_key = create_private_key()
@@ -125,10 +125,10 @@ def test_set_private_key(juju: Juju) -> None:
         timeout=TIMEOUT,
     )
 
-    new_client_certs = get_unit_certificates_cert(juju, leader_unit, TLS_CLIENT_RELATION)
-    new_peer_certs = get_unit_certificates_cert(juju, leader_unit, TLS_PEER_RELATION)
-    assert current_client_certs != new_client_certs
-    assert current_peer_certs == new_peer_certs
+    second_client_certs = get_unit_certificates_cert(juju, leader_unit, TLS_CLIENT_RELATION)
+    second_peer_certs = get_unit_certificates_cert(juju, leader_unit, TLS_PEER_RELATION)
+    assert first_client_certs != second_client_certs
+    assert first_peer_certs == second_peer_certs
 
     logger.info("Configuring the application with the new peer private key")
     juju.config(app=APP_NAME, values={"tls-peer-private-key": secret_uri})
@@ -137,10 +137,10 @@ def test_set_private_key(juju: Juju) -> None:
         timeout=TIMEOUT,
     )
 
-    new_client_certs = get_unit_certificates_cert(juju, leader_unit, TLS_CLIENT_RELATION)
-    new_peer_certs = get_unit_certificates_cert(juju, leader_unit, TLS_PEER_RELATION)
-    assert current_client_certs != new_client_certs
-    assert current_peer_certs != new_peer_certs
+    third_client_certs = get_unit_certificates_cert(juju, leader_unit, TLS_CLIENT_RELATION)
+    third_peer_certs = get_unit_certificates_cert(juju, leader_unit, TLS_PEER_RELATION)
+    assert second_client_certs == third_client_certs
+    assert second_peer_certs != third_peer_certs
 
     logger.info("Verifying cluster accessibility after client key rotation")
     for unit_name in get_app_units(juju, APP_NAME):

--- a/machines/tests/integration/integration/test_tls_private_key.py
+++ b/machines/tests/integration/integration/test_tls_private_key.py
@@ -148,6 +148,37 @@ def test_set_private_key(juju: Juju) -> None:
         assert is_connection_possible(config, **{"ssl_disabled": False})
 
 
+def test_disable_tls(juju: Juju) -> None:
+    """Verify TLS is disabled and the cluster is accessible."""
+    leader_unit = get_app_leader(juju, APP_NAME)
+    credentials = get_mysql_server_credentials(juju, leader_unit)
+
+    config = {
+        "username": credentials["username"],
+        "password": credentials["password"],
+    }
+
+    logger.info("Removing relation")
+    juju.remove_relation(f"{APP_NAME}:client-certificates", f"{TLS_APP_NAME}:certificates")
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, APP_NAME, TLS_APP_NAME),
+        timeout=TIMEOUT,
+        delay=5,
+    )
+
+    juju.remove_relation(f"{APP_NAME}:peer-certificates", f"{TLS_APP_NAME}:certificates")
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, APP_NAME, TLS_APP_NAME),
+        timeout=TIMEOUT,
+        delay=5,
+    )
+
+    for unit_name in get_app_units(juju, APP_NAME):
+        config["host"] = get_unit_ip(juju, APP_NAME, unit_name)
+        assert is_connection_possible(config, **{"ssl_disabled": False})
+        assert is_connection_possible(config, **{"ssl_disabled": True})
+
+
 def create_private_key() -> str:
     """Generates a private key using the PEM format (valid for certificates)."""
     private_key = generate_private_key(

--- a/machines/tests/integration/integration/test_tls_private_key.py
+++ b/machines/tests/integration/integration/test_tls_private_key.py
@@ -1,0 +1,182 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import base64
+import json
+import logging
+
+import jubilant
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.rsa import generate_private_key
+from jubilant import Juju
+
+from constants import (
+    TLS_CLIENT_RELATION,
+    TLS_PEER_RELATION,
+)
+
+from ..helpers import is_connection_possible
+from ..helpers_ha import (
+    MINUTE_SECS,
+    create_app_secret,
+    get_app_leader,
+    get_app_units,
+    get_mysql_server_credentials,
+    get_unit_ip,
+    get_unit_relation_data,
+    wait_for_apps_status,
+)
+
+logger = logging.getLogger(__name__)
+
+APP_NAME = "mysql"
+TLS_APP_NAME = "self-signed-certificates"
+CLUSTER_NAME = "test_cluster"
+TIMEOUT = 15 * MINUTE_SECS
+
+
+def test_build_and_deploy(juju: Juju, charm) -> None:
+    """Build the charm and deploy with TLS enabled."""
+    juju.deploy(
+        charm,
+        APP_NAME,
+        base="ubuntu@24.04",
+        config={"cluster-name": CLUSTER_NAME, "profile": "testing"},
+        num_units=3,
+        trust=True,
+    )
+
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, APP_NAME),
+        timeout=TIMEOUT,
+    )
+
+
+def test_tls_enabled(juju: Juju) -> None:
+    """Verify TLS is enabled and the cluster is accessible."""
+    app_units = get_app_units(juju, APP_NAME)
+
+    logger.info("Deploy TLS operator")
+    juju.deploy(
+        TLS_APP_NAME,
+        channel="1/stable",
+        config={"ca-common-name": "Test CA"},
+        base="ubuntu@24.04",
+    )
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, TLS_APP_NAME),
+        timeout=TIMEOUT,
+    )
+
+    logger.info("Relate to TLS operator")
+    juju.integrate(f"{APP_NAME}:{TLS_CLIENT_RELATION}", f"{TLS_APP_NAME}:certificates")
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, APP_NAME, TLS_APP_NAME),
+        timeout=TIMEOUT,
+        delay=5,
+    )
+
+    juju.integrate(f"{APP_NAME}:{TLS_PEER_RELATION}", f"{TLS_APP_NAME}:certificates")
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, APP_NAME, TLS_APP_NAME),
+        timeout=TIMEOUT,
+        delay=5,
+    )
+
+    credentials = get_mysql_server_credentials(juju, app_units[0])
+    config = {
+        "username": credentials["username"],
+        "password": credentials["password"],
+    }
+
+    logger.info("Asserting connections after relation")
+    for unit_name in app_units:
+        config["host"] = get_unit_ip(juju, APP_NAME, unit_name)
+        assert is_connection_possible(config, **{"ssl_disabled": False})
+
+    logger.info("Asserting TLS relation data exists")
+    assert get_unit_relation_data(juju, app_units[0], TLS_CLIENT_RELATION)
+    assert get_unit_relation_data(juju, app_units[0], TLS_PEER_RELATION)
+
+
+def test_set_private_key(juju: Juju) -> None:
+    """Set a new private key and verify the cluster remains accessible."""
+    leader_unit = get_app_leader(juju, APP_NAME)
+    credentials = get_mysql_server_credentials(juju, leader_unit)
+
+    config = {
+        "username": credentials["username"],
+        "password": credentials["password"],
+    }
+
+    current_client_certs = get_unit_certificates_cert(juju, leader_unit, TLS_CLIENT_RELATION)
+    current_peer_certs = get_unit_certificates_cert(juju, leader_unit, TLS_PEER_RELATION)
+
+    logger.info("Generating new private key")
+    private_key = create_private_key()
+
+    logger.info("Creating secret with the new private key")
+    secret_uri = create_app_secret(juju, APP_NAME, {"private-key": private_key})
+
+    logger.info("Configuring the application with the new client private key")
+    juju.config(app=APP_NAME, values={"tls-client-private-key": secret_uri})
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, APP_NAME, TLS_APP_NAME),
+        timeout=TIMEOUT,
+    )
+
+    new_client_certs = get_unit_certificates_cert(juju, leader_unit, TLS_CLIENT_RELATION)
+    new_peer_certs = get_unit_certificates_cert(juju, leader_unit, TLS_PEER_RELATION)
+    assert current_client_certs != new_client_certs
+    assert current_peer_certs == new_peer_certs
+
+    logger.info("Configuring the application with the new peer private key")
+    juju.config(app=APP_NAME, values={"tls-peer-private-key": secret_uri})
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, APP_NAME, TLS_APP_NAME),
+        timeout=TIMEOUT,
+    )
+
+    new_client_certs = get_unit_certificates_cert(juju, leader_unit, TLS_CLIENT_RELATION)
+    new_peer_certs = get_unit_certificates_cert(juju, leader_unit, TLS_PEER_RELATION)
+    assert current_client_certs != new_client_certs
+    assert current_peer_certs != new_peer_certs
+
+    logger.info("Verifying cluster accessibility after client key rotation")
+    for unit_name in get_app_units(juju, APP_NAME):
+        config["host"] = get_unit_ip(juju, APP_NAME, unit_name)
+        assert is_connection_possible(config, **{"ssl_disabled": False})
+
+
+def create_private_key() -> str:
+    """Generates a private key using the PEM format (valid for certificates)."""
+    private_key = generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+    )
+    private_key = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+    return base64.b64encode(private_key).decode()
+
+
+def get_unit_certificates_cert(juju: Juju, unit_name: str, relation_name: str) -> str:
+    """Returns the TLS Certificate used by the unit.
+
+    Args:
+        juju: The Juju instance
+        unit_name: The name of the unit
+        relation_name: name of the relation to get data from
+
+    Returns:
+        TLS Certificate or an empty string if there is no Certificate.
+    """
+    relation_data = get_unit_relation_data(juju, unit_name, relation_name)
+    relation_fields = json.loads(relation_data["application-data"]["certificates"])
+    if not relation_fields:
+        raise ValueError(f"No relation data could be grabbed for relation {relation_name}")
+
+    return relation_fields[0].get("certificate", "")

--- a/machines/tests/spread/integration/test_tls_private_key.py/task.yaml
+++ b/machines/tests/spread/integration/test_tls_private_key.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_tls_private_key.py
+environment:
+  TEST_MODULE: test_tls_private_key.py
+execute: |
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results


### PR DESCRIPTION
This PR exposes config options in order to rotate the private key that gets passed on TLS certificate generation.

### Approach

The overall approach has been ported from the Charmed ETCD operator, where the desired private-keys need to be defined within a Juju secrets, to later be passed down to the application configuration via secret URI. The private keys are validated and passed down to the TLS relation handlers.

### Additional changes
- Bumped `charmlibs-rollingops` to version `1.1.0`, allowing us to get rid of a work-around the [previous PR](https://github.com/canonical/mysql-operators/pull/271).

---

Blocked by https://github.com/canonical/mysql-operators/pull/316.

Depends on https://github.com/canonical/mysql-operators/pull/315.