### PR TITLE
[DPE-9259] (8.4/edge) Safe auto-recover from no_quorum

### DIFF
--- a/kubernetes/lib/charms/mysql/v0/mysql.py
+++ b/kubernetes/lib/charms/mysql/v0/mysql.py
@@ -863,8 +863,13 @@ class MySQLCharmBase(CharmBase, ABC):
         if self.unit_peer_data.get("member-role") != InstanceRole.PRIMARY:
             return ops.ActiveStatus("")
 
-        if self._mysql.is_cluster_replica() is False:
+        is_replica = self._mysql.is_cluster_replica()
+        if is_replica is False:
             return ops.ActiveStatus("Primary")
+        if is_replica is None:
+            # cluster-set status unreadable (e.g. lost quorum): a primary that
+            # cannot accept writes. Avoid mislabelling it as "Standby".
+            return ops.ActiveStatus("Primary (read-only)")
 
         status = self._mysql.get_replica_cluster_status()
         if status == ClusterGlobalStatus.OK:
@@ -2311,6 +2316,13 @@ class MySQLBase(ABC):
         """Start Group replication on the instance."""
         with suppress(ExecutionError):
             self._instance_client_tcp.start_instance_replication()
+
+    def is_cluster_in_no_quorum(self) -> bool:
+        """Check whether the cluster has lost quorum as seen from this instance."""
+        status = self.get_cluster_status()
+        if not status:
+            return False
+        return status["defaultReplicaSet"]["status"] == ClusterStatus.NO_QUORUM
 
     def force_quorum_from_instance(self) -> None:
         """Force quorum from the current instance.

--- a/kubernetes/src/charm.py
+++ b/kubernetes/src/charm.py
@@ -943,8 +943,8 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
 
         Returns:
             bool
-                True if the handling worked correctly and the caller can continue,
-                False otherwise.
+                False if the handling worked correctly and the caller can continue,
+                True otherwise.
 
         """
         single_node_cluster = self.only_one_cluster_node_thats_uninitialized
@@ -1121,7 +1121,9 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         self.unit_peer_data["member-state"] = state
         self.set_unit_status(self.build_unit_workload_status())
 
-        if self._handle_potential_cluster_crash_scenario(state):
+        # TODO: Logic here is almost the opposite as the machines charm, but not quite
+        # We should review and fix it
+        if not self._handle_potential_cluster_crash_scenario(state):
             self._set_app_status(state)
 
     def _set_app_status(self, state: str) -> None:

--- a/kubernetes/src/charm.py
+++ b/kubernetes/src/charm.py
@@ -938,7 +938,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         self._create_cluster()
         self._mysql.reconcile_binlogs_collection(force_restart=True)
 
-    def _handle_potential_cluster_crash_scenario(self, state: str) -> bool:
+    def _handle_potential_cluster_crash_scenario(self, state: str) -> bool:  # noqa: C901
         """Handle potential full cluster crash scenarios.
 
         Returns:
@@ -946,6 +946,30 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         """
         single_node_cluster = self.only_one_cluster_node_thats_uninitialized
         if not single_node_cluster and not self.cluster_initialized:
+            return True
+
+        # A surviving member can stay ONLINE in its local view while the
+        # cluster has lost quorum (majority UNREACHABLE). The reboot-from-
+        # complete-outage path below only fires on state == OFFLINE, so
+        # without this the leader stays stuck and the cluster never recovers.
+        if state == InstanceState.ONLINE and self._mysql.is_cluster_in_no_quorum():
+            logger.warning("Cluster has lost quorum")
+            try:
+                # reboot_cluster_from_complete_outage rejects an instance whose
+                # GR is still running; drop it to OFFLINE first.
+                self._mysql.stop_group_replication()
+                if self.unit.is_leader():
+                    # run on leader only for coordinate recovery
+                    logger.warning("Attempting reboot from complete outage")
+                    self._mysql.reboot_from_complete_outage()
+                    return False
+                else:
+                    # set offline state and delegate reboot from outage to leader
+                    logger.warning("Set instance to offline")
+                    self.unit_peer_data["member-state"] = InstanceState.OFFLINE
+            except MySQLRebootFromCompleteOutageError:
+                logger.error("Failed to reboot cluster from complete outage")
+                self.set_unit_status(BlockedStatus("failed to recover cluster"))
             return True
 
         if state == InstanceState.RECOVERING:

--- a/kubernetes/src/charm.py
+++ b/kubernetes/src/charm.py
@@ -963,10 +963,6 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
                     logger.warning("Attempting reboot from complete outage")
                     self._mysql.reboot_from_complete_outage()
                     return False
-                else:
-                    # set offline state and delegate reboot from outage to leader
-                    logger.warning("Set instance to offline")
-                    self.unit_peer_data["member-state"] = InstanceState.OFFLINE
             except MySQLRebootFromCompleteOutageError:
                 logger.error("Failed to reboot cluster from complete outage")
                 self.set_unit_status(BlockedStatus("failed to recover cluster"))

--- a/kubernetes/src/charm.py
+++ b/kubernetes/src/charm.py
@@ -12,6 +12,7 @@ if is_wrong_architecture() and __name__ == "__main__":
 
 import logging
 import random
+import socket
 from time import sleep
 
 import charm_refresh
@@ -400,6 +401,21 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             raise RuntimeError("Can't get fully qualified domain name for unit")
 
         return dotappend(unit_dns_domain)
