### PR TITLE
[MISC] Migrate CI to Canonical K8s (take 42)

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -8,7 +8,7 @@ on:
       artifact-prefix:
         description: |
           Prefix for charm package GitHub artifact(s)
-          
+
           Use canonical/data-platform-workflows build_charm.yaml to build the charm(s)
         required: true
         type: string
@@ -113,50 +113,19 @@ jobs:
           df --human-readable
       - name: Purge Docker
         # GitHub-hosted Azure runners ship Docker pre-installed and active.
-        # On boot the docker daemon registers an `iptables-nft` ruleset
-        # that includes `table ip filter` with `chain FORWARD { policy
-        # drop; }` and Docker-specific accept rules gated on docker0.
-        #
-        # Canonical K8s + Cilium native routing forwards pod-egress
-        # traffic via the host stack: pod packet enters lxcXXX veth →
-        # Cilium BPF returns TC_ACT_OK (to-stack) → kernel routing →
-        # FORWARD chain → POSTROUTING (CILIUM_POST_nat MASQUERADE) → eth0.
-        #
-        # Both nft and iptables-legacy register handlers at the FORWARD
-        # hook with priority `filter` (= 0). Linux runs ALL registered
-        # nf_hook_ops at the same priority sequentially; ANY DROP verdict
-        # stops processing. Docker's nft FORWARD policy=drop fires
-        # because pod traffic doesn't match any DOCKER-* accept rule
-        # (which are all gated on iif/oif=docker0). Cilium's ACCEPT
-        # rules in iptables-legacy filter FORWARD never get a chance.
+        # Canonical K8s requires "A system with no previous installations
+        # of containerd/docker as this may cause conflicts"
+        # (see https://documentation.ubuntu.com/canonical-kubernetes
+        # /release-1.32/snap/tutorial/getting-started/).
+        # Completely purging Docker requires also
+        # deleting the Docker-specific `iptables-nft` rulesets
+        # created on installation.
         if: ${{ inputs.path-to-charm-directory == 'kubernetes' }}
         timeout-minutes: 5
         run: |
-          sudo apt-get remove --purge -y docker-ce docker-ce-cli containerd.io 2>/dev/null || true
-
-          # Reset FORWARD policy to ACCEPT.
-          # Uses iptables-nft compatibility shim: well-defined semantics,
-          # modifies only the default policy of the existing chain,
-          # and does not flush rules belonging to other tenants of `table ip filter`.
-          sudo iptables-nft -P FORWARD ACCEPT 2>/dev/null || true
-
-          # Flush FORWARD so jumps to DOCKER-* chains disappear, then delete
-          # the chains themselves (chain deletion fails if jumps still
-          # reference them).
-          sudo nft flush chain ip filter FORWARD 2>/dev/null || true
-          for chain in DOCKER DOCKER-USER DOCKER-FORWARD \
-                       DOCKER-ISOLATION-STAGE-1 DOCKER-ISOLATION-STAGE-2 DOCKER-INGRESS; do
-              sudo nft delete chain ip filter "$chain" 2>/dev/null || true
-              sudo nft delete chain ip nat    "$chain" 2>/dev/null || true
-          done
-
-          # Bring down and remove leftover Docker network interfaces.
-          sudo ip link set docker0 down 2>/dev/null || true
-          sudo ip link delete docker0 type bridge 2>/dev/null || true
-
-          # Remove docker state directories so a stray `dockerd` start can't
-          # repopulate the iptables rules from cached state.
-          sudo rm -rf /var/lib/docker /var/lib/containerd /etc/docker /run/docker 2>/dev/null || true
+          sudo apt-get remove --purge -y docker-ce docker-ce-cli containerd.io docker.io containerd 2>/dev/null || true
+          sudo nft flush ruleset
+          sudo ip link delete docker0 2>/dev/null || true
       - name: Remove podman CNI bridge config
         # Ubuntu 24.04 runners ship podman with a CNI bridge config
         # (/etc/cni/net.d/87-podman-bridge.conflist) that sorts

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -111,6 +111,66 @@ jobs:
           rm -r /opt/hostedtoolcache/
           printf '\nDisk usage after cleanup\n'
           df --human-readable
