### PR TITLE
[MISC] preserve type on config dict

### DIFF
--- a/kubernetes/lib/charms/mysql/v0/mysql.py
+++ b/kubernetes/lib/charms/mysql/v0/mysql.py
@@ -1161,12 +1161,7 @@ class MySQLBase(ABC):
                 performance_schema_instrument = "'memory/%=OFF'"
 
         binlog_retention_seconds = binlog_retention_days * 24 * 60 * 60
-        config = configparser.ConfigParser(interpolation=None)
-
-        # do not enable slow query logs, but specify a log file path in case
-        # the admin enables them manually
-        config["mysqld"] = {
-            # All interfaces bind expected
+        mysqld_config: dict = {
             "bind_address": "0.0.0.0",  # noqa: S104
             "mysqlx_bind_address": "0.0.0.0",  # noqa: S104
             "admin_address": self.instance_address,
@@ -1179,36 +1174,39 @@ class MySQLBase(ABC):
             "general_log_file": f"{snap_common}/var/log/mysql/general.log",
             "loose-group_replication_paxos_single_leader": "ON",
             "slow_query_log_file": f"{snap_common}/var/log/mysql/slow.log",
-            "binlog_expire_logs_seconds": f"{binlog_retention_seconds}",
+            "binlog_expire_logs_seconds": binlog_retention_seconds,
             "loose-audit_log_policy": audit_log_policy.upper(),
             "loose-audit_log_file": f"{snap_common}/var/log/mysql/audit.log",
             "gtid_mode": "ON",
             "enforce_gtid_consistency": "ON",
             "activate_all_roles_on_login": "ON",
-            "max_connect_errors": "10000",
+            "max_connect_errors": 10000,
         }
 
         if audit_log_enabled:
             # This is used for being able to know the current state of the
             # audit plugin on config changes
-            config["mysqld"]["loose-audit_log_format"] = "JSON"
+            mysqld_config["loose-audit_log_format"] = "JSON"
         if audit_log_strategy == "async":
-            config["mysqld"]["loose-audit_log_strategy"] = "ASYNCHRONOUS"
+            mysqld_config["loose-audit_log_strategy"] = "ASYNCHRONOUS"
         else:
-            config["mysqld"]["loose-audit_log_strategy"] = "SEMISYNCHRONOUS"
+            mysqld_config["loose-audit_log_strategy"] = "SEMISYNCHRONOUS"
 
         if innodb_buffer_pool_chunk_size:
-            config["mysqld"]["innodb_buffer_pool_chunk_size"] = str(innodb_buffer_pool_chunk_size)
+            mysqld_config["innodb_buffer_pool_chunk_size"] = innodb_buffer_pool_chunk_size
         if performance_schema_instrument:
-            config["mysqld"]["performance-schema-instrument"] = performance_schema_instrument
+            mysqld_config["performance-schema-instrument"] = performance_schema_instrument
         if group_replication_message_cache_size:
-            config["mysqld"]["loose-group_replication_message_cache_size"] = str(
+            mysqld_config["loose-group_replication_message_cache_size"] = (
                 group_replication_message_cache_size
             )
 
+        config = configparser.ConfigParser(interpolation=None)
+        config["mysqld"] = {k: str(v) for k, v in mysqld_config.items()}
+
         with io.StringIO() as string_io:
             config.write(string_io)
-            return string_io.getvalue(), dict(config["mysqld"])
+            return string_io.getvalue(), mysqld_config
 
     def _build_mysql_database_dba_role(self, database: str) -> str:
         """Builds the database-level DBA role, given length constraints."""

--- a/kubernetes/src/charm.py
+++ b/kubernetes/src/charm.py
@@ -626,7 +626,9 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
 
         logger.info("Persisting configuration changes to file")
         new_config_dict = self._write_mysqld_configuration()
-        changed_config = compare_dictionaries(previous_config_dict, new_config_dict)
+        # flatten new_config_dict to match previous_config_dict format (all values as strings)
+        new_config_dict_flat = {k: str(v) for k, v in new_config_dict.items()}
+        changed_config = compare_dictionaries(previous_config_dict, new_config_dict_flat)
 
         if (
             self.mysql_config.keys_requires_restart(changed_config)

--- a/machines/lib/charms/mysql/v0/mysql.py
+++ b/machines/lib/charms/mysql/v0/mysql.py
@@ -1160,12 +1160,7 @@ class MySQLBase(ABC):
                 performance_schema_instrument = "'memory/%=OFF'"
 
         binlog_retention_seconds = binlog_retention_days * 24 * 60 * 60
-        config = configparser.ConfigParser(interpolation=None)
-
-        # do not enable slow query logs, but specify a log file path in case
-        # the admin enables them manually
-        config["mysqld"] = {
-            # All interfaces bind expected
+        mysqld_config: dict = {
             "bind_address": "0.0.0.0",  # noqa: S104
             "mysqlx_bind_address": "0.0.0.0",  # noqa: S104
             "admin_address": self.instance_address,
@@ -1178,36 +1173,37 @@ class MySQLBase(ABC):
             "general_log_file": f"{snap_common}/var/log/mysql/general.log",
             "loose-group_replication_paxos_single_leader": "ON",
             "slow_query_log_file": f"{snap_common}/var/log/mysql/slow.log",
-            "binlog_expire_logs_seconds": f"{binlog_retention_seconds}",
+            "binlog_expire_logs_seconds": binlog_retention_seconds,
             "loose-audit_log_policy": audit_log_policy.upper(),
             "loose-audit_log_file": f"{snap_common}/var/log/mysql/audit.log",
             "gtid_mode": "ON",
             "enforce_gtid_consistency": "ON",
             "activate_all_roles_on_login": "ON",
-            "max_connect_errors": "10000",
+            "max_connect_errors": 10000,
         }
 
         if audit_log_enabled:
-            # This is used for being able to know the current state of the
-            # audit plugin on config changes
-            config["mysqld"]["loose-audit_log_format"] = "JSON"
+            mysqld_config["loose-audit_log_format"] = "JSON"
         if audit_log_strategy == "async":
-            config["mysqld"]["loose-audit_log_strategy"] = "ASYNCHRONOUS"
+            mysqld_config["loose-audit_log_strategy"] = "ASYNCHRONOUS"
         else:
-            config["mysqld"]["loose-audit_log_strategy"] = "SEMISYNCHRONOUS"
+            mysqld_config["loose-audit_log_strategy"] = "SEMISYNCHRONOUS"
 
         if innodb_buffer_pool_chunk_size:
-            config["mysqld"]["innodb_buffer_pool_chunk_size"] = str(innodb_buffer_pool_chunk_size)
+            mysqld_config["innodb_buffer_pool_chunk_size"] = innodb_buffer_pool_chunk_size
         if performance_schema_instrument:
-            config["mysqld"]["performance-schema-instrument"] = performance_schema_instrument
+            mysqld_config["performance-schema-instrument"] = performance_schema_instrument
         if group_replication_message_cache_size:
-            config["mysqld"]["loose-group_replication_message_cache_size"] = str(
+            mysqld_config["loose-group_replication_message_cache_size"] = (
                 group_replication_message_cache_size
             )
 
+        config = configparser.ConfigParser(interpolation=None)
+        config["mysqld"] = {k: str(v) for k, v in mysqld_config.items()}
+
         with io.StringIO() as string_io:
             config.write(string_io)
-            return string_io.getvalue(), dict(config["mysqld"])
+            return string_io.getvalue(), mysqld_config
 
     def _build_mysql_database_dba_role(self, database: str) -> str:
         """Builds the database-level DBA role, given length constraints."""

--- a/machines/src/charm.py
+++ b/machines/src/charm.py
@@ -272,8 +272,10 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
 
         # render the new config
         new_config_dict = self._mysql.write_mysqld_config()
+        # flatten new_config_dict to match previous_config format (all values as strings)
+        new_config_dict_flat = {k: str(v) for k, v in new_config_dict.items()}
 
-        changed_config = compare_dictionaries(previous_config, new_config_dict)
+        changed_config = compare_dictionaries(previous_config, new_config_dict_flat)
 
         # Override log rotation
         self.log_rotation_setup.setup()

--- a/machines/tests/unit/test_mysql.py
+++ b/machines/tests/unit/test_mysql.py
@@ -1713,24 +1713,24 @@ class TestMySQLBase(unittest.TestCase):
             "mysqlx_bind_address": "0.0.0.0",
             "admin_address": "127.0.0.1",
             "report_host": "127.0.0.1",
-            "max_connections": "724",
-            "innodb_buffer_pool_size": "23219666944",
+            "max_connections": 724,
+            "innodb_buffer_pool_size": 23219666944,
             "log_error_services": "log_filter_internal;log_sink_internal",
             "log_error": "/var/log/mysql/error.log",
             "general_log": "OFF",
             "general_log_file": "/var/log/mysql/general.log",
             "slow_query_log_file": "/var/log/mysql/slow.log",
-            "binlog_expire_logs_seconds": "604800",
+            "binlog_expire_logs_seconds": 604800,
             "loose-audit_log_format": "JSON",
             "loose-audit_log_policy": "LOGINS",
             "loose-audit_log_strategy": "ASYNCHRONOUS",
             "loose-audit_log_file": "/var/log/mysql/audit.log",
             "loose-group_replication_paxos_single_leader": "ON",
-            "innodb_buffer_pool_chunk_size": "2902458368",
+            "innodb_buffer_pool_chunk_size": 2902458368,
             "gtid_mode": "ON",
             "enforce_gtid_consistency": "ON",
             "activate_all_roles_on_login": "ON",
-            "max_connect_errors": "10000",
+            "max_connect_errors": 10000,
         }
         self.maxDiff = None
 
@@ -1746,10 +1746,10 @@ class TestMySQLBase(unittest.TestCase):
         # < 2GB of memory, production profile
         memory_limit = 2147483600
 
-        expected_config["innodb_buffer_pool_size"] = "536870912"
+        expected_config["innodb_buffer_pool_size"] = 536870912
         del expected_config["innodb_buffer_pool_chunk_size"]
         expected_config["performance-schema-instrument"] = "'memory/%=OFF'"
-        expected_config["max_connections"] = "127"
+        expected_config["max_connections"] = 127
 
         _, rendered_config = self.mysql.render_mysqld_configuration(
             profile="production",
@@ -1762,10 +1762,10 @@ class TestMySQLBase(unittest.TestCase):
         self.assertEqual(rendered_config, expected_config)
 
         # testing profile
-        expected_config["innodb_buffer_pool_size"] = "20971520"
-        expected_config["innodb_buffer_pool_chunk_size"] = "1048576"
-        expected_config["loose-group_replication_message_cache_size"] = "134217728"
-        expected_config["max_connections"] = "100"
+        expected_config["innodb_buffer_pool_size"] = 20971520
+        expected_config["innodb_buffer_pool_chunk_size"] = 1048576
+        expected_config["loose-group_replication_message_cache_size"] = 134217728
+        expected_config["max_connections"] = 100
 
         _, rendered_config = self.mysql.render_mysqld_configuration(
             profile="testing",
@@ -1789,7 +1789,7 @@ class TestMySQLBase(unittest.TestCase):
             memory_limit=memory_limit,
         )
 
-        self.assertEqual(rendered_config["max_connections"], "500")
+        self.assertEqual(rendered_config["max_connections"], 500)
 
         # max_connections set,constrained by memory, but enforced
         _, rendered_config = self.mysql.render_mysqld_configuration(
@@ -1802,7 +1802,7 @@ class TestMySQLBase(unittest.TestCase):
             memory_limit=memory_limit,
         )
 
-        self.assertEqual(rendered_config["max_connections"], "800")
+        self.assertEqual(rendered_config["max_connections"], 800)
 
     def test_create_replica_cluster(self):
         """Test create_replica_cluster."""


### PR DESCRIPTION
## Issue

ConfigParser will stringfy all values, when converting back to dict, original types are lost.
Some values need to carry their type so they are correctly quoted on mysql-shell-client.
E.g.: `experimental-max-connections` is a int, but will be quoted as string, and will break when applying in the instance: `set global max_connections='200' != set global max_connections=200`

## Solution

Instead of rendering the configuration as a ConfigParser, render in dict and convert to CP when writing to file.