+
+    def _all_peers_reachable(self) -> bool:
+        """Return True if all peer units respond on MySQL port 3306.
+
+        Quorum recovery must not run when peers are unreachable — that scenario
+        indicates a network partition where the remote side may still be healthy.
+        """
+        for unit in self.peers.units:
+            address = self.get_unit_address(unit)
+            try:
+                with socket.create_connection((address, 3306), timeout=2):
+                    pass
+            except OSError:
+                return False
+        return True
 
     def is_unit_busy(self) -> bool:
         """Returns whether the unit is busy."""
@@ -956,7 +972,10 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         # complete-outage path below only fires on state == OFFLINE, so
         # without this the leader stays stuck and the cluster never recovers.
         if state == InstanceState.ONLINE and self._mysql.is_cluster_in_no_quorum():
-            logger.warning("Cluster has lost quorum")
+            logger.warning("Cluster has no quorum")
+            if self.peers.units and not self._all_peers_reachable():
+                logger.warning("Skipping quorum recovery: not all peers reachable")
+                return True
             try:
                 # reboot_cluster_from_complete_outage rejects an instance whose
                 # GR is still running; drop it to OFFLINE first.

--- a/kubernetes/src/charm.py
+++ b/kubernetes/src/charm.py
@@ -942,7 +942,10 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         """Handle potential full cluster crash scenarios.
 
         Returns:
-            bool indicating whether the caller should return
+            bool
+                True if the handling worked correctly and the caller can continue,
+                False otherwise.
+
         """
         single_node_cluster = self.only_one_cluster_node_thats_uninitialized
         if not single_node_cluster and not self.cluster_initialized:
@@ -1119,9 +1122,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         self.set_unit_status(self.build_unit_workload_status())
 
         if self._handle_potential_cluster_crash_scenario(state):
-            return
-
-        self._set_app_status(state)
+            self._set_app_status(state)
 
     def _set_app_status(self, state: str) -> None:
         """Set the application status based on the cluster state."""

--- a/kubernetes/tests/integration/helpers_ha.py
+++ b/kubernetes/tests/integration/helpers_ha.py
@@ -660,60 +660,6 @@ def stop_mysqld_service(juju: Juju, unit_name: str) -> None:
                 raise Exception("Failed to stop the mysqld process")
 
 
-def force_kill_mysqld_service(juju: Juju, unit_name: str) -> None:
-    """SIGKILL mysqld and suppress Pebble's auto-restart.
-
-    `pebble stop` on its own delivers SIGTERM,
-    which mysqld converts into a graceful Group Replication shutdown.
-    To sustain `NO_QUORUM` we need the killed unit
-    to appear UNREACHABLE to the survivor,
-    which requires bypassing graceful shutdown via SIGKILL.
-
-    However, SIGKILL alone is insufficient because the charm's Pebble layer
-    relies on Pebble's default `on-failure: restart`,
-    which would bring mysqld back within seconds.
-    Following SIGKILL with `pebble stop` transitions the service
-    to user-stopped state: when issued while the service is in `backoff`
-    (waiting to retry after the unexpected exit),
-    Pebble cancels the pending restart without sending any signal;
-    if Pebble has already forked a replacement that is still in `starting`,
-    SIGTERM aborts startup before the GR plugin loads,
-    so no graceful leave occurs.
-    The 24h `kill-delay` only matters once the service is fully `running`
-    with GR active, which mysqld startup (5-30s) cannot reach before our
-    `pebble stop` lands (typically <2s after SIGKILL).
-
-    Args:
-        juju: The Juju model.
-        unit_name: The name of the unit.
-
-    """
-    # `pkill -x` (exact process-name match), NOT `-f` (full cmdline match):
-    # `juju.ssh` wraps the command in a shell whose cmdline
-    # literally contains the string "mysqld" (from our pkill arguments),
-    # so `-f` would match - and SIGKILL - the shell itself, returning exit 137
-    # before pkill finishes signalling mysqld
-    juju.ssh(
-        command=f"pkill -x {MYSQLD_SERVICE} --signal SIGKILL",
-        target=unit_name,
-        container=CONTAINER_NAME,
-    )
-    juju.ssh(
-        command=f"pebble stop {MYSQLD_SERVICE}",
-        target=unit_name,
-        container=CONTAINER_NAME,
-    )
-
-    # Single verification: by the time `pebble stop` returns,
-    # the service is in `stopped` state
-    # If mysqld is still alive after a brief settle window,
-    # Pebble lost the race, so fail fast rather than masking with retries
-    for attempt in Retrying(stop=stop_after_attempt(5), wait=wait_fixed(2), reraise=True):
-        with attempt:
-            if get_unit_process_id(juju, unit_name, MYSQLD_SERVICE) is not None:
-                raise Exception(f"mysqld still alive on {unit_name} after SIGKILL + pebble stop")
-
-
 def wait_for_apps_status(jubilant_status_func: JujuAppsStatusFn, *apps: str) -> JujuModelStatusFn:
     """Waits for Juju agents to be idle, and for applications to reach a certain status.
 
@@ -753,3 +699,37 @@ def create_app_secret(
     secret_uri = juju.add_secret(secret_name, content=contents)
     juju.grant_secret(secret_uri, app_name)
     return secret_uri
+
+
+def force_kill_mysqld_service(juju: Juju, unit_name: str) -> None:
+    """SIGKILL mysqld and suppress Pebble's auto-restart.
+
+    Args:
+        juju: The Juju model.
+        unit_name: The name of the unit.
+
+    """
+    # `pkill -x` (exact process-name match), NOT `-f` (full cmdline match):
+    # `juju.ssh` wraps the command in a shell whose cmdline
+    # literally contains the string "mysqld" (from our pkill arguments),
+    # so `-f` would match - and SIGKILL - the shell itself, returning exit 137
+    # before pkill finishes signalling mysqld
+    juju.ssh(
+        command=f"pkill -x {MYSQLD_SERVICE} --signal SIGKILL",
+        target=unit_name,
+        container=CONTAINER_NAME,
+    )
+    juju.ssh(
+        command=f"pebble stop {MYSQLD_SERVICE}",
+        target=unit_name,
+        container=CONTAINER_NAME,
+    )
+
+    # Single verification: by the time `pebble stop` returns,
+    # the service is in `stopped` state
+    # If mysqld is still alive after a brief settle window,
+    # Pebble lost the race, so fail fast rather than masking with retries
+    for attempt in Retrying(stop=stop_after_attempt(5), wait=wait_fixed(2), reraise=True):
+        with attempt:
+            if get_unit_process_id(juju, unit_name, MYSQLD_SERVICE) is not None:
+                raise Exception(f"mysqld still alive on {unit_name} after SIGKILL + pebble stop")

--- a/kubernetes/tests/integration/helpers_ha.py
+++ b/kubernetes/tests/integration/helpers_ha.py
@@ -709,6 +709,7 @@ def force_kill_mysqld_service(juju: Juju, unit_name: str) -> None:
         unit_name: The name of the unit.
 
     """