+      - name: Purge Docker
+        # GitHub-hosted Azure runners ship Docker pre-installed and active.
+        # On boot the docker daemon registers an `iptables-nft` ruleset
+        # that includes `table ip filter` with `chain FORWARD { policy
+        # drop; }` and Docker-specific accept rules gated on docker0.
+        #
+        # Canonical K8s + Cilium native routing forwards pod-egress
+        # traffic via the host stack: pod packet enters lxcXXX veth →
+        # Cilium BPF returns TC_ACT_OK (to-stack) → kernel routing →
+        # FORWARD chain → POSTROUTING (CILIUM_POST_nat MASQUERADE) → eth0.
+        #
+        # Both nft and iptables-legacy register handlers at the FORWARD
+        # hook with priority `filter` (= 0). Linux runs ALL registered
+        # nf_hook_ops at the same priority sequentially; ANY DROP verdict
+        # stops processing. Docker's nft FORWARD policy=drop fires
+        # because pod traffic doesn't match any DOCKER-* accept rule
+        # (which are all gated on iif/oif=docker0). Cilium's ACCEPT
+        # rules in iptables-legacy filter FORWARD never get a chance.
+        if: ${{ inputs.path-to-charm-directory == 'kubernetes' }}
+        timeout-minutes: 5
+        run: |
+          sudo apt-get remove --purge -y docker-ce docker-ce-cli containerd.io 2>/dev/null || true
+
+          # Reset FORWARD policy to ACCEPT.
+          # Uses iptables-nft compatibility shim: well-defined semantics,
+          # modifies only the default policy of the existing chain,
+          # and does not flush rules belonging to other tenants of `table ip filter`.
+          sudo iptables-nft -P FORWARD ACCEPT 2>/dev/null || true
+
+          # Flush FORWARD so jumps to DOCKER-* chains disappear, then delete
+          # the chains themselves (chain deletion fails if jumps still
+          # reference them).
+          sudo nft flush chain ip filter FORWARD 2>/dev/null || true
+          for chain in DOCKER DOCKER-USER DOCKER-FORWARD \
+                       DOCKER-ISOLATION-STAGE-1 DOCKER-ISOLATION-STAGE-2 DOCKER-INGRESS; do
+              sudo nft delete chain ip filter "$chain" 2>/dev/null || true
+              sudo nft delete chain ip nat    "$chain" 2>/dev/null || true
+          done
+
+          # Bring down and remove leftover Docker network interfaces.
+          sudo ip link set docker0 down 2>/dev/null || true
+          sudo ip link delete docker0 type bridge 2>/dev/null || true
+
+          # Remove docker state directories so a stray `dockerd` start can't
+          # repopulate the iptables rules from cached state.
+          sudo rm -rf /var/lib/docker /var/lib/containerd /etc/docker /run/docker 2>/dev/null || true
+      - name: Remove podman CNI bridge config
+        # Ubuntu 24.04 runners ship podman with a CNI bridge config
+        # (/etc/cni/net.d/87-podman-bridge.conflist) that sorts
+        # lexicographically before Cilium's config (05-cilium.conflist).
+        # When that file is present, containerd picks the podman bridge
+        # as the active CNI before Cilium is ready, bypassing the
+        # node.kubernetes.io/network-unavailable taint and scheduling
+        # pods onto the 10.88.0.0/16 bridge instead of the Cilium pod
+        # CIDR. Removing the file ensures Cilium is the only CNI plugin
+        # from the start.
+        if: ${{ inputs.path-to-charm-directory == 'kubernetes' }}
+        timeout-minutes: 1
+        run: |
+          sudo rm -f /etc/cni/net.d/87-podman-bridge.conflist
       - name: Checkout
         timeout-minutes: 3
         uses: actions/checkout@v6

