### PR TITLE
[MISC] 8.0 - Remove kubernetes test helper

### DIFF
--- a/kubernetes/pyproject.toml
+++ b/kubernetes/pyproject.toml
@@ -52,7 +52,6 @@ integration = [
     "pyyaml~=6.0",
     "urllib3~=2.0",
     "lightkube~=0.15.0",
-    "kubernetes~=27.2.0",
     "allure-pytest~=2.13",
     "allure-pytest-default-results~=0.1.2",
     "jubilant-backports~=1.4",

--- a/kubernetes/tests/integration/helpers_ha.py
+++ b/kubernetes/tests/integration/helpers_ha.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from typing import Any
 
 import jubilant_backports
-import kubernetes
 import yaml
 from jubilant_backports import CLIError, Juju
 from jubilant_backports.statustypes import Status
@@ -104,39 +103,6 @@ def delete_k8s_pod(juju: Juju, unit_name: str) -> None:
         name=get_mysql_instance_label(unit_name),
         namespace=juju.model,
     )
-
-
-def exec_k8s_container_command(
-    juju: Juju, unit_name: str, container_name: str, command: str
-) -> None:
-    """Send the specified signal to a pod container process.
-
-    Args:
-        juju: The juju instance to use.
-        unit_name: The name of the unit to send signal to
-        container_name: The name of the container to send signal to
-        command: The command to execute
-    """
-    kubernetes.config.load_kube_config()
-
-    response = kubernetes.stream.stream(
-        kubernetes.client.api.core_v1_api.CoreV1Api().connect_get_namespaced_pod_exec,
-        get_mysql_instance_label(unit_name),
-        juju.model,
-        container=container_name,
-        command=command.split(),
-        stdin=False,
-        stdout=True,
-        stderr=True,
-        tty=False,
-        _preload_content=False,
-    )
-    response.run_forever(
-        timeout=5,
-    )
-
-    if response.returncode != 0:
-        raise RuntimeError("Failed to execute command")
 
 
 def get_k8s_stateful_set_partitions(juju: Juju, app_name: str) -> int:

--- a/kubernetes/tests/integration/integration/high_availability/test_async_replication.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_async_replication.py
@@ -16,7 +16,6 @@ from constants import CONTAINER_NAME
 from ... import architecture
 from ...helpers_ha import (
     CHARM_METADATA,
-    exec_k8s_container_command,
     get_app_leader,
     get_app_units,
     get_mysql_cluster_status,
@@ -259,11 +258,10 @@ def test_failover(first_model: str, second_model: str) -> None:
 
     # Simulating a failure on the primary cluster
     for unit_name in model_2_mysql_units:
-        exec_k8s_container_command(
-            juju=model_2,
-            unit_name=unit_name,
-            container_name=CONTAINER_NAME,
-            command="pkill -f mysqld --signal SIGSTOP",
+        model_2.ssh(
+            target=unit_name,
+            container=CONTAINER_NAME,
+            command="pkill -x mysqld --signal SIGSTOP",
         )
 
     logging.info("Promoting standby cluster to primary with force flag")
@@ -294,11 +292,10 @@ def test_failover(first_model: str, second_model: str) -> None:
     # Restore mysqld process
     logging.info("Unfreezing mysqld on primary cluster units")
     for unit_name in model_2_mysql_units:
-        exec_k8s_container_command(
-            juju=model_2,
-            unit_name=unit_name,
-            container_name=CONTAINER_NAME,
-            command="pkill -f mysqld --signal SIGCONT",
+        model_2.ssh(
+            target=unit_name,
+            container=CONTAINER_NAME,
+            command="pkill -x mysqld --signal SIGCONT",
         )
 
 

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_expelled_rejoin.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_expelled_rejoin.py
@@ -15,7 +15,6 @@ from ...helpers import execute_queries_on_unit
 from ...helpers_ha import (
     CHARM_METADATA,
     check_mysql_units_writes_increment,
-    exec_k8s_container_command,
     get_mysql_primary_unit,
     get_mysql_server_credentials,
     get_unit_address,
@@ -95,22 +94,20 @@ def test_expelled_member_rejoin(juju: Juju, continuous_writes) -> None:
 
     target_pid = get_unit_process_id(juju, target_unit, MYSQL_PROCESS_NAME)
     logging.info(f"Sending SIGSTOP to mysqld (pid={target_pid}) on {target_unit}")
-    exec_k8s_container_command(
-        juju=juju,
-        unit_name=target_unit,
-        container_name=CONTAINER_NAME,
-        command=f"pkill -f {MYSQL_PROCESS_NAME} --signal SIGSTOP",
+    juju.ssh(
+        target=target_unit,
+        container=CONTAINER_NAME,
+        command=f"pkill -x {MYSQL_PROCESS_NAME} --signal SIGSTOP",
     )
 
     logging.info("Waiting 30 seconds for unit to be expelled from group")
     time.sleep(30)
 
     logging.info(f"Sending SIGCONT to mysqld on {target_unit}")
-    exec_k8s_container_command(
-        juju=juju,
-        unit_name=target_unit,
-        container_name=CONTAINER_NAME,
-        command=f"pkill -f {MYSQL_PROCESS_NAME} --signal SIGCONT",
+    juju.ssh(
+        target=target_unit,
+        container=CONTAINER_NAME,
+        command=f"pkill -x {MYSQL_PROCESS_NAME} --signal SIGCONT",
     )
 
     logging.info(f"Waiting for {target_unit} to enter maintenance")

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_process_frozen.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_process_frozen.py
@@ -19,7 +19,6 @@ from ... import architecture
 from ...helpers_ha import (
     CHARM_METADATA,
     check_mysql_units_writes_increment,
-    exec_k8s_container_command,
     get_app_units,
     get_mysql_primary_unit,
     get_unit_process_id,
@@ -85,11 +84,10 @@ def test_freeze_db_process(juju: Juju, continuous_writes) -> None:
     mysql_primary_unit_pid = get_unit_process_id(juju, mysql_primary_unit, MYSQL_PROCESS_NAME)
 
     logging.info(f"Stopping process id {mysql_primary_unit_pid}")
-    exec_k8s_container_command(
-        juju=juju,
-        unit_name=mysql_primary_unit,
-        container_name=CONTAINER_NAME,
-        command=f"pkill -f {MYSQL_PROCESS_NAME} --signal SIGSTOP",
+    juju.ssh(
+        target=mysql_primary_unit,
+        container=CONTAINER_NAME,
+        command=f"pkill -x {MYSQL_PROCESS_NAME} --signal SIGSTOP",
     )
 
     # Ensure that the mysqld process is stopped after receiving the sigstop
@@ -112,11 +110,10 @@ def test_freeze_db_process(juju: Juju, continuous_writes) -> None:
             assert new_mysql_primary_unit != mysql_primary_unit
 
     logging.info(f"Continuing process id {mysql_primary_unit_pid}")
-    exec_k8s_container_command(
-        juju=juju,
-        unit_name=mysql_primary_unit,
-        container_name=CONTAINER_NAME,
-        command=f"pkill -f {MYSQL_PROCESS_NAME} --signal SIGCONT",
+    juju.ssh(
+        target=mysql_primary_unit,
+        container=CONTAINER_NAME,
+        command=f"pkill -x {MYSQL_PROCESS_NAME} --signal SIGCONT",
     )
 
     # Ensure that the mysqld process has started after receiving the sigstop

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_process_killed.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_process_killed.py
@@ -15,7 +15,6 @@ from ...helpers import generate_random_string
 from ...helpers_ha import (
     CHARM_METADATA,
     check_mysql_units_writes_increment,
-    exec_k8s_container_command,
     get_mysql_primary_unit,
     get_unit_process_id,
     insert_mysql_test_data,
@@ -83,11 +82,10 @@ def test_kill_db_process(juju: Juju, continuous_writes) -> None:
     mysql_primary_unit_pid = get_unit_process_id(juju, mysql_primary_unit, MYSQL_PROCESS_NAME)
 
     logging.info(f"Killing process id {mysql_primary_unit_pid}")
-    exec_k8s_container_command(
-        juju=juju,
-        unit_name=mysql_primary_unit,
-        container_name=CONTAINER_NAME,
-        command="pkill -f mysqld --signal SIGKILL",
+    juju.ssh(
+        target=mysql_primary_unit,
+        container=CONTAINER_NAME,
+        command="pkill -x mysqld --signal SIGKILL",
     )
 
     time.sleep(10)

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_stop_primary.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_stop_primary.py
@@ -13,7 +13,6 @@ from ... import architecture
 from ...helpers_ha import (
     CHARM_METADATA,
     check_mysql_units_writes_increment,
-    exec_k8s_container_command,
     get_mysql_primary_unit,
     get_unit_process_id,
     load_mysql_test_data,
@@ -77,11 +76,10 @@ def test_graceful_crash_of_primary(juju: Juju, continuous_writes) -> None:
     mysql_primary_unit_pid = get_unit_process_id(juju, mysql_primary_unit, MYSQL_PROCESS_NAME)
 
     logging.info(f"Terminating process id {mysql_primary_unit_pid}")
-    exec_k8s_container_command(
-        juju=juju,
-        unit_name=mysql_primary_unit,
-        container_name=CONTAINER_NAME,
-        command=f"pkill -f {MYSQL_PROCESS_NAME} --signal SIGTERM",
+    juju.ssh(
+        target=mysql_primary_unit,
+        container=CONTAINER_NAME,
+        command=f"pkill -x {MYSQL_PROCESS_NAME} --signal SIGTERM",
     )
 
     new_mysql_primary_unit_pid = get_unit_process_id(juju, mysql_primary_unit, MYSQL_PROCESS_NAME)


### PR DESCRIPTION
This PR removes the custom Kubernetes exec test helper, and replace it by `juju.ssh`. The result should be the same.