+    # TODO: Merge with exec_k8s_container_command
     # `pkill -x` (exact process-name match), NOT `-f` (full cmdline match):
     # `juju.ssh` wraps the command in a shell whose cmdline
     # literally contains the string "mysqld" (from our pkill arguments),

--- a/kubernetes/tests/integration/helpers_ha.py
+++ b/kubernetes/tests/integration/helpers_ha.py
@@ -660,6 +660,60 @@ def stop_mysqld_service(juju: Juju, unit_name: str) -> None:
                 raise Exception("Failed to stop the mysqld process")
 
 
+def force_kill_mysqld_service(juju: Juju, unit_name: str) -> None:
+    """SIGKILL mysqld and suppress Pebble's auto-restart.
+
+    `pebble stop` on its own delivers SIGTERM,
+    which mysqld converts into a graceful Group Replication shutdown.
+    To sustain `NO_QUORUM` we need the killed unit
+    to appear UNREACHABLE to the survivor,
+    which requires bypassing graceful shutdown via SIGKILL.
+
+    However, SIGKILL alone is insufficient because the charm's Pebble layer
+    relies on Pebble's default `on-failure: restart`,
+    which would bring mysqld back within seconds.
+    Following SIGKILL with `pebble stop` transitions the service
+    to user-stopped state: when issued while the service is in `backoff`
+    (waiting to retry after the unexpected exit),
+    Pebble cancels the pending restart without sending any signal;
+    if Pebble has already forked a replacement that is still in `starting`,
+    SIGTERM aborts startup before the GR plugin loads,
+    so no graceful leave occurs.
+    The 24h `kill-delay` only matters once the service is fully `running`
+    with GR active, which mysqld startup (5-30s) cannot reach before our
+    `pebble stop` lands (typically <2s after SIGKILL).
+
+    Args:
+        juju: The Juju model.
+        unit_name: The name of the unit.
+
+    """
+    # `pkill -x` (exact process-name match), NOT `-f` (full cmdline match):
+    # `juju.ssh` wraps the command in a shell whose cmdline
+    # literally contains the string "mysqld" (from our pkill arguments),
+    # so `-f` would match - and SIGKILL - the shell itself, returning exit 137
+    # before pkill finishes signalling mysqld
+    juju.ssh(
+        command=f"pkill -x {MYSQLD_SERVICE} --signal SIGKILL",
+        target=unit_name,
+        container=CONTAINER_NAME,
+    )
+    juju.ssh(
+        command=f"pebble stop {MYSQLD_SERVICE}",
+        target=unit_name,
+        container=CONTAINER_NAME,
+    )
+
+    # Single verification: by the time `pebble stop` returns,
+    # the service is in `stopped` state
+    # If mysqld is still alive after a brief settle window,
+    # Pebble lost the race, so fail fast rather than masking with retries
+    for attempt in Retrying(stop=stop_after_attempt(5), wait=wait_fixed(2), reraise=True):
+        with attempt:
+            if get_unit_process_id(juju, unit_name, MYSQLD_SERVICE) is not None:
+                raise Exception(f"mysqld still alive on {unit_name} after SIGKILL + pebble stop")
+
+
 def wait_for_apps_status(jubilant_status_func: JujuAppsStatusFn, *apps: str) -> JujuModelStatusFn:
     """Waits for Juju agents to be idle, and for applications to reach a certain status.
 

--- a/kubernetes/tests/integration/integration/high_availability/test_primary_switchover.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_primary_switchover.py
@@ -3,7 +3,6 @@
 
 import logging
 import os
-import subprocess
 from time import sleep
 
 import jubilant
@@ -14,9 +13,11 @@ from ...helpers_ha import (
     CHARM_METADATA,
     get_app_name,
     get_app_units,
-    get_mysql_instance_label,
     get_mysql_primary_unit,
     load_mysql_test_data,
+    start_mysqld_service,
+    stop_mysqld_service,
+    update_interval,
     wait_for_apps_status,
 )
 
@@ -111,11 +112,15 @@ def test_cluster_failover_after_majority_loss(juju: Juju) -> None:
     logging.info(f"Unit selected for promotion: {unit_to_promote}")
 
     logging.info("Simulate quorum loss")
-    units_to_kill = [non_primary_units.pop(), primary_unit]
+    units_to_stop = [non_primary_units.pop(), primary_unit]
 
     # ensure no update-status is triggered
     with update_interval(juju, "30m"):
-        kill_pods(juju, units_to_kill)
+        # Stop mysqld via Pebble on a majority of units:
+        # `pebble stop` is honoured until an explicit `pebble start`,
+        # so the survivor stays in NO_QUORUM until we restart mysqld below
+        for unit in units_to_stop:
+            stop_mysqld_service(juju, unit)
         # allow time to cluster settled in no_quorum
         sleep(10)
         logging.info("Attempting to promote a unit to primary after quorum loss...")
@@ -125,6 +130,11 @@ def test_cluster_failover_after_majority_loss(juju: Juju) -> None:
             params={"scope": "unit", "force": True},
             wait=600,
         )
+        # Bring mysqld back on the stopped units
+        # so they can rejoin the new primary;
+        # otherwise the cluster never reaches all-active
+        for unit in units_to_stop:
+            start_mysqld_service(juju, unit)
 
     with update_interval(juju, "15s"):
         logging.info("Waiting for all units to become active after switchover...")
@@ -135,19 +145,3 @@ def test_cluster_failover_after_majority_loss(juju: Juju) -> None:
         )
 
     assert get_mysql_primary_unit(juju, app_name) == unit_to_promote, "Failover failed"
-
-
-def kill_pods(juju: Juju, unit_names: list[str]) -> None:
-    """Kill the unit pods simultaneously using kubectl."""
-    pod_names = [get_mysql_instance_label(unit) for unit in unit_names]
-    cmd = [
-        "kubectl",
-        "delete",
-        "pod",
-        *pod_names,
-        "-n",
-        juju.model,
-        "--grace-period=0",
-        "--force",
-    ]
-    subprocess.run(cmd, check=True)

--- a/kubernetes/tests/integration/integration/high_availability/test_primary_switchover.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_primary_switchover.py
@@ -11,12 +11,12 @@ from jubilant import Juju
 from ... import architecture
 from ...helpers_ha import (
     CHARM_METADATA,
+    force_kill_mysqld_service,
     get_app_name,
     get_app_units,
     get_mysql_primary_unit,
     load_mysql_test_data,
     start_mysqld_service,
-    stop_mysqld_service,
     update_interval,
     wait_for_apps_status,
 )
@@ -112,15 +112,15 @@ def test_cluster_failover_after_majority_loss(juju: Juju) -> None:
     logging.info(f"Unit selected for promotion: {unit_to_promote}")
 
     logging.info("Simulate quorum loss")
-    units_to_stop = [non_primary_units.pop(), primary_unit]
+    units_to_kill = [non_primary_units.pop(), primary_unit]
 
     # ensure no update-status is triggered
     with update_interval(juju, "30m"):
-        # Stop mysqld via Pebble on a majority of units:
-        # `pebble stop` is honoured until an explicit `pebble start`,
-        # so the survivor stays in NO_QUORUM until we restart mysqld below
-        for unit in units_to_stop:
-            stop_mysqld_service(juju, unit)
+        # SIGKILL mysqld on a majority of units
+        # so the survivor sees the killed units as UNREACHABLE
+        # rather than gracefully departed
+        for unit in units_to_kill:
+            force_kill_mysqld_service(juju, unit)
         # allow time to cluster settled in no_quorum
         sleep(10)
         logging.info("Attempting to promote a unit to primary after quorum loss...")

--- a/kubernetes/tests/integration/integration/high_availability/test_primary_switchover.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_primary_switchover.py
@@ -16,7 +16,6 @@ from ...helpers_ha import (
     get_app_units,
     get_mysql_primary_unit,
     load_mysql_test_data,
-    start_mysqld_service,
     update_interval,
     wait_for_apps_status,
 )
@@ -116,9 +115,6 @@ def test_cluster_failover_after_majority_loss(juju: Juju) -> None:
 
     # ensure no update-status is triggered
     with update_interval(juju, "30m"):
-        # SIGKILL mysqld on a majority of units
-        # so the survivor sees the killed units as UNREACHABLE
-        # rather than gracefully departed
         for unit in units_to_kill:
             force_kill_mysqld_service(juju, unit)
         # allow time to cluster settled in no_quorum
@@ -129,19 +125,6 @@ def test_cluster_failover_after_majority_loss(juju: Juju) -> None:
             action="promote-to-primary",
             params={"scope": "unit", "force": True},
             wait=600,
-        )
-        # Bring mysqld back on the stopped units
-        # so they can rejoin the new primary;
-        # otherwise the cluster never reaches all-active
-        for unit in units_to_stop:
-            start_mysqld_service(juju, unit)
-
-    with update_interval(juju, "15s"):
-        logging.info("Waiting for all units to become active after switchover...")
-        juju.wait(
-            ready=jubilant.all_active,
-            timeout=10 * MINUTE_SECS,
-            delay=5,
         )
 
     assert get_mysql_primary_unit(juju, app_name) == unit_to_promote, "Failover failed"

--- a/kubernetes/tests/integration/integration/high_availability/test_primary_switchover.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_primary_switchover.py
@@ -16,7 +16,6 @@ from ...helpers_ha import (
     get_app_units,
     get_mysql_primary_unit,
     load_mysql_test_data,
-    update_interval,
     wait_for_apps_status,
 )
 
@@ -113,18 +112,16 @@ def test_cluster_failover_after_majority_loss(juju: Juju) -> None:
     logging.info("Simulate quorum loss")
     units_to_kill = [non_primary_units.pop(), primary_unit]
 
-    # ensure no update-status is triggered
-    with update_interval(juju, "30m"):
-        for unit in units_to_kill:
-            force_kill_mysqld_service(juju, unit)
-        # allow time to cluster settled in no_quorum
-        sleep(10)
-        logging.info("Attempting to promote a unit to primary after quorum loss...")
-        juju.run(
-            unit=unit_to_promote,
-            action="promote-to-primary",
-            params={"scope": "unit", "force": True},
-            wait=600,
-        )
+    for unit in units_to_kill:
+        force_kill_mysqld_service(juju, unit)
+    # allow time to cluster settled in no_quorum
+    sleep(10)
+    logging.info("Attempting to promote a unit to primary after quorum loss...")
+    juju.run(
+        unit=unit_to_promote,
+        action="promote-to-primary",
+        params={"scope": "unit", "force": True},
+        wait=600,
+    )
 
     assert get_mysql_primary_unit(juju, app_name) == unit_to_promote, "Failover failed"

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_safe_recover_quorum.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_safe_recover_quorum.py
@@ -1,10 +1,8 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
-
 import logging
 import os
 import subprocess
-from time import sleep
 
 import jubilant
 from jubilant import Juju
@@ -12,11 +10,13 @@ from jubilant import Juju
 from ... import architecture
 from ...helpers_ha import (
     CHARM_METADATA,
+    check_mysql_units_writes_increment,
     get_app_name,
     get_app_units,
     get_mysql_instance_label,
     get_mysql_primary_unit,
     load_mysql_test_data,
+    update_interval,
     wait_for_apps_status,
 )
 
@@ -65,40 +65,12 @@ def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
         load_mysql_test_data(juju, MYSQL_APP_NAME, path)
 
 
-def test_cluster_switchover(juju: Juju) -> None:
-    """Test that the primary node can be switched over."""
-    logging.info("Testing cluster switchover...")
+def test_auto_recover_on_quorum_loss(juju: Juju, continuous_writes) -> None:
+    """Test safe auto-recover after quorum loss."""
     app_name = get_app_name(juju, MYSQL_APP_NAME)
     assert app_name, "MySQL application not found in the cluster"
 
     app_units = set(get_app_units(juju, app_name))
-    assert len(app_units) > 1, "Not enough units to perform a switchover"
-
-    primary_unit = get_mysql_primary_unit(juju, app_name)
-    assert primary_unit, "No primary unit found in the cluster"
-    logging.info(f"Current primary unit: {primary_unit}")
-
-    logging.info("Selecting a new primary unit for switchover...")
-    app_units.discard(primary_unit)
-    new_primary_unit = app_units.pop()
-    logging.info(f"New primary unit selected: {new_primary_unit}")
-
-    juju.run(
-        unit=new_primary_unit,
-        action="promote-to-primary",
-        params={"scope": "unit"},
-    )
-
-    assert get_mysql_primary_unit(juju, app_name) == new_primary_unit, "Switchover failed"
-
-
-def test_cluster_failover_after_majority_loss(juju: Juju) -> None:
-    """Test the promote-to-primary command after losing the majority of nodes, with force flag."""
-    app_name = get_app_name(juju, MYSQL_APP_NAME)
-    assert app_name, "MySQL application not found in the cluster"
-
-    app_units = set(get_app_units(juju, app_name))
-    assert len(app_units) > 1, "Not enough units to perform a switchover"
 
     primary_unit = get_mysql_primary_unit(juju, app_name)
     assert primary_unit, "No primary unit found in the cluster"
@@ -106,25 +78,13 @@ def test_cluster_failover_after_majority_loss(juju: Juju) -> None:
 
     non_primary_units = app_units - {primary_unit}
 
-    unit_to_promote = non_primary_units.pop()
-
-    logging.info(f"Unit selected for promotion: {unit_to_promote}")
+    unit_to_survive = non_primary_units.pop()
 
     logging.info("Simulate quorum loss")
-    units_to_kill = [non_primary_units.pop(), primary_unit]
+    logging.info(f"Unit selected for survival: {unit_to_survive}")
 
-    # ensure no update-status is triggered
-    with update_interval(juju, "30m"):
-        kill_pods(juju, units_to_kill)
-        # allow time to cluster settled in no_quorum
-        sleep(10)
-        logging.info("Attempting to promote a unit to primary after quorum loss...")
-        juju.run(
-            unit=unit_to_promote,
-            action="promote-to-primary",
-            params={"scope": "unit", "force": True},
-            wait=600,
-        )
+    units_to_kill = [non_primary_units.pop(), primary_unit]
+    kill_pods(juju, units_to_kill)
 
     with update_interval(juju, "15s"):
         logging.info("Waiting for all units to become active after switchover...")
@@ -134,7 +94,7 @@ def test_cluster_failover_after_majority_loss(juju: Juju) -> None:
             delay=5,
         )
 
-    assert get_mysql_primary_unit(juju, app_name) == unit_to_promote, "Failover failed"
+    check_mysql_units_writes_increment(juju, MYSQL_APP_NAME)
 
 
 def kill_pods(juju: Juju, unit_names: list[str]) -> None:

--- a/machines/lib/charms/mysql/v0/mysql.py
+++ b/machines/lib/charms/mysql/v0/mysql.py
@@ -862,8 +862,13 @@ class MySQLCharmBase(CharmBase, ABC):
         if self.unit_peer_data.get("member-role") != InstanceRole.PRIMARY:
             return ops.ActiveStatus("")
 
-        if self._mysql.is_cluster_replica() is False:
+        is_replica = self._mysql.is_cluster_replica()
+        if is_replica is False:
             return ops.ActiveStatus("Primary")
+        if is_replica is None:
+            # cluster-set status unreadable (e.g. lost quorum): a primary that
+            # cannot accept writes. Avoid mislabelling it as "Standby".
+            return ops.ActiveStatus("Primary (read-only)")
 
         status = self._mysql.get_replica_cluster_status()
         if status == ClusterGlobalStatus.OK:
@@ -2310,6 +2315,13 @@ class MySQLBase(ABC):
         """Start Group replication on the instance."""
         with suppress(ExecutionError):
             self._instance_client_tcp.start_instance_replication()
+
+    def is_cluster_in_no_quorum(self) -> bool:
+        """Check whether the cluster has lost quorum as seen from this instance."""
+        status = self.get_cluster_status()
+        if not status:
+            return False
+        return status["defaultReplicaSet"]["status"] == ClusterStatus.NO_QUORUM
 
     def force_quorum_from_instance(self) -> None:
         """Force quorum from the current instance.