--- a/kubernetes/concierge.yaml
+++ b/kubernetes/concierge.yaml
@@ -6,10 +6,6 @@ providers:
     enable: true
     bootstrap: true
     channel: 1.32-classic/stable
-    features:
-      dns:
-      local-storage:
-      network:
     bootstrap-constraints:
       root-disk: 5G
 host:

--- a/kubernetes/concierge.yaml
+++ b/kubernetes/concierge.yaml
@@ -2,12 +2,16 @@ juju:
   model-defaults:
     logging-config: <root>=INFO; unit=DEBUG
 providers:
-  microk8s:
+  k8s:
     enable: true
     bootstrap: true
-    addons:
-      - dns
-      - hostpath-storage
+    channel: 1.32-classic/stable
+    features:
+      dns:
+      local-storage:
+      network:
+    bootstrap-constraints:
+      root-disk: 5G
 host:
   snaps:
     jhack:

--- a/kubernetes/spread.yaml
+++ b/kubernetes/spread.yaml
@@ -110,9 +110,39 @@ environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
   CONCIERGE_JUJU_CHANNEL/juju36: 3.6/stable
 prepare: |
-  # Avoid conflicts with existing Docker and containerd installations
-  apt-get remove -y docker-ce docker-ce-cli containerd.io || true
-  rm -rf /run/containerd
+  # Purge Docker - packages, kernel-resident nft tables, interfaces.
+  #
+  # Why this matters:
+  # GitHub-hosted Azure runners ship Docker pre-installed and active.
+  # On boot the docker daemon registers an `iptables-nft` ruleset
+  # that includes `table ip filter` with `chain FORWARD { policy
+  # drop; }` and Docker-specific accept rules gated on docker0.
+  #
+  # Canonical K8s + Cilium native routing forwards pod-egress
+  # traffic via the host stack: pod packet enters lxcXXX veth →
+  # Cilium BPF returns TC_ACT_OK (to-stack) → kernel routing →
+  # FORWARD chain → POSTROUTING (CILIUM_POST_nat MASQUERADE) → eth0.
+  #
+  # Both nft and iptables-legacy register handlers at the FORWARD
+  # hook with priority `filter` (= 0). Linux runs ALL registered
+  # nf_hook_ops at the same priority sequentially; ANY DROP verdict
+  # stops processing. Docker's nft FORWARD policy=drop fires
+  # because pod traffic doesn't match any DOCKER-* accept rule
+  # (which are all gated on iif/oif=docker0). Cilium's ACCEPT
+  # rules in iptables-legacy filter FORWARD never get a chance.
+  sudo systemctl stop docker.service docker.socket containerd.service 2>/dev/null || true
+  sudo apt-get remove --purge -y docker-ce docker-ce-cli containerd.io 2>/dev/null || true
+  # Wipe Docker's nft tables. `delete table` is idempotent-ish: the
+  # `|| true` covers the case where Docker was never installed.
+  for tbl in 'ip filter' 'ip nat' 'ip mangle' 'ip6 filter' 'ip6 nat' 'ip6 mangle'; do
+      sudo nft delete table $tbl 2>/dev/null || true
+  done
+  # Bring down and remove leftover Docker network interfaces.
+  sudo ip link set docker0 down 2>/dev/null || true
+  sudo ip link delete docker0 type bridge 2>/dev/null || true
+  # Remove docker state directories so a stray `dockerd` start can't
+  # repopulate the iptables rules from cached state.
+  sudo rm -rf /var/lib/docker /var/lib/containerd /etc/docker /run/docker 2>/dev/null || true
   # Ubuntu 24.04 runners ship podman with a CNI bridge config
   # that sorts before Cilium's config,
   # causing pods to land on the wrong network.

