### PR TITLE
[MISC] only auto recover no_quorum if all peers are reachable

### DIFF
--- a/kubernetes/src/charm.py
+++ b/kubernetes/src/charm.py
@@ -15,6 +15,7 @@ if is_wrong_architecture() and __name__ == "__main__":
 
 import logging
 import random
+import socket
 from time import sleep
 
 import ops
@@ -334,6 +335,21 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         Translate juju unit name to resolvable hostname.
         """
         return get_k8s_fqdn(self.get_unit_hostname(unit.name), self.unit_label)
+
+    def _all_peers_reachable(self) -> bool:
+        """Return True if all peer units respond on MySQL port 3306.
+
+        Quorum recovery must not run when peers are unreachable — that scenario
+        indicates a network partition where the remote side may still be healthy.
+        """
+        for unit in self.peers.units:
+            address = self.get_unit_address(unit)
+            try:
+                with socket.create_connection((address, 3306), timeout=2):
+                    pass
+            except OSError:
+                return False
+        return True
 
     def is_unit_busy(self) -> bool:
         """Returns whether the unit is busy."""
@@ -851,7 +867,10 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         # complete-outage path below only fires on state == OFFLINE, so
         # without this the leader stays stuck and the cluster never recovers.
         if state == InstanceState.ONLINE and self._mysql.is_cluster_in_no_quorum():
-            logger.warning("Cluster has lost quorum")
+            logger.warning("Cluster has no quorum")
+            if self.peers.units and not self._all_peers_reachable():
+                logger.warning("Skipping quorum recovery: not all peers reachable")
+                return True
             try:
                 # reboot_cluster_from_complete_outage rejects an instance whose
                 # GR is still running; drop it to OFFLINE first.

--- a/kubernetes/tests/integration/integration/high_availability/test_primary_switchover.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_primary_switchover.py
@@ -114,19 +114,17 @@ def test_cluster_failover_after_majority_loss(juju: Juju) -> None:
     logging.info("Simulate quorum loss")
     units_to_kill = [non_primary_units.pop(), primary_unit]
 
-    # ensure no update-status is triggered
-    with update_interval(juju, "30m"):
-        for unit in units_to_kill:
-            force_kill_mysqld_service(juju, unit)
-        # allow time to cluster settled in no_quorum
-        sleep(10)
-        logging.info("Attempting to promote a unit to primary after quorum loss...")
-        juju.run(
-            unit=unit_to_promote,
-            action="promote-to-primary",
-            params={"scope": "unit", "force": True},
-            wait=600,
-        )
+    for unit in units_to_kill:
+        force_kill_mysqld_service(juju, unit)
+    # allow time to cluster settled in no_quorum
+    sleep(10)
+    logging.info("Attempting to promote a unit to primary after quorum loss...")
+    juju.run(
+        unit=unit_to_promote,
+        action="promote-to-primary",
+        params={"scope": "unit", "force": True},
+        wait=600,
+    )
 
     assert get_mysql_primary_unit(juju, app_name, unit_to_promote) == unit_to_promote, (
         "Failover failed"

--- a/kubernetes/tests/integration/integration/high_availability/test_primary_switchover.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_primary_switchover.py
@@ -15,7 +15,6 @@ from ...helpers_ha import (
     get_app_units,
     get_mysql_primary_unit,
     load_mysql_test_data,
-    update_interval,
     wait_for_apps_status,
 )
 

--- a/machines/src/charm.py
+++ b/machines/src/charm.py
@@ -617,7 +617,10 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         # complete-outage path below only fires on state == OFFLINE, so
         # without this the leader stays stuck and the cluster never recovers.
         if state == InstanceState.ONLINE and self._mysql.is_cluster_in_no_quorum():
-            logger.warning("Cluster has lost quorum")
+            logger.warning("Cluster has no quorum")
+            if self.peers.units and not self._all_peers_reachable():
+                logger.warning("Skipping quorum recovery: not all peers reachable")
+                return
             try:
                 # reboot_cluster_from_complete_outage rejects an instance whose
                 # GR is still running; drop it to OFFLINE first.
@@ -860,6 +863,23 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             return str(self.peers.data[unit].get(f"{relation_name}-address", ""))
         except KeyError:
             return ""
+
+    def _all_peers_reachable(self) -> bool:
+        """Return True if all peer units respond on MySQL port 3306.
+
+        Quorum recovery must not run when peers are unreachable — that scenario
+        indicates a network partition where the remote side may still be healthy.
+        """
+        for unit in self.peers.units:
+            address = self.get_unit_address(unit, PEER)
+            if not address:
+                return False
+            try:
+                with socket.create_connection((address, 3306), timeout=2):
+                    pass
+            except OSError:
+                return False
+        return True
 
     def update_endpoints(self) -> None:
         """Update endpoints for the cluster."""

--- a/machines/tests/integration/integration/high_availability/test_primary_switchover.py
+++ b/machines/tests/integration/integration/high_availability/test_primary_switchover.py
@@ -14,7 +14,6 @@ from ...helpers_ha import (
     get_mysql_primary_unit,
     get_unit_machine,
     load_mysql_test_data,
-    update_interval,
     wait_for_apps_status,
 )
 

--- a/machines/tests/integration/integration/high_availability/test_primary_switchover.py
+++ b/machines/tests/integration/integration/high_availability/test_primary_switchover.py
@@ -112,18 +112,16 @@ def test_cluster_failover_after_majority_loss(juju: Juju) -> None:
     for unit in units_to_kill:
         machine_name.append(get_unit_machine(juju, app_name, unit))
 
-    # ensure no update-status is triggered
-    with update_interval(juju, "30m"):
-        subprocess.run(["lxc", "stop", "--force", machine_name[0], machine_name[1]], check=True)
-        # allow time to cluster settled in no_quorum
-        sleep(10)
-        logging.info("Attempting to promote a unit to primary after quorum loss...")
-        juju.run(
-            unit=unit_to_promote,
-            action="promote-to-primary",
-            params={"scope": "unit", "force": True},
-            wait=600,
-        )
+    subprocess.run(["lxc", "stop", "--force", machine_name[0], machine_name[1]], check=True)
+    # allow time to cluster settled in no_quorum
+    sleep(10)
+    logging.info("Attempting to promote a unit to primary after quorum loss...")
+    juju.run(
+        unit=unit_to_promote,
+        action="promote-to-primary",
+        params={"scope": "unit", "force": True},
+        wait=600,
+    )
 
     assert get_mysql_primary_unit(juju, app_name, unit_to_promote) == unit_to_promote, (
         "Failover failed"


### PR DESCRIPTION
Prior PR #338 tries to recover from no_quorum regardless of peers reachability, see [comment](https://github.com/canonical/mysql-operators/pull/354#issuecomment-4693197777)

This guards against the auto recovery if any peers is not available.