### PR TITLE
[MISC] Quote MYSQLD_PARENT_PID in Pebble env dict

### DIFF
--- a/kubernetes/src/charm.py
+++ b/kubernetes/src/charm.py
@@ -222,7 +222,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
                     "group": MYSQL_SYSTEM_GROUP,
                     "kill-delay": "24h",
                     "environment": {
-                        "MYSQLD_PARENT_PID": 1,
+                        "MYSQLD_PARENT_PID": "1",
                     },
                     "requires": [MYSQL_LOG_SERVICE],
                     "after": [MYSQL_LOG_SERVICE],

--- a/kubernetes/tests/unit/test_charm.py
+++ b/kubernetes/tests/unit/test_charm.py
@@ -75,7 +75,7 @@ class TestCharm(unittest.TestCase):
                     "user": "mysql",
                     "group": "mysql",
                     "kill-delay": "24h",
-                    "environment": {"MYSQLD_PARENT_PID": 1},
+                    "environment": {"MYSQLD_PARENT_PID": "1"},
                     "requires": ["mysql"],
                     "after": ["mysql"],
                 },


### PR DESCRIPTION
## Summary

- Found by `charm-find-bugs` skill (AP-005): Pebble's `ServiceDict.environment` is typed `dict[str, str]`, but the layer used the integer literal `1` for `MYSQLD_PARENT_PID`.
- Pebble silently coerces it via the Go YAML decoder, so no runtime impact, but static type checkers flag the dict.
- Quote the value: `\"1\"`.

## Test plan

- [ ] `pyright` / `mypy` no longer flags the env dict in `_pebble_layer`.
- [ ] Existing `_pebble_layer` unit tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)