--- a/kubernetes/spread.yaml
+++ b/kubernetes/spread.yaml
@@ -60,7 +60,7 @@ backends:
       # For example, with microk8s, using `concierge restore` takes twice as long as this (e.g. 6
       # min instead of 3 min between every spread job)
       juju destroy-model --force --no-wait --destroy-storage --no-prompt testing
-      juju kill-controller --no-prompt concierge-microk8s
+      juju kill-controller --no-prompt concierge-k8s
     restore: |
       rm -rf "$SPREAD_PATH"
 
@@ -110,9 +110,20 @@ environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
   CONCIERGE_JUJU_CHANNEL/juju36: 3.6/stable
 prepare: |
+  # Avoid conflicts with existing Docker and containerd installations
+  apt-get remove -y docker-ce docker-ce-cli containerd.io || true
+  rm -rf /run/containerd
+  # Ubuntu 24.04 runners ship podman with a CNI bridge config
+  # that sorts before Cilium's config,
+  # causing pods to land on the wrong network.
+  # Remove it before k8s bootstrap
+  # so Cilium is the only CNI plugin from the start.
+  rm -f /etc/cni/net.d/87-podman-bridge.conflist
+
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"
   cd "$SPREAD_PATH"
+
   snap install --classic concierge
 
   # Install charmcraft & pipx (on lxd-vm backend)

--- a/kubernetes/spread.yaml
+++ b/kubernetes/spread.yaml
@@ -110,58 +110,6 @@ environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
   CONCIERGE_JUJU_CHANNEL/juju36: 3.6/stable
 prepare: |
-  # Purge Docker - packages, kernel-resident FORWARD policy, interfaces.
-  #
-  # Why this matters:
-  # GitHub-hosted Azure runners ship Docker pre-installed and active.
-  # On boot the docker daemon registers an `iptables-nft` ruleset
-  # that includes `table ip filter` with `chain FORWARD { policy
-  # drop; }` and Docker-specific accept rules gated on docker0.
-  #
-  # Canonical K8s + Cilium native routing forwards pod-egress
-  # traffic via the host stack: pod packet enters lxcXXX veth →
-  # Cilium BPF returns TC_ACT_OK (to-stack) → kernel routing →
-  # FORWARD chain → POSTROUTING (CILIUM_POST_nat MASQUERADE) → eth0.
-  #
-  # Both nft and iptables-legacy register handlers at the FORWARD
-  # hook with priority `filter` (= 0). Linux runs ALL registered
-  # nf_hook_ops at the same priority sequentially; ANY DROP verdict
-  # stops processing. Docker's nft FORWARD policy=drop fires
-  # because pod traffic doesn't match any DOCKER-* accept rule
-  # (which are all gated on iif/oif=docker0). Cilium's ACCEPT
-  # rules in iptables-legacy filter FORWARD never get a chance.
-  sudo systemctl stop docker.service docker.socket containerd.service 2>/dev/null || true
-  sudo apt-get remove --purge -y docker-ce docker-ce-cli containerd.io 2>/dev/null || true
-
-  # Reset FORWARD policy to ACCEPT
-  # Uses iptables-nft compatibility shim:
-  # well-defined semantics, modifies only the default policy of the existing chain,
-  # does not flush rules belonging to other tenants of `table ip filter`.
-  sudo iptables-nft -P FORWARD ACCEPT 2>/dev/null || true
-
-  # Flush FORWARD so jumps to DOCKER-* chains disappear,
-  # then delete the chains themselves
-  # (chain deletion fails if jumps still reference them).
-  sudo nft flush chain ip filter FORWARD 2>/dev/null || true
-  for chain in DOCKER DOCKER-USER DOCKER-FORWARD \
-               DOCKER-ISOLATION-STAGE-1 DOCKER-ISOLATION-STAGE-2 DOCKER-INGRESS; do
-      sudo nft delete chain ip filter "$chain" 2>/dev/null || true
-      sudo nft delete chain ip nat    "$chain" 2>/dev/null || true
-  done
-
-  # Bring down and remove leftover Docker network interfaces.
-  sudo ip link set docker0 down 2>/dev/null || true
-  sudo ip link delete docker0 type bridge 2>/dev/null || true
-  # Remove docker state directories so a stray `dockerd` start can't
-  # repopulate the iptables rules from cached state.
-  sudo rm -rf /var/lib/docker /var/lib/containerd /etc/docker /run/docker 2>/dev/null || true
-  # Ubuntu 24.04 runners ship podman with a CNI bridge config
-  # that sorts before Cilium's config,
-  # causing pods to land on the wrong network.
-  # Remove it before k8s bootstrap
-  # so Cilium is the only CNI plugin from the start.
-  rm -f /etc/cni/net.d/87-podman-bridge.conflist
-
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"
   cd "$SPREAD_PATH"

