### PR TITLE
[MISC] Fix node count target

### DIFF
--- a/kubernetes/lib/charms/mysql/v0/mysql.py
+++ b/kubernetes/lib/charms/mysql/v0/mysql.py
@@ -2060,7 +2060,7 @@ class MySQLBase(ABC):
             auto_dissolve: (optional) Whether to automatically dissolve the cluster
                 if this is the last instance in the cluster.
         """
-        if self.get_cluster_node_count() == 1:
+        if self.get_cluster_node_count(from_instance=from_instance) == 1:
             self.dissolve_cluster(auto_dissolve)
             return
 

--- a/machines/lib/charms/mysql/v0/mysql.py
+++ b/machines/lib/charms/mysql/v0/mysql.py
@@ -2059,7 +2059,7 @@ class MySQLBase(ABC):
             auto_dissolve: (optional) Whether to automatically dissolve the cluster
                 if this is the last instance in the cluster.
         """
-        if self.get_cluster_node_count() == 1:
+        if self.get_cluster_node_count(from_instance=from_instance) == 1:
             self.dissolve_cluster(auto_dissolve)
             return
 


### PR DESCRIPTION
## Issue

On manual rejoin procedure, fallback path of instance_remove->instance_add fails at the remove step.
The node count is done against self, which is offline on the cluster, detecting single node, which in turns set remove path as cluster dissolve (last node in the cluster), which is not the case.

## Solution

When `from_instance` is set, use it for node count.
