### PR TITLE
[DPE-10337] Use non-stale data node for cluster belonging

### DIFF
--- a/kubernetes/lib/charms/mysql/v0/mysql.py
+++ b/kubernetes/lib/charms/mysql/v0/mysql.py
@@ -1937,14 +1937,29 @@ class MySQLBase(ABC):
             unit_status = unit_spec.get("status")
             return unit_status in (InstanceState.ONLINE, InstanceState.RECOVERING)
 
-    def instance_belongs_to_cluster(self, unit_label: str) -> bool:
+    def instance_belongs_to_cluster(
+        self, unit_label: str, from_instance: str | None = None
+    ) -> bool:
         """Check if instance belongs to cluster independently of current state.
+
+        Membership is queried from ``from_instance`` (typically the cluster
+        primary), since the local instance metadata can be stale.
 
         Args:
             unit_label: The label of the unit to check.
+            from_instance: Instance to query cluster metadata from. Defaults to
+                the local instance.
         """
+        if from_instance:
+            client = InstanceClient(
+                self._build_instance_tcp_executor(from_instance),
+                self._quoter,
+            )
+        else:
+            client = self._instance_client_tcp
+
         try:
-            labels = self._instance_client_tcp.get_cluster_instance_labels(self.cluster_name)
+            labels = client.get_cluster_instance_labels(self.cluster_name)
         except ExecutionError:
             return False
         else:

--- a/kubernetes/src/charm.py
+++ b/kubernetes/src/charm.py
@@ -908,7 +908,8 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             return
 
         if not self._mysql.instance_belongs_to_cluster(
-            self.unit_label, from_instance=cluster_primary
+            unit_label=self.unit_label,
+            from_instance=cluster_primary,
         ):
             logger.warning("Instance does not belong to the cluster. Cannot perform manual rejoin")
             return

--- a/kubernetes/src/charm.py
+++ b/kubernetes/src/charm.py
@@ -966,6 +966,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         if member_state == "UNKNOWN" or member_state == InstanceState.RECOVERING:
             # avoid changing status while tls is being set up or charm is being initialized
             logger.info(f"Unit {member_state=}")
+            self.unit.status = MaintenanceStatus(member_state)
             return True
 
         # avoid changing status while async replication is setting up

--- a/kubernetes/src/charm.py
+++ b/kubernetes/src/charm.py
@@ -902,13 +902,15 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         It is supposed to be called when the MySQL 8.0.21+ auto-rejoin attempts have been exhausted,
         on an OFFLINE replica that still belongs to the cluster
         """
-        if not self._mysql.instance_belongs_to_cluster(self.unit_label):
-            logger.warning("Instance does not belong to the cluster. Cannot perform manual rejoin")
-            return
-
         cluster_primary = self._get_primary_from_online_peer()
         if not cluster_primary:
             logger.warning("Instance does not have ONLINE peers. Cannot perform manual rejoin")
+            return
+
+        if not self._mysql.instance_belongs_to_cluster(
+            self.unit_label, from_instance=cluster_primary
+        ):
+            logger.warning("Instance does not belong to the cluster. Cannot perform manual rejoin")
             return
 
         # add random delay to mitigate collisions when multiple units are rejoining

--- a/machines/lib/charms/mysql/v0/mysql.py
+++ b/machines/lib/charms/mysql/v0/mysql.py
@@ -1936,14 +1936,29 @@ class MySQLBase(ABC):
             unit_status = unit_spec.get("status")
             return unit_status in (InstanceState.ONLINE, InstanceState.RECOVERING)
 
-    def instance_belongs_to_cluster(self, unit_label: str) -> bool:
+    def instance_belongs_to_cluster(
+        self, unit_label: str, from_instance: str | None = None
+    ) -> bool:
         """Check if instance belongs to cluster independently of current state.
+
+        Membership is queried from ``from_instance`` (typically the cluster
+        primary), since the local instance metadata can be stale.
 
         Args:
             unit_label: The label of the unit to check.
+            from_instance: Instance to query cluster metadata from. Defaults to
+                the local instance.
         """
+        if from_instance:
+            client = InstanceClient(
+                self._build_instance_tcp_executor(from_instance),
+                self._quoter,
+            )
+        else:
+            client = self._instance_client_tcp
+
         try:
-            labels = self._instance_client_tcp.get_cluster_instance_labels(self.cluster_name)
+            labels = client.get_cluster_instance_labels(self.cluster_name)
         except ExecutionError:
             return False
         else:

--- a/machines/src/charm.py
+++ b/machines/src/charm.py
@@ -504,13 +504,15 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         It is supposed to be called when the MySQL 8.0.21+ auto-rejoin attempts have been exhausted,
         on an OFFLINE replica that still belongs to the cluster
         """
-        if not self._mysql.instance_belongs_to_cluster(self.unit_label):
-            logger.warning("Instance does not belong to the cluster. Cannot perform manual rejoin")
-            return
-
         cluster_primary = self._get_primary_from_online_peer()
         if not cluster_primary:
             logger.warning("Instance does not have ONLINE peers. Cannot perform manual rejoin")
+            return
+
+        if not self._mysql.instance_belongs_to_cluster(
+            self.unit_label, from_instance=cluster_primary
+        ):
+            logger.warning("Instance does not belong to the cluster. Cannot perform manual rejoin")
             return
 
         # add random delay to mitigate collisions when multiple units are rejoining

--- a/machines/src/charm.py
+++ b/machines/src/charm.py
@@ -510,7 +510,8 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             return
 
         if not self._mysql.instance_belongs_to_cluster(
-            self.unit_label, from_instance=cluster_primary
+            unit_label=self.unit_label,
+            from_instance=cluster_primary,
         ):
             logger.warning("Instance does not belong to the cluster. Cannot perform manual rejoin")
             return


### PR DESCRIPTION
## Issue

See #344

## Solution

- Use metadata from active/primary unit to check instance in the cluster
- Bonus: k8s charm was not setting unknown|recovering unit status

Fix #344