--- a/machines/src/charm.py
+++ b/machines/src/charm.py
@@ -446,6 +446,12 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         """Helper method to handle non-online instance statuses.
 
         Invoked from the update status event handler.
+
+        Returns:
+            bool
+                True if the handling worked correctly and the caller can continue,
+                False otherwise.
+
         """
         # A surviving member can stay ONLINE in its local view while the
         # cluster has lost quorum (majority UNREACHABLE). The reboot-from-
@@ -631,10 +637,8 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         self.unit_peer_data["member-state"] = state
         self.set_unit_status(self.build_unit_workload_status())
 
-        if not self._handle_non_online_instance_status(state):
-            return
-
-        self._set_app_status(state)
+        if self._handle_non_online_instance_status(state):
+            self._set_app_status(state)
 
     def _on_cos_agent_relation_created(self, event: RelationCreatedEvent) -> None:
         """Handle the cos_agent relation created event.

--- a/machines/src/charm.py
+++ b/machines/src/charm.py
@@ -458,7 +458,10 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         # complete-outage path below only fires on state == OFFLINE, so
         # without this the leader stays stuck and the cluster never recovers.
         if state == InstanceState.ONLINE and self._mysql.is_cluster_in_no_quorum():
-            logger.warning("Cluster has lost quorum")
+            logger.warning("Cluster has no quorum")
+            if self.peers.units and not self._all_peers_reachable():
+                logger.warning("Skipping quorum recovery: not all peers reachable")
+                return True
             try:
                 # reboot_cluster_from_complete_outage rejects an instance whose
                 # GR is still running; drop it to OFFLINE first.
@@ -887,6 +890,23 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             status = refresh_status
 
         self.unit.status = status
+
+    def _all_peers_reachable(self) -> bool:
+        """Return True if all peer units respond on MySQL port 3306.
+
+        Quorum recovery must not run when peers are unreachable — that scenario
+        indicates a network partition where the remote side may still be healthy.
+        """
+        for unit in self.peers.units:
+            address = self.get_unit_address(unit, PEER)
+            if not address:
+                return False
+            try:
+                with socket.create_connection((address, 3306), timeout=2):
+                    pass
+            except OSError:
+                return False
+        return True
 
     def update_endpoints(self) -> None:
         """Update endpoints for the cluster."""

--- a/machines/src/charm.py
+++ b/machines/src/charm.py
@@ -462,10 +462,6 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
                     logger.warning("Attempting reboot from complete outage")
                     self._mysql.reboot_from_complete_outage()
                     return False
-                else:
-                    # set offline state and delegate reboot from outage to leader
-                    logger.warning("Set instance to offline")
-                    self.unit_peer_data["member-state"] = InstanceState.OFFLINE
             except MySQLRebootFromCompleteOutageError:
                 logger.error("Failed to reboot cluster from complete outage")
                 self.set_unit_status(BlockedStatus("failed to recover cluster"))

--- a/machines/src/charm.py
+++ b/machines/src/charm.py
@@ -442,11 +442,35 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
 
         set_destination(f"{endpoint}/v1/traces", None)
 
-    def _handle_non_online_instance_status(self, state: str) -> bool:
+    def _handle_non_online_instance_status(self, state: str) -> bool:  # noqa: C901
         """Helper method to handle non-online instance statuses.
 
         Invoked from the update status event handler.
         """
+        # A surviving member can stay ONLINE in its local view while the
+        # cluster has lost quorum (majority UNREACHABLE). The reboot-from-
+        # complete-outage path below only fires on state == OFFLINE, so
+        # without this the leader stays stuck and the cluster never recovers.
+        if state == InstanceState.ONLINE and self._mysql.is_cluster_in_no_quorum():
+            logger.warning("Cluster has lost quorum")
+            try:
+                # reboot_cluster_from_complete_outage rejects an instance whose
+                # GR is still running; drop it to OFFLINE first.
+                self._mysql.stop_group_replication()
+                if self.unit.is_leader():
+                    # run on leader only for coordinate recovery
+                    logger.warning("Attempting reboot from complete outage")
+                    self._mysql.reboot_from_complete_outage()
+                    return False
+                else:
+                    # set offline state and delegate reboot from outage to leader
+                    logger.warning("Set instance to offline")
+                    self.unit_peer_data["member-state"] = InstanceState.OFFLINE
+            except MySQLRebootFromCompleteOutageError:
+                logger.error("Failed to reboot cluster from complete outage")
+                self.set_unit_status(BlockedStatus("failed to recover cluster"))
+            return True
+
         if state == InstanceState.RECOVERING:
             # server is in the process of becoming an active member
             logger.info("Instance is being recovered")
@@ -867,7 +891,6 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
     def update_endpoints(self) -> None:
         """Update endpoints for the cluster."""
         self.database_relation._update_endpoints_all_relations(None)
-        self._on_update_status(None)
 
     def _can_start(self, event: StartEvent) -> bool:
         """Check if the unit can start.