--- a/kubernetes/spread.yaml
+++ b/kubernetes/spread.yaml
@@ -110,7 +110,7 @@ environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
   CONCIERGE_JUJU_CHANNEL/juju36: 3.6/stable
 prepare: |
-  # Purge Docker - packages, kernel-resident nft tables, interfaces.
+  # Purge Docker - packages, kernel-resident FORWARD policy, interfaces.
   #
   # Why this matters:
   # GitHub-hosted Azure runners ship Docker pre-installed and active.
@@ -132,11 +132,23 @@ prepare: |
   # rules in iptables-legacy filter FORWARD never get a chance.
   sudo systemctl stop docker.service docker.socket containerd.service 2>/dev/null || true
   sudo apt-get remove --purge -y docker-ce docker-ce-cli containerd.io 2>/dev/null || true
-  # Wipe Docker's nft tables. `delete table` is idempotent-ish: the
-  # `|| true` covers the case where Docker was never installed.
-  for tbl in 'ip filter' 'ip nat' 'ip mangle' 'ip6 filter' 'ip6 nat' 'ip6 mangle'; do
-      sudo nft delete table $tbl 2>/dev/null || true
+
+  # Reset FORWARD policy to ACCEPT
+  # Uses iptables-nft compatibility shim:
+  # well-defined semantics, modifies only the default policy of the existing chain,
+  # does not flush rules belonging to other tenants of `table ip filter`.
+  sudo iptables-nft -P FORWARD ACCEPT 2>/dev/null || true
+
+  # Flush FORWARD so jumps to DOCKER-* chains disappear,
+  # then delete the chains themselves
+  # (chain deletion fails if jumps still reference them).
+  sudo nft flush chain ip filter FORWARD 2>/dev/null || true
+  for chain in DOCKER DOCKER-USER DOCKER-FORWARD \
+               DOCKER-ISOLATION-STAGE-1 DOCKER-ISOLATION-STAGE-2 DOCKER-INGRESS; do
+      sudo nft delete chain ip filter "$chain" 2>/dev/null || true
+      sudo nft delete chain ip nat    "$chain" 2>/dev/null || true
   done
+
   # Bring down and remove leftover Docker network interfaces.
   sudo ip link set docker0 down 2>/dev/null || true
   sudo ip link delete docker0 type bridge 2>/dev/null || true

--- a/kubernetes/spread.yaml
+++ b/kubernetes/spread.yaml
@@ -129,6 +129,16 @@ prepare: |
   # Install charmcraft & pipx (on lxd-vm backend)
   concierge prepare --trace
 
