### PR TITLE
[MISC] 8.4 - Remove kubernetes test helper

### DIFF
--- a/kubernetes/pyproject.toml
+++ b/kubernetes/pyproject.toml
@@ -49,7 +49,6 @@ integration = [
     "pyyaml~=6.0",
     "urllib3~=2.0",
     "lightkube~=0.19.0",
-    "kubernetes~=27.2.0",
     "allure-pytest~=2.13",
     "allure-pytest-default-results~=0.1.2",
     "cryptography~=47.0",

--- a/kubernetes/tests/integration/helpers_ha.py
+++ b/kubernetes/tests/integration/helpers_ha.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import Any
 
 import jubilant
-import kubernetes
 import yaml
 from jubilant import CLIError, Juju
 from jubilant.statustypes import Status
@@ -108,39 +107,6 @@ def delete_k8s_pod(juju: Juju, unit_name: str) -> None:
         name=get_mysql_instance_label(unit_name),
         namespace=juju.model,
     )
-
-
-def exec_k8s_container_command(
-    juju: Juju, unit_name: str, container_name: str, command: str
-) -> None:
-    """Send the specified signal to a pod container process.
-
-    Args:
-        juju: The juju instance to use.
-        unit_name: The name of the unit to send signal to
-        container_name: The name of the container to send signal to
-        command: The command to execute
-    """
-    kubernetes.config.load_kube_config()
-
-    response = kubernetes.stream.stream(
-        kubernetes.client.api.core_v1_api.CoreV1Api().connect_get_namespaced_pod_exec,
-        get_mysql_instance_label(unit_name),
-        juju.model,
-        container=container_name,
-        command=command.split(),
-        stdin=False,
-        stdout=True,
-        stderr=True,
-        tty=False,
-        _preload_content=False,
-    )
-    response.run_forever(
-        timeout=5,
-    )
-
-    if response.returncode != 0:
-        raise RuntimeError("Failed to execute command")
 
 
 def get_k8s_endpoint_addresses(juju: Juju, endpoint_name: str) -> list[str]:

--- a/kubernetes/tests/integration/integration/high_availability/test_async_replication.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_async_replication.py
@@ -16,7 +16,6 @@ from constants import CONTAINER_NAME
 from ... import architecture
 from ...helpers_ha import (
     CHARM_METADATA,
-    exec_k8s_container_command,
     get_app_leader,
     get_app_units,
     get_mysql_cluster_status,
@@ -251,11 +250,10 @@ def test_failover(first_model: str, second_model: str) -> None:
 
     # Simulating a failure on the primary cluster
     for unit_name in model_2_mysql_units:
-        exec_k8s_container_command(
-            juju=model_2,
-            unit_name=unit_name,
-            container_name=CONTAINER_NAME,
-            command="pkill -f mysqld --signal SIGSTOP",
+        model_2.ssh(
+            target=unit_name,
+            container=CONTAINER_NAME,
+            command="pkill -x mysqld --signal SIGSTOP",
         )
 
     logging.info("Promoting standby cluster to primary with force flag")
@@ -286,11 +284,10 @@ def test_failover(first_model: str, second_model: str) -> None:
     # Restore mysqld process
     logging.info("Unfreezing mysqld on primary cluster units")
     for unit_name in model_2_mysql_units:
-        exec_k8s_container_command(
-            juju=model_2,
-            unit_name=unit_name,
-            container_name=CONTAINER_NAME,
-            command="pkill -f mysqld --signal SIGCONT",
+        model_2.ssh(
+            target=unit_name,
+            container=CONTAINER_NAME,
+            command="pkill -x mysqld --signal SIGCONT",
         )
 
 

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_process_frozen.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_process_frozen.py
@@ -19,7 +19,6 @@ from ... import architecture
 from ...helpers_ha import (
     CHARM_METADATA,
     check_mysql_units_writes_increment,
-    exec_k8s_container_command,
     get_app_units,
     get_mysql_primary_unit,
     get_unit_process_id,
@@ -83,11 +82,10 @@ def test_freeze_db_process(juju: Juju, continuous_writes) -> None:
     mysql_primary_unit_pid = get_unit_process_id(juju, mysql_primary_unit, MYSQL_PROCESS_NAME)
 
     logging.info(f"Stopping process id {mysql_primary_unit_pid}")
-    exec_k8s_container_command(
-        juju=juju,
-        unit_name=mysql_primary_unit,
-        container_name=CONTAINER_NAME,
-        command=f"pkill -f {MYSQL_PROCESS_NAME} --signal SIGSTOP",
+    juju.ssh(
+        target=mysql_primary_unit,
+        container=CONTAINER_NAME,
+        command=f"pkill -x {MYSQL_PROCESS_NAME} --signal SIGSTOP",
     )
 
     # Ensure that the mysqld process is stopped after receiving the sigstop
@@ -110,11 +108,10 @@ def test_freeze_db_process(juju: Juju, continuous_writes) -> None:
             assert new_mysql_primary_unit != mysql_primary_unit
 
     logging.info(f"Continuing process id {mysql_primary_unit_pid}")
-    exec_k8s_container_command(
-        juju=juju,
-        unit_name=mysql_primary_unit,
-        container_name=CONTAINER_NAME,
-        command=f"pkill -f {MYSQL_PROCESS_NAME} --signal SIGCONT",
+    juju.ssh(
+        target=mysql_primary_unit,
+        container=CONTAINER_NAME,
+        command=f"pkill -x {MYSQL_PROCESS_NAME} --signal SIGCONT",
     )
 
     # Ensure that the mysqld process has started after receiving the sigstop

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_process_killed.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_process_killed.py
@@ -15,7 +15,6 @@ from ...helpers import generate_random_string
 from ...helpers_ha import (
     CHARM_METADATA,
     check_mysql_units_writes_increment,
-    exec_k8s_container_command,
     get_mysql_primary_unit,
     get_unit_process_id,
     insert_mysql_test_data,
@@ -81,11 +80,10 @@ def test_kill_db_process(juju: Juju, continuous_writes) -> None:
     mysql_primary_unit_pid = get_unit_process_id(juju, mysql_primary_unit, MYSQL_PROCESS_NAME)
 
     logging.info(f"Killing process id {mysql_primary_unit_pid}")
-    exec_k8s_container_command(
-        juju=juju,
-        unit_name=mysql_primary_unit,
-        container_name=CONTAINER_NAME,
-        command="pkill -f mysqld --signal SIGKILL",
+    juju.ssh(
+        target=mysql_primary_unit,
+        container=CONTAINER_NAME,
+        command="pkill -x mysqld --signal SIGKILL",
     )
 
     time.sleep(10)

--- a/kubernetes/tests/integration/integration/high_availability/test_self_healing_stop_primary.py
+++ b/kubernetes/tests/integration/integration/high_availability/test_self_healing_stop_primary.py
@@ -13,7 +13,6 @@ from ... import architecture
 from ...helpers_ha import (
     CHARM_METADATA,
     check_mysql_units_writes_increment,
-    exec_k8s_container_command,
     get_mysql_primary_unit,
     get_unit_process_id,
     load_mysql_test_data,
@@ -75,11 +74,10 @@ def test_graceful_crash_of_primary(juju: Juju, continuous_writes) -> None:
     mysql_primary_unit_pid = get_unit_process_id(juju, mysql_primary_unit, MYSQL_PROCESS_NAME)
 
     logging.info(f"Terminating process id {mysql_primary_unit_pid}")
-    exec_k8s_container_command(
-        juju=juju,
-        unit_name=mysql_primary_unit,
-        container_name=CONTAINER_NAME,
-        command=f"pkill -f {MYSQL_PROCESS_NAME} --signal SIGTERM",
+    juju.ssh(
+        target=mysql_primary_unit,
+        container=CONTAINER_NAME,
+        command=f"pkill -x {MYSQL_PROCESS_NAME} --signal SIGTERM",
     )
 
     new_mysql_primary_unit_pid = get_unit_process_id(juju, mysql_primary_unit, MYSQL_PROCESS_NAME)


### PR DESCRIPTION
This PR removes the custom Kubernetes exec test helper, and replace it by `juju.ssh`. The result should be the same.