--- a/machines/tests/integration/integration/high_availability/test_primary_switchover.py
+++ b/machines/tests/integration/integration/high_availability/test_primary_switchover.py
@@ -15,7 +15,6 @@ from ...helpers_ha import (
     get_mysql_primary_unit,
     get_unit_machine,
     load_mysql_test_data,
-    update_interval,
     wait_for_apps_status,
 )
 
@@ -111,18 +110,16 @@ def test_cluster_failover_after_majority_loss(juju: Juju) -> None:
     for unit in units_to_kill:
         machine_name.append(get_unit_machine(juju, app_name, unit))
 
-    # ensure no update-status is triggered
-    with update_interval(juju, "30m"):
-        subprocess.run(["lxc", "stop", "--force", machine_name[0], machine_name[1]], check=True)
-        # allow time to cluster settled in no_quorum
-        sleep(10)
-        logging.info("Attempting to promote a unit to primary after quorum loss...")
-        juju.run(
-            unit=unit_to_promote,
-            action="promote-to-primary",
-            params={"scope": "unit", "force": True},
-            wait=600,
-        )
+    subprocess.run(["lxc", "stop", "--force", machine_name[0], machine_name[1]], check=True)
+    # allow time to cluster settled in no_quorum
+    sleep(10)
+    logging.info("Attempting to promote a unit to primary after quorum loss...")
+    juju.run(
+        unit=unit_to_promote,
+        action="promote-to-primary",
+        params={"scope": "unit", "force": True},
+        wait=600,
+    )
 
     assert get_mysql_primary_unit(juju, app_name, unit_to_promote) == unit_to_promote, (
         "Failover failed"

--- a/machines/tests/integration/integration/high_availability/test_primary_switchover.py
+++ b/machines/tests/integration/integration/high_availability/test_primary_switchover.py
@@ -112,7 +112,7 @@ def test_cluster_failover_after_majority_loss(juju: Juju) -> None:
 
     # ensure no update-status is triggered
     with update_interval(juju, "30m"):
-        subprocess.run(["lxc", "restart", "--force", machine_name[0], machine_name[1]], check=True)
+        subprocess.run(["lxc", "stop", "--force", machine_name[0], machine_name[1]], check=True)
         # allow time to cluster settled in no_quorum
         sleep(10)
         logging.info("Attempting to promote a unit to primary after quorum loss...")

--- a/machines/tests/integration/integration/high_availability/test_primary_switchover.py
+++ b/machines/tests/integration/integration/high_availability/test_primary_switchover.py
@@ -15,6 +15,7 @@ from ...helpers_ha import (
     get_mysql_primary_unit,
     get_unit_machine,
     load_mysql_test_data,
+    update_interval,
     wait_for_apps_status,
 )
 

--- a/machines/tests/integration/integration/high_availability/test_primary_switchover.py
+++ b/machines/tests/integration/integration/high_availability/test_primary_switchover.py
@@ -123,12 +123,6 @@ def test_cluster_failover_after_majority_loss(juju: Juju) -> None:
             wait=600,
         )
 