+  # k8s status --wait-ready returns as soon as 1 node is ready
+  # (see https://github.com/canonical/k8s-snap/issues/1789)
+  # but Cilium, CoreDNS, and storage may still be initialising
+  k8s kubectl -n kube-system rollout status deployment/cilium-operator --timeout=5m
+  k8s kubectl -n kube-system rollout status deployment/coredns --timeout=5m
+  k8s kubectl -n kube-system rollout status deployment/metrics-server --timeout=5m
+  k8s kubectl -n kube-system rollout status daemonset/cilium --timeout=5m
+  k8s kubectl -n kube-system rollout status daemonset/ck-storage-rawfile-csi-node --timeout=5m
+  k8s kubectl -n kube-system rollout status statefulset/ck-storage-rawfile-csi-controller --timeout=5m
+
   pipx install tox poetry
 prepare-each: |
   cd "$SPREAD_PATH"

--- a/kubernetes/spread.yaml
+++ b/kubernetes/spread.yaml
@@ -162,12 +162,13 @@ prepare: |
   # k8s status --wait-ready returns as soon as 1 node is ready
   # (see https://github.com/canonical/k8s-snap/issues/1789)
   # but Cilium, CoreDNS, and storage may still be initialising
-  k8s kubectl -n kube-system rollout status deployment/cilium-operator --timeout=5m
-  k8s kubectl -n kube-system rollout status deployment/coredns --timeout=5m
-  k8s kubectl -n kube-system rollout status deployment/metrics-server --timeout=5m
-  k8s kubectl -n kube-system rollout status daemonset/cilium --timeout=5m
-  k8s kubectl -n kube-system rollout status daemonset/ck-storage-rawfile-csi-node --timeout=5m
-  k8s kubectl -n kube-system rollout status statefulset/ck-storage-rawfile-csi-controller --timeout=5m
+  for res in deployment/cilium-operator deployment/coredns deployment/metrics-server daemonset/cilium daemonset/ck-storage-rawfile-csi-node statefulset/ck-storage-rawfile-csi-controller; do
+      if k8s kubectl -n kube-system get "$res" >/dev/null 2>&1; then
+          k8s kubectl -n kube-system rollout status "$res" --timeout=5m
+      else
+          echo "Skipping rollout status for missing $res"
+      fi
+  done
 
   pipx install tox poetry
 prepare-each: |

