### PR TITLE
[MISC] Anchor logs_retention_period validator regex

### DIFF
--- a/kubernetes/src/config.py
+++ b/kubernetes/src/config.py
@@ -172,7 +172,7 @@ class CharmConfig(BaseConfigModel):
     @classmethod
     def logs_retention_period_validator(cls, value: str) -> str:
         """Check logs retention period."""
-        if not re.match(r"auto|\d{1,3}", value) or value == "0":
+        if not re.fullmatch(r"auto|\d{1,3}", value) or value == "0":
             raise ValueError("logs_retention_period must be integer greater than 0 or `auto`")
 
         return value


### PR DESCRIPTION
## Summary

- Found by `charm-find-bugs` skill (AP-021): `re.match(r\"auto|\\d{1,3}\", value)` only anchors the start, so values like `\"autoxx\"`, `\"00\"`, or `\"123abc\"` passed validation.
- Switch to `re.fullmatch` so the whole string must match.

## Test plan

- [ ] Unit test: `\"auto\"`, `\"3\"`, `\"30\"`, `\"999\"` accepted.
- [ ] Unit test: `\"autoxx\"`, `\"00\"`, `\"4xyz\"`, `\"1000\"`, `\"0\"` rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)