### PR TITLE
[MISC] 8.4 - Enable upgrade tests again

### DIFF
--- a/kubernetes/tests/spread/integration/test_async_replication_upgrade.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_async_replication_upgrade.py/task.yaml
@@ -2,8 +2,6 @@ summary: test_async_replication_upgrade.py
 environment:
   TEST_MODULE: high_availability/test_async_replication_upgrade.py
 execute: |
-  # TODO: Uncomment when separation of storage has been released to the `8.4/edge` channel
-  # tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
-  exit 0
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/kubernetes/tests/spread/integration/test_upgrade.py/task.yaml
+++ b/kubernetes/tests/spread/integration/test_upgrade.py/task.yaml
@@ -2,8 +2,6 @@ summary: test_upgrade.py
 environment:
   TEST_MODULE: high_availability/test_upgrade.py
 execute: |
-  # TODO: Uncomment when separation of storage has been released to the `8.4/edge` channel
-  # tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
-  exit 0
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_async_replication_upgrade.py/task.yaml
+++ b/machines/tests/spread/integration/test_async_replication_upgrade.py/task.yaml
@@ -2,8 +2,6 @@ summary: test_async_replication_upgrade.py
 environment:
   TEST_MODULE: high_availability/test_async_replication_upgrade.py
 execute: |
-  # TODO: Uncomment when separation of storage has been released to the `8.4/edge` channel
-  # tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
-  exit 0
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results

--- a/machines/tests/spread/integration/test_upgrade.py/task.yaml
+++ b/machines/tests/spread/integration/test_upgrade.py/task.yaml
@@ -2,8 +2,6 @@ summary: test_upgrade.py
 environment:
   TEST_MODULE: high_availability/test_upgrade.py
 execute: |
-  # TODO: Uncomment when separation of storage has been released to the `8.4/edge` channel
-  # tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
-  exit 0
+  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results


### PR DESCRIPTION
This PR enables _upgrade_ integration tests again, after the version of the Charmed MySQL 8.4 operator containing the _separation of storage_ feature got released into the `8.4/edge` channel.