-    with update_interval(juju, "15s"):
-        logging.info("Waiting for all units to become active after switchover...")
-        juju.wait(
-            ready=jubilant.all_active,
-            timeout=10 * MINUTE_SECS,
-            delay=5,
-        )
-
-    assert get_mysql_primary_unit(juju, app_name) == unit_to_promote, "Failover failed"
+    assert get_mysql_primary_unit(juju, app_name, unit_to_promote) == unit_to_promote, (
+        "Failover failed"
+    )

--- a/machines/tests/integration/integration/high_availability/test_primary_switchover.py
+++ b/machines/tests/integration/integration/high_availability/test_primary_switchover.py
@@ -4,6 +4,7 @@
 import logging
 import os
 import subprocess
+from time import sleep
 
 import jubilant
 from jubilant import Juju
@@ -15,7 +16,6 @@ from ...helpers_ha import (
     get_unit_machine,
     load_mysql_test_data,
     wait_for_apps_status,
-    wait_for_unit_status,
 )
 
 MYSQL_APP_NAME = "mysql"
@@ -110,31 +110,25 @@ def test_cluster_failover_after_majority_loss(juju: Juju) -> None:
     for unit in units_to_kill:
         machine_name.append(get_unit_machine(juju, app_name, unit))
 
-    subprocess.run(["lxc", "restart", "--force", machine_name[0], machine_name[1]], check=True)
+    # ensure no update-status is triggered
+    with update_interval(juju, "30m"):
+        subprocess.run(["lxc", "restart", "--force", machine_name[0], machine_name[1]], check=True)
+        # allow time to cluster settled in no_quorum
+        sleep(10)
+        logging.info("Attempting to promote a unit to primary after quorum loss...")
+        juju.run(
+            unit=unit_to_promote,
+            action="promote-to-primary",
+            params={"scope": "unit", "force": True},
+            wait=600,
+        )
 
