### PR TITLE
[MISC] Return after BlockedStatus when primary address missing in legacy relations

### DIFF
--- a/kubernetes/src/relations/mysql.py
+++ b/kubernetes/src/relations/mysql.py
@@ -268,6 +268,7 @@ class MySQLRelation(Object):
         if not primary_address:
             logger.error("Unable to get cluster primary address")
             self.charm.unit.status = BlockedStatus("Failed to retrieve cluster primary address")
+            return
 
         updates = {
             "database": database,

--- a/kubernetes/src/relations/mysql_root.py
+++ b/kubernetes/src/relations/mysql_root.py
@@ -225,6 +225,7 @@ class MySQLRootRelation(Object):
             self.charm.unit.status = BlockedStatus(
                 "Failed to retrieve the cluster primary address"
             )
+            return
 
         updates = {
             "database": database,


### PR DESCRIPTION
## Summary

- Found by `charm-find-bugs` skill (AP-030 / AP-055): in the `mysql` and `mysql-root` legacy relation created handlers, when `get_cluster_primary_address` returned None the code set BlockedStatus but did **not** return.
- Execution fell through and committed `"host": None` into the relation databag and `app_peer_data`, exposing a broken host value to consumers.
- Add the missing `return` so the unit blocks without publishing invalid data.

## Test plan

- [ ] Unit test (`mysql`): mock `get_cluster_primary_address` -> None, assert BlockedStatus set and `app_peer_data[MYSQL_RELATION_DATA_KEY]` not written.
- [ ] Unit test (`mysql-root`): same as above for `MYSQL_ROOT_RELATION_DATA_KEY`.
- [ ] Integration: relate before primary is elected; verify consumer never sees `host: null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)