### PR TITLE
[MISC] Fix create_endpoint_services skipping roles after 409

### DIFF
--- a/kubernetes/src/k8s_helpers.py
+++ b/kubernetes/src/k8s_helpers.py
@@ -86,9 +86,9 @@ class KubernetesHelpers:
             except ApiError as e:
                 if e.status.code == 403:
                     logger.error("Kubernetes service creation failed: `juju trust` needed")
-                if e.status.code == 409:
+                elif e.status.code == 409:
                     logger.warning("Kubernetes service already exists")
-                    return
+                    continue
                 else:
                     logger.exception("Kubernetes service creation failed: %s", e)
                 raise KubernetesClientError from e


### PR DESCRIPTION
## Summary

- Found by `charm-find-bugs` skill (AP-038): in `create_endpoint_services`, when the first Service in `roles` already exists (HTTP 409) the handler `return`ed inside the `for` loop and never created the remaining Services (e.g. `replicas` left uncreated when `primary` exists).
- Switch the early `return` to `continue` so the loop keeps processing.
- Convert the 403 branch to `elif` so it no longer falls through into the 409 check.

## Test plan

- [ ] Unit test: simulate `ApiError` with `status.code == 409` on the first role; assert second role is still created.
- [ ] Unit test: 403 path raises `KubernetesClientError` without double-logging.
- [ ] Integration: deploy with 2+ roles and a pre-existing `primary` Service; verify `replicas` Service is created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)