--- a/kubernetes/tests/integration/integration/high_availability/conftest.py
+++ b/kubernetes/tests/integration/integration/high_availability/conftest.py
@@ -60,7 +60,9 @@ def deploy_chaos_mesh(namespace: str) -> None:
             with attempt:
                 output = subprocess.check_output(
                     [
-                        "microk8s.kubectl",
+                        "sudo",
+                        "k8s",
+                        "kubectl",
                         "get",
                         "pods",
                         f"--namespace={namespace}",

--- a/kubernetes/tests/integration/integration/high_availability/scripts/deploy_chaos_mesh.sh
+++ b/kubernetes/tests/integration/integration/high_availability/scripts/deploy_chaos_mesh.sh
@@ -12,13 +12,13 @@ fi
 
 deploy_chaos_mesh() {
 	echo "adding chaos-mesh helm repo"
-	microk8s.helm3 repo add chaos-mesh https://charts.chaos-mesh.org
+	sudo k8s helm repo add chaos-mesh https://charts.chaos-mesh.org
 	
 	echo "installing chaos-mesh"
-        microk8s.helm3 install chaos-mesh chaos-mesh/chaos-mesh \
+        sudo k8s helm install chaos-mesh chaos-mesh/chaos-mesh \
           --namespace="${chaos_mesh_ns}" \
           --set chaosDaemon.runtime=containerd \
-          --set chaosDaemon.socketPath=/var/snap/microk8s/common/run/containerd.sock \
+          --set chaosDaemon.socketPath=/run/containerd/containerd.sock \
           --set dashboard.create=false \
           --version "${chaos_mesh_version}" \
           --set clusterScoped=false \

--- a/kubernetes/tests/integration/integration/high_availability/scripts/destroy_chaos_mesh.sh
+++ b/kubernetes/tests/integration/integration/high_availability/scripts/destroy_chaos_mesh.sh
@@ -11,43 +11,43 @@ fi
 
 destroy_chaos_mesh() {
 	echo "deleting api-resources"
-	for i in $(microk8s.kubectl api-resources | awk '/chaos-mesh/ {print $1}'); do
-	    timeout 30 microk8s.kubectl delete "${i}" --all --all-namespaces || true
+	for i in $(sudo k8s kubectl api-resources | awk '/chaos-mesh/ {print $1}'); do
+	    timeout 30 sudo k8s kubectl delete "${i}" --all --all-namespaces || true
 	done
 
-	if microk8s.kubectl get mutatingwebhookconfiguration | grep -q 'chaos-mesh-mutation'; then
-		timeout 30 microk8s.kubectl delete mutatingwebhookconfiguration chaos-mesh-mutation || true
+	if sudo k8s kubectl get mutatingwebhookconfiguration | grep -q 'chaos-mesh-mutation'; then
+		timeout 30 sudo k8s kubectl delete mutatingwebhookconfiguration chaos-mesh-mutation || true
 	fi
 
-	if microk8s.kubectl get validatingwebhookconfiguration | grep -q 'chaos-mesh-validation-auth'; then
-		timeout 30 microk8s.kubectl delete validatingwebhookconfiguration chaos-mesh-validation-auth || true
+	if sudo k8s kubectl get validatingwebhookconfiguration | grep -q 'chaos-mesh-validation-auth'; then
+		timeout 30 sudo k8s kubectl delete validatingwebhookconfiguration chaos-mesh-validation-auth || true
 	fi
 
-	if microk8s.kubectl get validatingwebhookconfiguration | grep -q 'chaos-mesh-validation'; then
-		timeout 30 microk8s.kubectl delete validatingwebhookconfiguration chaos-mesh-validation || true
+	if sudo k8s kubectl get validatingwebhookconfiguration | grep -q 'chaos-mesh-validation'; then
+		timeout 30 sudo k8s kubectl delete validatingwebhookconfiguration chaos-mesh-validation || true
 	fi
 
-	if microk8s.kubectl get clusterrolebinding | grep -q 'chaos-mesh'; then
+	if sudo k8s kubectl get clusterrolebinding | grep -q 'chaos-mesh'; then
 		echo "deleting clusterrolebindings"
-		readarray -t args < <(microk8s.kubectl get clusterrolebinding | awk '/chaos-mesh/ {print $1}')
-		timeout 30 microk8s.kubectl delete clusterrolebinding "${args[@]}" || true
+		readarray -t args < <(sudo k8s kubectl get clusterrolebinding | awk '/chaos-mesh/ {print $1}')
+		timeout 30 sudo k8s kubectl delete clusterrolebinding "${args[@]}" || true
 	fi
 
-	if microk8s.kubectl get clusterrole | grep -q 'chaos-mesh'; then
+	if sudo k8s kubectl get clusterrole | grep -q 'chaos-mesh'; then
 		echo "deleting clusterroles"
-		readarray -t args < <(microk8s.kubectl get clusterrole | awk '/chaos-mesh/ {print $1}')
-		timeout 30 microk8s.kubectl delete clusterrole "${args[@]}" || true
+		readarray -t args < <(sudo k8s kubectl get clusterrole | awk '/chaos-mesh/ {print $1}')
+		timeout 30 sudo k8s kubectl delete clusterrole "${args[@]}" || true
 	fi
 
-	if microk8s.kubectl get crd | grep -q 'chaos-mesh.org'; then
+	if sudo k8s kubectl get crd | grep -q 'chaos-mesh.org'; then
 		echo "deleting crds"
-		readarray -t args < <(microk8s.kubectl get crd | awk '/chaos-mesh.org/ {print $1}')
-		timeout 30 microk8s.kubectl delete crd "${args[@]}" || true
+		readarray -t args < <(sudo k8s kubectl get crd | awk '/chaos-mesh.org/ {print $1}')
+		timeout 30 sudo k8s kubectl delete crd "${args[@]}" || true
 	fi
 
-	if [ -n "${chaos_mesh_ns}" ] && microk8s.helm3 repo list --namespace="${chaos_mesh_ns}" | grep -q 'chaos-mesh'; then
+	if [ -n "${chaos_mesh_ns}" ] && sudo k8s helm repo list --namespace="${chaos_mesh_ns}" | grep -q 'chaos-mesh'; then
 		echo "uninstalling chaos-mesh helm repo"
-		microk8s.helm3 uninstall chaos-mesh --namespace="${chaos_mesh_ns}" || true
+		sudo k8s helm uninstall chaos-mesh --namespace="${chaos_mesh_ns}" || true
 	fi
 }
 

--- a/kubernetes/tests/integration/integration/high_availability/test_replication_logs_rotation.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_replication_logs_rotation.py
@@ -192,7 +192,9 @@ def read_unit_file(juju: Juju, unit_name: str, container: str, file_path: str) -
     with tempfile.NamedTemporaryFile(mode="r+", dir=Path.home()) as temp_file:
         subprocess.run(
             [
-                "microk8s.kubectl",
+                "sudo",
+                "k8s",
+                "kubectl",
                 "cp",
                 f"--namespace={juju.model}",
                 f"--container={container}",
@@ -223,7 +225,9 @@ def write_unit_file(juju: Juju, unit_name: str, container: str, file_path: str, 
 
         subprocess.check_call(
             [
-                "microk8s.kubectl",
+                "sudo",
+                "k8s",
+                "kubectl",
                 "cp",
                 f"--namespace={juju.model}",
                 f"--container={container}",

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_network_cut.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_network_cut.py
@@ -126,11 +126,8 @@ def create_instance_isolation_config(juju: Juju, unit_name: str) -> None:
             temp_file.write(str.encode(template))
             temp_file.flush()
 
-        env = os.environ
-        env["KUBECONFIG"] = os.path.expanduser("~/.kube/config")
-
         try:
-            subprocess.check_output(["microk8s.kubectl", "apply", "-f", temp_file.name], env=env)
+            subprocess.check_output(["sudo", "k8s", "kubectl", "apply", "-f", temp_file.name])
         except subprocess.CalledProcessError as e:
             logging.error(e.output)
             logging.error(e.stderr)
@@ -139,16 +136,14 @@ def create_instance_isolation_config(juju: Juju, unit_name: str) -> None:
 
 def remove_instance_isolation_config(juju: Juju) -> None:
     """Delete the NetworkChaos that is isolating the primary unit of the cluster."""
-    env = os.environ
-    env["KUBECONFIG"] = os.path.expanduser("~/.kube/config")
-
     subprocess.check_output(
         [
-            "microk8s.kubectl",
+            "sudo",
+            "k8s",
+            "kubectl",
             f"--namespace={juju.model}",
             "delete",
             "networkchaos",
             "network-loss-primary",
         ],
-        env=env,
     )


### PR DESCRIPTION
## Issue

See previous attempts: #142 , #297 

After it was ruled out that Concierge + Spread were the source of DNS issues https://github.com/canonical/mysql-operators/pull/142#issuecomment-4614209505, I started a long debugging session to eventually find out that one of the culprits was some legacy Podman configuration that was interfering with Kubernetes networking.

I also found that `k8s status --wait-ready` is not a fully reliable indicator https://github.com/canonical/k8s-snap/issues/1789

But the real game changer was properly purging Docker. Turns out `apt-get remove` (without `--purge`) does not flush the kernel-resident nft tables nor the network interface, and [similarly to the connectivity conflicts between Docker and LXD](https://documentation.ubuntu.com/lxd/default/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker), this confuses Cilium, which is present in Canonical K8s but not MicroK8s.

## Solution

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
