### PR TITLE
[MISC] fix user deletion on legacy

### DIFF
--- a/kubernetes/src/mysql_k8s_helpers.py
+++ b/kubernetes/src/mysql_k8s_helpers.py
@@ -569,7 +569,7 @@ class MySQL(MySQLBase):
 
         get_label_users_selector = f'%"{label_name}": "{label_value}"%'
         get_label_users_query = (
-            "SELECT user.user, user.host"
+            "SELECT user.user, user.host "  # noqa: S608
             "FROM mysql.user AS user "
             "JOIN information_schema.user_attributes AS attributes "
             "   ON (user.user = attributes.user AND user.host = attributes.host) "

--- a/kubernetes/src/relations/mysql_root.py
+++ b/kubernetes/src/relations/mysql_root.py
@@ -7,7 +7,7 @@ import json
 import logging
 import typing
 
-from charms.mysql.v0.mysql import MySQLCheckUserExistenceError, MySQLDeleteUsersForUnitError
+from charms.mysql.v0.mysql import MySQLCheckUserExistenceError
 from ops.charm import (
     LeaderElectedEvent,
     RelationBrokenEvent,
@@ -20,6 +20,7 @@ from constants import CONTAINER_NAME, LEGACY_MYSQL_ROOT, PASSWORD_LENGTH, ROOT_P
 from mysql_k8s_helpers import (
     MySQLCreateDatabaseError,
     MySQLCreateUserError,
+    MySQLDeleteUsersWithLabelError,
     MySQLEscalateUserPrivilegesError,
 )
 from utils import generate_random_password
@@ -261,7 +262,7 @@ class MySQLRootRelation(Object):
 
         try:
             self.charm._mysql.delete_users_with_label("label", "mysql-root-legacy-relation")
-        except MySQLDeleteUsersForUnitError:
+        except MySQLDeleteUsersWithLabelError:
             self.charm.unit.status = BlockedStatus("Failed to delete database users")
 
         del self.charm.app_peer_data[MYSQL_ROOT_RELATION_USER_KEY]

--- a/kubernetes/tests/unit/test_mysql_k8s_helpers.py
+++ b/kubernetes/tests/unit/test_mysql_k8s_helpers.py
@@ -176,7 +176,7 @@ class TestMySQL(unittest.TestCase):
     def test_delete_users_with_label(self):
         """Test successful execution of delete_users_with_label."""
         search_query = (
-            "SELECT user.user, user.host"
+            "SELECT user.user, user.host "
             "FROM mysql.user AS user "
             "JOIN information_schema.user_attributes AS attributes "
             "   ON (user.user = attributes.user AND user.host = attributes.host) "


### PR DESCRIPTION
Removing the last `mysql-root` legacy relation never cleaned up its
users and left the unit stuck. Two bugs combined:

- `delete_users_with_label` built `SELECT user.user, user.host` +
  `FROM mysql.user ...` with no space between the implicitly
  concatenated literals, producing `user.hostFROM` -- the query always
  failed. The unit test had encoded the same typo, so it never caught
  it.
- `_on_mysql_root_relation_broken` caught `MySQLDeleteUsersForUnitError`
  while `delete_users_with_label` raises `MySQLDeleteUsersWithLabelError`,
  so the (now reachable) error propagated and put the hook into an error
  loop instead of setting BlockedStatus.

Fix the SQL spacing, catch the correct exception, and update the test.

Co-Authored-By: Claude Opus 4.8
