### PR TITLE
[MISC] 8.4 - Disable async-replication upgrade test

### DIFF
--- a/kubernetes/tests/spread/integration/test_async_replication_upgrade.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_async_replication_upgrade.py/task.yaml
@@ -2,6 +2,8 @@ summary: test_async_replication_upgrade.py
 environment:
   TEST_MODULE: high_availability/test_async_replication_upgrade.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
+  # TODO: Uncomment when separation of storage has been released to the `8.4/edge` channel
+  # tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
+  exit 0
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_async_replication_upgrade.py/task.yaml
+++ b/machines/tests/spread/integration/test_async_replication_upgrade.py/task.yaml
@@ -2,6 +2,8 @@ summary: test_async_replication_upgrade.py
 environment:
   TEST_MODULE: high_availability/test_async_replication_upgrade.py
 execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
+  # TODO: Uncomment when separation of storage has been released to the `8.4/edge` channel
+  # tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
+  exit 0
 artifacts:
   - allure-results


### PR DESCRIPTION
This PR temporarily disables the async-replication upgrade tests in order to have new revisions of the MySQL 8.4 operators published to the `8.4/edge` channels. These tests should have been disabled, alongside the _regular_ upgrade tests when _separation of storage_ was introduced (see PR https://github.com/canonical/mysql-operators/pull/257).