### PR TITLE
[MISC] Increase sock file wait timeout on upgrade

### DIFF
--- a/kubernetes/src/mysql_k8s_helpers.py
+++ b/kubernetes/src/mysql_k8s_helpers.py
@@ -293,11 +293,11 @@ class MySQL(MySQLBase):
             self.container.remove_path(file_path)
             self.container.remove_path(MYSQLD_INIT_CONFIG_FILE)
 
-    @retry(reraise=True, stop=stop_after_delay(120), wait=wait_fixed(2))
+    @retry(reraise=True, stop=stop_after_delay(600), wait=wait_fixed(2))
     def wait_until_mysql_connection(self, check_port: bool = True) -> None:
         """Wait until a connection to MySQL daemon is possible.
 
-        Retry every 2 seconds for 120 seconds if there is an issue obtaining a connection.
+        Retry every 2 seconds for 600 seconds if there is an issue obtaining a connection.
         """
         if not self.container.exists(MYSQLD_SOCK_FILE):
             raise MySQLServiceNotRunningError

--- a/machines/src/mysql_vm_helpers.py
+++ b/machines/src/mysql_vm_helpers.py
@@ -428,11 +428,11 @@ class MySQL(MySQLBase):
                     "mysqld service not running"
                 ) from e
 
-    @retry(reraise=True, stop=stop_after_delay(120), wait=wait_fixed(5))
+    @retry(reraise=True, stop=stop_after_delay(600), wait=wait_fixed(2))
     def wait_until_mysql_connection(self, check_port: bool = True) -> None:
         """Wait until a connection to MySQL has been obtained.
 
-        Retry every 5 seconds for 120 seconds if there is an issue obtaining a connection.
+        Retry every 2 seconds for 600 seconds if there is an issue obtaining a connection.
         """
         logger.debug("Waiting for MySQL connection")
 


### PR DESCRIPTION
## Issue

During testing of upgrade, under resources pressure, upgrade can fail due internal mysqld version migration taking longer than the hard coded 2 minutes timeout:

The `error.log` for the just upgraded mysqld:
```log
2026-06-29T21:09:44.699699Z 0 [System] [MY-010116] [Server] /usr/sbin/mysqld (mysqld 8.0.45-0ubuntu0.22.04.1) starting as process 32
...
2026-06-29T21:09:49.818853Z 7 [System] [MY-013381] [Server] Server upgrade from '80044' to '80045' started.
2026-06-29T21:11:49.079498Z 7 [System] [MY-013381] [Server] Server upgrade from '80044' to '80045' completed
....
2026-06-29T21:11:51.660561Z 0 [System] [MY-010931] [Server] /usr/sbin/mysqld: ready for connections. Version: '8.0.45-0ubuntu0.22.04.1'  socket: '/var/run/mysqld/mysqld.sock'  port: 3306  (Ubuntu).
```

The charm waits for `mysqld.sock` availability for 2 minutes as the first check for successful upgrade.
But from the log we see that from starting the mysqld process to the `mysqld.sock`, a bit over 2 minutes have passed.

The upgrade fails, but inspecting the cluster status, the upgraded unit did rejoins the cluster:

```yaml
 topology:
      mysql-k8s-0:
        address: mysql-k8s-0.mysql-k8s-endpoints.m2.svc.cluster.local.:3306
        memberrole: primary
        mode: r/w
        role: ha
        status: online
        version: 8.0.44
      mysql-k8s-1: # <- the "failed" unit
        address: mysql-k8s-1.mysql-k8s-endpoints.m2.svc.cluster.local.:3306
        memberrole: secondary
        mode: r/o
        replicationlagfromimmediatesource: "00:00:00.323137"
        replicationlagfromoriginalsource: "00:00:00.323137"
        role: ha
        status: online  
        version: 8.0.45
      mysql-k8s-2:
        address: mysql-k8s-2.mysql-k8s-endpoints.m2.svc.cluster.local.:3306
        memberrole: secondary
        mode: r/o
        replicationlagfromimmediatesource: "00:00:00.084540"
        replicationlagfromoriginalsource: "00:00:00.084540"
        role: ha
        status: online
        version: 8.0.45
```


