### PR TITLE
[MISC] (8.4/edge) Fix `test_instance_roles.py` flakiness

### DIFF
--- a/kubernetes/tests/integration/integration/roles/test_instance_roles.py
+++ b/kubernetes/tests/integration/integration/roles/test_instance_roles.py
@@ -131,6 +131,10 @@ def test_charmed_read_role(juju: Juju):
 
     juju.remove_relation(f"{DATABASE_APP_NAME}:database", f"{INTEGRATOR_APP_NAME}1:mysql")
     juju.wait(
+        ready=lambda status: "database" not in status.apps[DATABASE_APP_NAME].relations,
+        timeout=15 * MINUTE_SECS,
+    )
+    juju.wait(
         ready=wait_for_apps_status(jubilant.all_blocked, f"{INTEGRATOR_APP_NAME}1"),
         timeout=15 * MINUTE_SECS,
     )


### PR DESCRIPTION
## Issue

Just wait before re-adding relation.

Original failure visible in https://github.com/canonical/mysql-operators/actions/runs/27555515730/job/81508844698#step:7:2187

## Solution

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