-    logging.info("Waiting to settle in error state")
-    juju.wait(
-        ready=lambda status: all((
-            wait_for_unit_status(app_name, unit_to_promote, "active")(status),
-            wait_for_unit_status(app_name, units_to_kill[0], "maintenance")(status),
-            wait_for_unit_status(app_name, units_to_kill[1], "maintenance")(status),
-        )),
-        timeout=15 * MINUTE_SECS,
-        delay=15,
-    )
-
-    juju.run(
-        unit=unit_to_promote,
-        action="promote-to-primary",
-        params={"scope": "unit", "force": True},
-        wait=600,
-    )
-
-    logging.info("Waiting for all units to become active after switchover...")
-    juju.wait(
-        ready=jubilant.all_active,
-        timeout=10 * MINUTE_SECS,
-        delay=5,
-    )
+    with update_interval(juju, "15s"):
+        logging.info("Waiting for all units to become active after switchover...")
+        juju.wait(
+            ready=jubilant.all_active,
+            timeout=10 * MINUTE_SECS,
+            delay=5,
+        )
 
     assert get_mysql_primary_unit(juju, app_name) == unit_to_promote, "Failover failed"

--- a/machines/tests/integration/integration/high_availability/test_self_healing_safe_recover_quorum.py
+++ b/machines/tests/integration/integration/high_availability/test_self_healing_safe_recover_quorum.py
@@ -1,0 +1,97 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+import logging
+import os
+import subprocess
+
+import jubilant
+from jubilant import Juju
+
+from ...helpers_ha import (
+    check_mysql_units_writes_increment,
+    get_app_name,
+    get_app_units,
+    get_mysql_primary_unit,
+    get_unit_machine,
+    load_mysql_test_data,
+    update_interval,
+    wait_for_apps_status,
+)
+
+MYSQL_APP_NAME = "mysql"
+MYSQL_TEST_APP_NAME = "mysql-test-app"
+
+MINUTE_SECS = 60
+
+
+def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
+    """Simple test to ensure that the MySQL and application charms get deployed."""
+    logging.info("Deploying MySQL cluster")
+    juju.deploy(
+        charm=charm,
+        app=MYSQL_APP_NAME,
+        base="ubuntu@24.04",
+        config={"profile": "testing"},
+        num_units=3,
+    )
+    juju.deploy(
+        charm=MYSQL_TEST_APP_NAME,
+        app=MYSQL_TEST_APP_NAME,
+        base="ubuntu@24.04",
+        channel="latest/edge",
+        config={"sleep_interval": 500},
+        num_units=1,
+    )
+
+    juju.integrate(
+        f"{MYSQL_APP_NAME}:database",
+        f"{MYSQL_TEST_APP_NAME}:database",
+    )
+
+    logging.info("Wait for applications to become active")
+    juju.wait(
+        ready=wait_for_apps_status(jubilant.all_active, MYSQL_APP_NAME, MYSQL_TEST_APP_NAME),
+        timeout=20 * MINUTE_SECS,
+    )
+
+    if path := os.getenv("DATA_SOURCE_PATH"):
+        logging.info("Loading test database")
+        load_mysql_test_data(juju, MYSQL_APP_NAME, path)
+
+
+def test_auto_recover_on_quorum_loss(juju: Juju, continuous_writes) -> None:
+    """Test safe auto-recover after quorum loss."""
+    app_name = get_app_name(juju, MYSQL_APP_NAME)
+    assert app_name, "MySQL application not found in the cluster"
+
+    app_units = set(get_app_units(juju, app_name))
+
+    primary_unit = get_mysql_primary_unit(juju, app_name)
+    assert primary_unit, "No primary unit found in the cluster"
+    logging.info(f"Current primary unit: {primary_unit}")
+
+    non_primary_units = app_units - {primary_unit}
+
+    unit_to_survive = non_primary_units.pop()
+
+    logging.info("Simulate quorum loss")
+    logging.info(f"Unit selected for survival: {unit_to_survive}")
+
+    units_to_kill = [non_primary_units.pop(), primary_unit]
+    kill_units(juju, app_name, units_to_kill)
+
+    with update_interval(juju, "15s"):
+        logging.info("Waiting for all units to become active after switchover...")
+        juju.wait(
+            ready=jubilant.all_active,
+            timeout=10 * MINUTE_SECS,
+            delay=5,
+        )
+
+    check_mysql_units_writes_increment(juju, MYSQL_APP_NAME)
+
+
+def kill_units(juju: Juju, app_name: str, unit_names: list[str]) -> None:
+    """Kill the units simultaneously using lxc."""
+    machine_names = [get_unit_machine(juju, app_name, unit) for unit in unit_names]
+    subprocess.run(["lxc", "restart", "--force", *machine_names], check=True)

--- a/machines/tests/unit/test_charm.py
+++ b/machines/tests/unit/test_charm.py
@@ -187,6 +187,7 @@ class TestCharm(unittest.TestCase):
         self.charm.on.start.emit()
         self.assertTrue(isinstance(self.harness.model.unit.status, BlockedStatus))
 
+    @patch("mysql_vm_helpers.MySQL.is_cluster_in_no_quorum", return_value=False)
     @patch(
         "charm.MySQLOperatorCharm.cluster_initialized",
         new_callable=PropertyMock(return_value=True),
@@ -218,6 +219,7 @@ class TestCharm(unittest.TestCase):
         _build_unit_workload_status,
         _unit_initialized,
         _cluster_initialized,
+        _is_cluster_no_quorum,
     ):
         self.harness.update_relation_data(
             self.peer_relation_id,


### PR DESCRIPTION
## Issue

Use the no_quorum->offline->reboot_from_outage to safe restore from quorum loss when all nodes become reachable

(Backports #338 with #136 in mind)

## Solution

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
